### PR TITLE
Pointer support in arrays, plus minor usability improvements

### DIFF
--- a/src/HexManiac.Core/Models/AutoSearchModel.cs
+++ b/src/HexManiac.Core/Models/AutoSearchModel.cs
@@ -1,4 +1,5 @@
 ﻿using HavenSoft.HexManiac.Core.Models.Runs;
+using System.Diagnostics;
 using System.Linq;
 using static HavenSoft.HexManiac.Core.Models.Runs.ArrayRun;
 
@@ -35,6 +36,7 @@ namespace HavenSoft.HexManiac.Core.Models {
          if (gamesToDecode.Contains(gameCode)) {
             DecodeHeader();
             DecodeNameArrays();
+            DecodeDataArrays();
          }
       }
 
@@ -73,7 +75,19 @@ namespace HavenSoft.HexManiac.Core.Models {
             }
             if (TrySearch(this, "[name\"\"13]", out var abilitynames)) {
                ObserveAnchorWritten(noChangeDelta, "abilitynames", abilitynames);
+               if (gameCode == FireRed) Debug.Assert(abilitynames.ElementCount == 78);
             }
+         }
+
+         // types[name""7]18
+         // this one is weird, because things actually point to each individual name, as well as being in an array
+      }
+
+      private void DecodeDataArrays() {
+         // abilitydescriptions[description<"">]abilitynames
+
+         if (TrySearch(this, "[name\"\"14 a: b: c: d<> e: f: g<> h: i: j<> k: l:]", out var itemdata)) {
+            ObserveAnchorWritten(noChangeDelta, "items", itemdata);
          }
       }
    }

--- a/src/HexManiac.Core/Models/AutoSearchModel.cs
+++ b/src/HexManiac.Core/Models/AutoSearchModel.cs
@@ -51,14 +51,14 @@ namespace HavenSoft.HexManiac.Core.Models {
       }
 
       private void DecodeNameArrays() {
-         // pokenames
-         if (TrySearch(this, "[name\"\"11]", out var pokenames)) {
-            ObserveAnchorWritten(noChangeDelta, "pokenames", pokenames);
-         }
-
          // movenames
          if (TrySearch(this, "[name\"\"13]", out var movenames)) {
             ObserveAnchorWritten(noChangeDelta, "movenames", movenames);
+         }
+
+         // pokenames
+         if (TrySearch(this, "[name\"\"11]", out var pokenames)) {
+            ObserveAnchorWritten(noChangeDelta, "pokenames", pokenames);
          }
 
          // abilitynames / trainer names
@@ -75,7 +75,6 @@ namespace HavenSoft.HexManiac.Core.Models {
             }
             if (TrySearch(this, "[name\"\"13]", out var abilitynames)) {
                ObserveAnchorWritten(noChangeDelta, "abilitynames", abilitynames);
-               if (gameCode == FireRed) Debug.Assert(abilitynames.ElementCount == 78);
             }
          }
 

--- a/src/HexManiac.Core/Models/IDataModel.cs
+++ b/src/HexManiac.Core/Models/IDataModel.cs
@@ -30,6 +30,7 @@ namespace HavenSoft.HexManiac.Core.Models {
       void Load(byte[] newData, StoredMetadata metadata);
       void ExpandData(ModelDelta changeToken, int minimumLength);
 
+      IReadOnlyList<int> SearchForPointersToAnchor(ModelDelta changeToken, int address);
       void WritePointer(ModelDelta changeToken, int address, int pointerDestination);
       void WriteValue(ModelDelta changeToken, int address, int value);
       int ReadPointer(int address);
@@ -86,6 +87,8 @@ namespace HavenSoft.HexManiac.Core.Models {
 
       public abstract IFormattedRun RelocateForExpansion(ModelDelta changeToken, IFormattedRun run, int minimumLength);
 
+      public abstract IReadOnlyList<int> SearchForPointersToAnchor(ModelDelta changeToken, int address);
+
       public int ReadValue(int index) {
          int word = 0;
          word |= RawData[index + 0] << 0;
@@ -129,6 +132,8 @@ namespace HavenSoft.HexManiac.Core.Models {
       public override void ClearFormatAndData(ModelDelta changeToken, int start, int length) {
          for (int i = 0; i < length; i++) changeToken.ChangeData(this, start + i, 0xFF);
       }
+
+      public override IReadOnlyList<int> SearchForPointersToAnchor(ModelDelta changeToken, int address) => throw new NotImplementedException();
 
       public override string Copy(int start, int length) {
          var bytes = Enumerable.Range(start, length).Select(i => RawData[i]);

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -451,7 +451,7 @@ namespace HavenSoft.HexManiac.Core.Models {
             if (run is PointerRun) ClearPointerFormat(changeToken, run.Start);
             if (run is ArrayRun arrayRun) ModifyAnchorsFromPointerArray(changeToken, arrayRun, ClearPointerFormat);
 
-            ClearAnchorFormat(changeToken, originalStart, run);
+            ClearAnchorFormat(changeToken, originalStart, run, alsoClearData);
 
             if (alsoClearData) {
                for (int i = 0; i < run.Length; i++) changeToken.ChangeData(this, run.Start + i, 0xFF);
@@ -462,11 +462,13 @@ namespace HavenSoft.HexManiac.Core.Models {
          }
       }
 
-      private void ClearAnchorFormat(ModelDelta changeToken, int originalStart, IFormattedRun run) {
+      private void ClearAnchorFormat(ModelDelta changeToken, int originalStart, IFormattedRun run, bool alsoClearData) {
          if (run.Start != originalStart) {
             // delete the anchor
             if (anchorForAddress.TryGetValue(run.Start, out string name)) {
-               foreach (var source in run.PointerSources ?? new int[0]) WriteValue(changeToken, source, 0);
+               if (alsoClearData) {
+                  foreach (var source in run.PointerSources ?? new int[0]) WriteValue(changeToken, source, 0);
+               }
                unmappedNameToSources[anchorForAddress[run.Start]] = new List<int>(run.PointerSources);
                foreach (var source in run.PointerSources) {
                   changeToken.AddUnmappedPointer(source, name);

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -178,7 +178,8 @@ namespace HavenSoft.HexManiac.Core.Models {
       }
 
       public override int GetAddressFromAnchor(ModelDelta changeToken, int requestSource, string anchor) {
-         if (addressForAnchor.TryGetValue(anchor, out int address)) {
+
+         if (addressForAnchor.TryGetValueCaseInsensitive(anchor, out int address)) {
             return address;
          }
 
@@ -601,13 +602,13 @@ namespace HavenSoft.HexManiac.Core.Models {
 
       public override IReadOnlyList<string> GetAutoCompleteAnchorNameOptions(string partial) {
          partial = partial.ToLower();
-         var mappedNames = addressForAnchor.Keys.Select(name => name.ToLower());
+         var mappedNames = addressForAnchor.Keys;
          var results = new List<string>();
          foreach (var name in mappedNames) {
             var unmatchedName = name;
             int index = -1;
             foreach (var character in partial) {
-               index = unmatchedName.IndexOf(character);
+               index = unmatchedName.IndexOf(character.ToString(), StringComparison.CurrentCultureIgnoreCase);
                if (index == -1) break;
                unmatchedName = unmatchedName.Substring(index);
             }
@@ -845,6 +846,20 @@ namespace HavenSoft.HexManiac.Core.Models {
       private int BinarySearch(int start) {
          var index = runs.BinarySearch(new CompareFormattedRun(start), FormattedRunComparer.Instance);
          return index;
+      }
+   }
+
+   public static class StringDictionaryExtensions {
+      public static bool TryGetValueCaseInsensitive<T>(this IDictionary<string, T> self, string key, out T value) {
+         foreach (var option in self.Keys) {
+            if (key.Equals(option, StringComparison.CurrentCultureIgnoreCase)) {
+               value = self[option];
+               return true;
+            }
+         }
+
+         value = default(T);
+         return false;
       }
    }
 }

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -209,7 +209,6 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          }
 
          if (currentSegment.Type == ElementContentType.Pointer) {
-            // TODO display the pointer in red if it points to outside the data
             var destination = data.ReadPointer(offsets.SegmentStart);
             var destinationName = data.GetAnchorFromAddress(offsets.SegmentStart, destination);
             return new Pointer(offsets.SegmentStart, index - offsets.SegmentStart, destination, destinationName);

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -222,7 +222,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          int elementIndex = offset / ElementLength;
          int elementOffset = offset % ElementLength;
          int segmentIndex = 0, segmentOffset = elementOffset;
-         while (ElementContent[segmentIndex].Length < segmentOffset) {
+         while (ElementContent[segmentIndex].Length <= segmentOffset) {
             segmentOffset -= ElementContent[segmentIndex].Length; segmentIndex++;
          }
          return new ArrayOffset(elementIndex, segmentIndex, byteOffset - segmentOffset, segmentOffset);

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -9,6 +9,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       Unknown,
       PCS,
       Integer,
+      Pointer,
    }
 
    public class ArrayRunElementSegment {
@@ -206,6 +207,12 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
             return new Integer(offsets.SegmentStart, index, value, currentSegment.Length);
          }
 
+         if (currentSegment.Type == ElementContentType.Pointer) {
+            var destination = data.ReadPointer(offsets.SegmentStart);
+            var destinationName = data.GetAnchorFromAddress(offsets.SegmentStart, destination);
+            return new Pointer(offsets.SegmentStart, index - offsets.SegmentStart, destination, destinationName);
+         }
+
          throw new NotImplementedException();
       }
 
@@ -323,6 +330,10 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
                return true;
             case ElementContentType.Integer:
                return true;
+            case ElementContentType.Pointer:
+               var destination = owner.ReadPointer(start);
+               if (destination == Pointer.NULL) return true;
+               return 0 <= destination && destination <= owner.Count;
             default:
                throw new NotImplementedException();
          }

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -40,9 +40,21 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
    }
 
    public class ArrayOffset {
+      /// <summary>
+      /// Ranges from 0 to ElementCount
+      /// </summary>
       public int ElementIndex { get; }
+      /// <summary>
+      /// Ranges from 0 to ElementContent.Count
+      /// </summary>
       public int SegmentIndex { get; }
+      /// <summary>
+      /// The data address where the current segment starts. Ranges from n to n+ElementContent[SegmentIndex].Length.
+      /// </summary>
       public int SegmentStart { get; }
+      /// <summary>
+      /// The index into the current segment. 0 means the start of the segment.
+      /// </summary>
       public int SegmentOffset { get; }
       public ArrayOffset(int elementIndex, int segmentIndex, int segmentStart, int segmentOffset) {
          ElementIndex = elementIndex;
@@ -252,14 +264,16 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
                formatLength = 2;
                while (formatLength < segments.Length && char.IsDigit(segments[formatLength])) formatLength++;
                segmentLength = int.Parse(segments.Substring(2, formatLength - 2));
-            } else if (segments.StartsWith("::")) {
+            } else if (segments.StartsWith(DoubleByteIntegerFormat + string.Empty + DoubleByteIntegerFormat)) {
                (format, formatLength, segmentLength) = (ElementContentType.Integer, 2, 4);
-            } else if (segments.StartsWith(":.") || segments.StartsWith(".:")) {
+            } else if (segments.StartsWith(DoubleByteIntegerFormat + string.Empty + SingleByteIntegerFormat) || segments.StartsWith(".:")) {
                (format, formatLength, segmentLength) = (ElementContentType.Integer, 2, 3);
-            } else if (segments.StartsWith(":")) {
+            } else if (segments.StartsWith(DoubleByteIntegerFormat.ToString())) {
                (format, formatLength, segmentLength) = (ElementContentType.Integer, 1, 2);
-            } else if (segments.StartsWith(".")) {
+            } else if (segments.StartsWith(SingleByteIntegerFormat.ToString())) {
                (format, formatLength, segmentLength) = (ElementContentType.Integer, 1, 1);
+            } else if (segments.StartsWith(PointerRun.PointerStart + string.Empty + PointerRun.PointerEnd)) {
+               (format, formatLength, segmentLength) = (ElementContentType.Pointer, 2, 4);
             }
 
             if (format == ElementContentType.Unknown) throw new FormatException($"Could not parse format '{segments}'");

--- a/src/HexManiac.Core/Models/Runs/PointerRun.cs
+++ b/src/HexManiac.Core/Models/Runs/PointerRun.cs
@@ -14,7 +14,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       public override IDataFormat CreateDataFormat(IDataModel data, int index) {
          var destinationAddress = data.ReadPointer(Start);
          var anchor = data.GetAnchorFromAddress(Start, destinationAddress);
-         var pointer = new Pointer(Start, index - Start, data.ReadPointer(Start), anchor);
+         var pointer = new Pointer(Start, index - Start, destinationAddress, anchor);
          return pointer;
       }
       protected override IFormattedRun Clone(IReadOnlyList<int> newPointerSources) {

--- a/src/HexManiac.Core/ViewModels/ChildViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ChildViewPort.cs
@@ -7,7 +7,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
    public class ChildViewPort : ViewPort, IChildViewPort {
       public IViewPort Parent { get; }
 
-      public ChildViewPort(IViewPort viewPort) : base(new Models.LoadedFile(string.Empty, viewPort.Model.RawData), viewPort.Model) {
+      public ChildViewPort(IViewPort viewPort) : base(string.Empty, viewPort.Model) {
          Parent = viewPort;
          Width = Parent.Width;
       }

--- a/src/HexManiac.Core/ViewModels/EditorViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/EditorViewModel.cs
@@ -164,9 +164,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                if (TryUpdate(ref selectedIndex, value)) {
                   findPrevious.CanExecuteChanged.Invoke(findPrevious, EventArgs.Empty);
                   findNext.CanExecuteChanged.Invoke(findNext, EventArgs.Empty);
-                  GotoViewModel.PropertyChanged -= GotoPropertyChanged;
-                  GotoViewModel = new GotoControlViewModel(SelectedTab);
-                  GotoViewModel.PropertyChanged += GotoPropertyChanged;
+                  UpdateGotoViewModel();
                }
             }
          }
@@ -407,6 +405,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                if (selectedIndex == tabs.Count) TryUpdate(ref selectedIndex, tabs.Count - 1, nameof(SelectedIndex));
                CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, tab, index));
             }
+            UpdateGotoViewModel();
             return;
          }
 
@@ -446,6 +445,12 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          if (content is IViewPort viewPort && !string.IsNullOrEmpty(viewPort.FileName)) {
             fileSystem.RemoveListenerForFile(viewPort.FileName, viewPort.ConsiderReload);
          }
+      }
+
+      private void UpdateGotoViewModel() {
+         GotoViewModel.PropertyChanged -= GotoPropertyChanged;
+         GotoViewModel = new GotoControlViewModel(SelectedTab);
+         GotoViewModel.PropertyChanged += GotoPropertyChanged;
       }
 
       private void ForwardDelayedWork(object sender, Action e) => RequestDelayedWork?.Invoke(this, e);

--- a/src/HexManiac.Core/ViewModels/EditorViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/EditorViewModel.cs
@@ -218,7 +218,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
             var file = arg as LoadedFile ?? fileSystem.OpenFile("GameBoy Advanced", "gba");
             if (file == null) return;
             var metadata = fileSystem.MetadataFor(file.Name);
-            Add(new ViewPort(file, new AutoSearchModel(file.Contents, metadata)));
+            Add(new ViewPort(file.Name, new AutoSearchModel(file.Contents, metadata)));
          };
 
          ImplementFindCommands();

--- a/src/HexManiac.Core/ViewModels/GotoControlViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/GotoControlViewModel.cs
@@ -25,7 +25,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          set {
             if (viewPort == null) return;
             if (TryUpdate(ref text, value)) {
-               var options = viewPort.Model.GetAutoCompleteAnchorNameOptions(text);
+               var options = viewPort.Model?.GetAutoCompleteAnchorNameOptions(text) ?? new string[0];
                AutoCompleteOptions = CreateAutoCompleteOptions(options, options.Count);
                ShowAutoCompleteOptions = AutoCompleteOptions.Count > 0;
             }

--- a/src/HexManiac.Core/ViewModels/ITabContent.cs
+++ b/src/HexManiac.Core/ViewModels/ITabContent.cs
@@ -25,5 +25,6 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       event EventHandler Closed;
       event EventHandler<ITabContent> RequestTabChange;
       event EventHandler<Action> RequestDelayedWork;
+      event EventHandler RequestMenuClose;
    }
 }

--- a/src/HexManiac.Core/ViewModels/IViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/IViewPort.cs
@@ -26,8 +26,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       IDataModel Model { get; }
       bool IsSelected(Point point);
 
-      IReadOnlyList<int> Find(string search);
-      IChildViewPort CreateChildView(int offset);
+      IReadOnlyList<(int start, int end)> Find(string search);
+      IChildViewPort CreateChildView(int startAddress, int endAddress);
       void FollowLink(int x, int y);
       void ExpandSelection(int x, int y);
       void ConsiderReload(IFileSystem fileSystem);

--- a/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
@@ -11,6 +11,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
    public class SearchResultsViewPort : ViewModelCore, IViewPort {
       private readonly StubCommand scroll, close;
       private readonly List<IChildViewPort> children = new List<IChildViewPort>();
+      private readonly List<(int start, int end)> childrenSelection = new List<(int, int)>();
       private int width, height, scrollValue, maxScrollValue;
 
       #region Implementing IViewPort
@@ -110,17 +111,18 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          };
       }
 
-      public void Add(IChildViewPort child) {
+      public void Add(IChildViewPort child, int start, int end) {
          children.Add(child);
+         childrenSelection.Add((start, end));
          maxScrollValue += child.Height;
          if (children.Count > 1) maxScrollValue++;
          NotifyCollectionChanged();
       }
 
-      public IChildViewPort CreateChildView(int offset) => throw new NotImplementedException();
+      public IChildViewPort CreateChildView(int startAddress, int endAddress) => throw new NotImplementedException();
 
       // if asked to search the search results... just don't
-      public IReadOnlyList<int> Find(string search) => new int[0];
+      public IReadOnlyList<(int, int)> Find(string search) => new (int, int)[0];
 
       public bool IsSelected(Point point) {
          var (x, y) = (point.X, point.Y);
@@ -140,6 +142,12 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          var parent = child.Parent;
          var dataOffset = Math.Max(0, child.DataOffset - (y - line) * child.Width);
          parent.Goto.Execute(dataOffset.ToString("X6"));
+
+         if (parent is ViewPort viewPort) {
+            viewPort.SelectionStart = viewPort.ConvertAddressToViewPoint(childrenSelection[childIndex].start);
+            viewPort.SelectionEnd = viewPort.ConvertAddressToViewPoint(childrenSelection[childIndex].end);
+         }
+
          RequestTabChange?.Invoke(this, parent);
       }
 

--- a/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
@@ -85,6 +85,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       public event NotifyCollectionChangedEventHandler CollectionChanged;
       public event EventHandler<ITabContent> RequestTabChange;
       public event EventHandler<Action> RequestDelayedWork;
+      public event EventHandler RequestMenuClose;
 #pragma warning restore 0067
 
       #endregion

--- a/src/HexManiac.Core/ViewModels/Selection.cs
+++ b/src/HexManiac.Core/ViewModels/Selection.cs
@@ -169,16 +169,25 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       }
 
       private void GotoAddressHelper(int address) {
-         SelectionStart = Scroll.DataIndexToViewPoint(address);
-         Scroll.ScrollValue += selectionStart.Y;
-         while (Scroll.DataIndex < address) Scroll.Scroll.Execute(Direction.Right);
+         var destinationRun = model.GetNextRun(address) as ArrayRun;
+         var destinationIsArray = destinationRun != null && destinationRun.Start == address;
 
-         if (model.GetNextRun(address) is ArrayRun array && array.Start == address) {
-            PreferredWidth = array.ElementLength;
-         }
-         else {
+         if (destinationIsArray) {
+            PreferredWidth = destinationRun.ElementLength;
+         } else {
             PreferredWidth = DefaultPreferredWidth;
          }
+
+         var startAddress = address;
+         if (!destinationIsArray && PreferredWidth > 1) address -= address % PreferredWidth;
+
+         // first, change the selection and scroll to select the actual requested address
+         SelectionStart = Scroll.DataIndexToViewPoint(startAddress);
+         Scroll.ScrollValue += selectionStart.Y;
+
+         // then, scroll left/right as needed to align everything
+         while (Scroll.DataIndex < address) Scroll.Scroll.Execute(Direction.Right);
+         while (Scroll.DataIndex > address) Scroll.Scroll.Execute(Direction.Left);
       }
 
       /// <summary>

--- a/src/HexManiac.Core/ViewModels/Selection.cs
+++ b/src/HexManiac.Core/ViewModels/Selection.cs
@@ -9,6 +9,7 @@ using System.Windows.Input;
 
 namespace HavenSoft.HexManiac.Core.ViewModels {
    public class Selection : ViewModelCore {
+      private const int DefaultPreferredWidth = 0x10;
 
       private readonly IDataModel model;
 
@@ -23,7 +24,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       // if we navigate back, then scroll, then navigate forward, we want to remember the scroll if we go back again.
       private readonly Stack<int> backStack = new Stack<int>(), forwardStack = new Stack<int>();
 
-      private int preferredWidth = 1, maxWidth = 4;
+      private int preferredWidth = DefaultPreferredWidth, maxWidth = 4;
 
       private Point selectionStart, selectionEnd;
 
@@ -176,7 +177,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
             PreferredWidth = array.ElementLength;
          }
          else {
-            PreferredWidth = 1;
+            PreferredWidth = DefaultPreferredWidth;
          }
       }
 

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -262,6 +262,15 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
       public IDataModel Model { get; private set; }
 
+      public bool FormattedDataIsSelected {
+         get {
+            var (left, right) = (scroll.ViewPointToDataIndex(SelectionStart), scroll.ViewPointToDataIndex(SelectionEnd));
+            if (left > right) (left, right) = (right, left);
+            var nextRun = Model.GetNextRun(left);
+            return nextRun.Start <= right;
+         }
+      }
+
 #pragma warning disable 0067 // it's ok if events are never used
       public event EventHandler<string> OnError;
       public event EventHandler<string> OnMessage;
@@ -329,9 +338,12 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
       public bool IsSelected(Point point) => selection.IsSelected(point);
 
-      public void ClearFormat(Point point) {
-         var dataIndex = scroll.ViewPointToDataIndex(point);
-         Model.ClearFormat(history.CurrentChange, dataIndex, 1);
+      public void ClearFormat() {
+         var startDataIndex = scroll.ViewPointToDataIndex(SelectionStart);
+         var endDataIndex = scroll.ViewPointToDataIndex(SelectionEnd);
+         if (startDataIndex > endDataIndex) (startDataIndex, endDataIndex) = (endDataIndex, startDataIndex);
+
+         Model.ClearFormat(history.CurrentChange, startDataIndex, endDataIndex - startDataIndex + 1);
          RefreshBackingData();
       }
 

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -968,7 +968,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
             fullValue = Model.GetAddressFromAnchor(history.CurrentChange, index, destination);
          }
 
-         if (0 <= fullValue && fullValue < Model.Count) {
+         if (fullValue == Pointer.NULL || (0 <= fullValue && fullValue < Model.Count)) {
             Model.WritePointer(history.CurrentChange, index, fullValue);
             if (!inArray) Model.ObserveRunWritten(history.CurrentChange, new PointerRun(index));
             ClearEdits(point);

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -969,9 +969,13 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          }
 
          if (fullValue == Pointer.NULL || (0 <= fullValue && fullValue < Model.Count)) {
-            Model.WritePointer(history.CurrentChange, index, fullValue);
-            if (!inArray) Model.ObserveRunWritten(history.CurrentChange, new PointerRun(index));
-            // TODO do something amazing here... we don't need to observe the run being written, but there's still pointer updates to be done
+            if (inArray) {
+               Model.UpdateArrayPointer(history.CurrentChange, index, fullValue);
+            } else {
+               Model.WritePointer(history.CurrentChange, index, fullValue);
+               Model.ObserveRunWritten(history.CurrentChange, new PointerRun(index));
+            }
+
             ClearEdits(point);
             SilentScroll(index + 4);
          } else {

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -971,6 +971,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          if (fullValue == Pointer.NULL || (0 <= fullValue && fullValue < Model.Count)) {
             Model.WritePointer(history.CurrentChange, index, fullValue);
             if (!inArray) Model.ObserveRunWritten(history.CurrentChange, new PointerRun(index));
+            // TODO do something amazing here... we don't need to observe the run being written, but there's still pointer updates to be done
             ClearEdits(point);
             SilentScroll(index + 4);
          } else {

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -269,6 +269,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       public event NotifyCollectionChangedEventHandler CollectionChanged;
       public event EventHandler<ITabContent> RequestTabChange;
       public event EventHandler<Action> RequestDelayedWork;
+      public event EventHandler RequestMenuClose;
 #pragma warning restore 0067
 
       public ViewPort() : this(new LoadedFile(string.Empty, new byte[0])) { }
@@ -352,7 +353,11 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
             var offsets = arrayRun2.ConvertByteOffsetToArrayOffset(offset);
             SilentScroll(offsets.SegmentStart + arrayRun2.ElementContent[offsets.SegmentIndex].Length);
          }
-         if (key == ConsoleKey.Escape) { ClearEdits(SelectionStart); ClearMessage?.Invoke(this, EventArgs.Empty); }
+         if (key == ConsoleKey.Escape) {
+            ClearEdits(SelectionStart);
+            ClearMessage?.Invoke(this, EventArgs.Empty);
+            RequestMenuClose?.Invoke(this, EventArgs.Empty);
+         }
          if (key != ConsoleKey.Backspace) return;
 
          var point = GetEditPoint();

--- a/src/HexManiac.Tests/ArrayRunTests.cs
+++ b/src/HexManiac.Tests/ArrayRunTests.cs
@@ -288,7 +288,7 @@ namespace HavenSoft.HexManiac.Tests {
       }
 
       [Fact]
-      public void CannotCutPasteArrayToMakeItHitAnotherRun() {
+      public void CannotCutPasteArrayToMakeItHitAnotherAnchor() {
          // arrange
          var delta = new ModelDelta();
          var errors = new List<string>();

--- a/src/HexManiac.Tests/ArrayRunTests.cs
+++ b/src/HexManiac.Tests/ArrayRunTests.cs
@@ -28,9 +28,9 @@ namespace HavenSoft.HexManiac.Tests {
       [Fact]
       public void ArrayElementsMustHaveNames() {
          var model = new PokemonModel(new byte[0x200]);
-         var success = ArrayRun.TryParse(model, "[\"\"10]13", 12, null, out var arrayRun); // no name given for the format member
+         var errorInfo = ArrayRun.TryParse(model, "[\"\"10]13", 12, null, out var arrayRun); // no name given for the format member
 
-         Assert.False(success);
+         Assert.NotEqual(ErrorInfo.NoError, errorInfo);
       }
 
       [Fact]

--- a/src/HexManiac.Tests/ArrayRunTests.cs
+++ b/src/HexManiac.Tests/ArrayRunTests.cs
@@ -56,7 +56,7 @@ namespace HavenSoft.HexManiac.Tests {
          var model = new PokemonModel(buffer);
          ArrayRun.TryParse(model, "[name\"\"12]13", 12, null, out var arrayRun);
          model.ObserveRunWritten(new ModelDelta(), arrayRun);
-         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), model) { PreferredWidth = -1, Width = 12, Height = 20 };
+         var viewPort = new ViewPort("file.txt", model) { PreferredWidth = -1, Width = 12, Height = 20 };
 
          // spot checks: it should look like a string that starts where the segment starts
          var pcs = (PCS)viewPort[0, 4].Format;
@@ -87,7 +87,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanParseArrayAnchorAddedFromViewPort() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("^bob[name\"\"14]12 ");
 
@@ -98,7 +98,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void ChangingAnchorTextWhileAnchorStartIsOutOfViewWorks() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.Edit("^bob[name\"\"16]16 ");
 
          viewPort.ScrollValue = 2;
@@ -113,7 +113,7 @@ namespace HavenSoft.HexManiac.Tests {
          WriteStrings(buffer, 0x00, "bob", "tom", "sam", "car", "pal", "egg");
 
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("^words[word\"\"4] "); // notice, no length is given
 
@@ -127,7 +127,7 @@ namespace HavenSoft.HexManiac.Tests {
          WriteStrings(buffer, 100, "bobb", "tomm", "samm", "carr", "pall", "eggg");
 
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("^words[word\"\"5] "); // notice, no length is given
 
@@ -156,7 +156,7 @@ namespace HavenSoft.HexManiac.Tests {
          var model = new PokemonModel(buffer);
          ArrayRun.TryParse(model, "[word\"\"5]", 0, null, out var arrayRun);
          model.ObserveAnchorWritten(new ModelDelta(), "words", arrayRun);
-         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.SelectionStart = new Point(6, 0);
 
          viewPort.Edit("a"); // change "tomm" to "tamm"
@@ -168,7 +168,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanPasteArray() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("^strings[name\"\"16] ");
          viewPort.Edit("+\"bob\" +\"sam\" +\"steve\" +\"kevin\"");
@@ -181,7 +181,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void PastingArrayLeavesArrayFormat() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("^pokenames[name\"\"11] +\"??????????\"+\"BULBASAUR\"");
          viewPort.SelectionStart = new Point(0, 0);
@@ -203,7 +203,7 @@ namespace HavenSoft.HexManiac.Tests {
 
          ArrayRun.TryParse(model, "[word\"\"5]", 100, null, out var arrayRun);
          model.ObserveAnchorWritten(new ModelDelta(), "words", arrayRun);
-         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.FollowLink(0, 7); // 7*16 = 112, right in the middle of our data
          // note that this will change our width to 15, because we're linking to data of width 5 when our maxwidth is 16.
@@ -229,7 +229,7 @@ namespace HavenSoft.HexManiac.Tests {
 
          ArrayRun.TryParse(model, "[word\"\"5]", 100, null, out var arrayRun);
          model.ObserveAnchorWritten(new ModelDelta(), "words", arrayRun);
-         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.FollowLink(0, 7); // 7*16 = 112, right in the middle of our data
 
@@ -255,7 +255,7 @@ namespace HavenSoft.HexManiac.Tests {
          var model = new PokemonModel(buffer);
          model.WritePointer(delta, 0x00, 0x20);
          model.ObserveRunWritten(delta, new PointerRun(0x00));
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.SelectionStart = new Point(0, 2);
          viewPort.Edit("^testdata[name\"\"16]5 ");
 
@@ -304,7 +304,7 @@ namespace HavenSoft.HexManiac.Tests {
          model.ObserveRunWritten(delta, new PointerRun(0x00));
          model.WritePointer(delta, 0x04, 0x90);
          model.ObserveRunWritten(delta, new PointerRun(0x04)); // the anchor at 0x90 should prevent a paste overwrite
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.SelectionStart = new Point(0, 2);
          viewPort.Edit("^testdata[name\"\"16]5 ");
          viewPort.OnError += (sender, message) => errors.Add(message);
@@ -342,7 +342,7 @@ namespace HavenSoft.HexManiac.Tests {
          model.ObserveRunWritten(delta, new PointerRun(0x00));
          model.WritePointer(delta, 0x04, 0x90);
          model.ObserveRunWritten(delta, new PointerRun(0x04)); // the anchor at 0x90 should prevent a paste overwrite
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.SelectionStart = new Point(0, 2);
          viewPort.Edit("^testdata[name\"\"16]5 ");
          viewPort.OnError += (sender, message) => errors.Add(message);
@@ -381,7 +381,7 @@ namespace HavenSoft.HexManiac.Tests {
          model.ObserveRunWritten(delta, new PointerRun(0x00));
          model.WritePointer(delta, 0x04, 0x90);
          model.ObserveRunWritten(delta, new PointerRun(0x04)); // the anchor at 0x90 should prevent a paste overwrite
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.SelectionStart = new Point(0, 2);
          viewPort.Edit("^testdata[name\"\"16]5 ");
          viewPort.OnError += (sender, message) => errors.Add(message);
@@ -400,7 +400,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void ArarysSupportIntegers() {
          var buffer = new byte[0x200];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          var errors = new List<string>();
          viewPort.OnError += (sender, e) => errors.Add(e);
 
@@ -414,7 +414,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void ArrayExtendsIfBasedOnAnotherNameWhichIsExtended() {
          var buffer = new byte[0x200];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          var errors = new List<string>();
          viewPort.OnError += (sender, e) => errors.Add(e);
 
@@ -438,7 +438,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanEditIntsInArray() {
          var buffer = new byte[0x200];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          var errors = new List<string>();
          viewPort.OnError += (sender, e) => errors.Add(e);
          viewPort.Edit("^sample[code:]8 ");

--- a/src/HexManiac.Tests/ArrayRunTests.cs
+++ b/src/HexManiac.Tests/ArrayRunTests.cs
@@ -56,7 +56,7 @@ namespace HavenSoft.HexManiac.Tests {
          var model = new PokemonModel(buffer);
          ArrayRun.TryParse(model, "[name\"\"12]13", 12, null, out var arrayRun);
          model.ObserveRunWritten(new ModelDelta(), arrayRun);
-         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), model) { Width = 12, Height = 20 };
+         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), model) { PreferredWidth = -1, Width = 12, Height = 20 };
 
          // spot checks: it should look like a string that starts where the segment starts
          var pcs = (PCS)viewPort[0, 4].Format;

--- a/src/HexManiac.Tests/AsciiRunTests.cs
+++ b/src/HexManiac.Tests/AsciiRunTests.cs
@@ -15,7 +15,7 @@ namespace HavenSoft.HexManiac.Tests {
          model[0x12] = (byte)'c';
          model[0x13] = (byte)'d';
 
-         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.SelectionStart = new Point(0, 1);
          viewPort.Edit("^data`asc`4 ");
 
@@ -34,7 +34,7 @@ namespace HavenSoft.HexManiac.Tests {
 
          model.ObserveRunWritten(new ModelDelta(), new AsciiRun(0x10, 4));
 
-         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.SelectionStart = new Point(1, 1);
          viewPort.Edit("3");
 

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -1,0 +1,107 @@
+﻿
+using HavenSoft.HexManiac.Core.Models;
+using HavenSoft.HexManiac.Core.Models.Runs;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace HavenSoft.HexManiac.Tests {
+   /// <summary>
+   /// The Auto-Search tests exist to verify that data can be found in the Vanilla roms.
+   /// These tests are skippable, so that they'll work even if you don't have the ROMs on your system.
+   /// This is important, since the ROMs aren't part of the repository.
+   /// </summary>
+   public class AutoSearchTests {
+
+      public static IEnumerable<object[]> PokemonGames => new[] {
+         "Emerald",
+         "FireRed",
+         "LeafGreen",
+         "Ruby",
+         "Sapphire",
+      }.Select(game => new object[] { "sampleFiles/Pokemon " + game + ".gba" });
+
+      [SkippableTheory]
+      [MemberData(nameof(PokemonGames))]
+      public void PokemonNamesAreFound(string game) {
+         var model = LoadModel(game);
+         var noChange = new NoDataChangeDeltaModel();
+
+         var address = model.GetAddressFromAnchor(noChange, -1, "pokenames");
+         var run = (ArrayRun)model.GetNextAnchor(address);
+         Assert.Equal(412, run.ElementCount);
+      }
+
+      [SkippableTheory]
+      [MemberData(nameof(PokemonGames))]
+      public void MovesNamesAreFound(string game) {
+         var model = LoadModel(game);
+         var noChange = new NoDataChangeDeltaModel();
+
+         var address = model.GetAddressFromAnchor(noChange, -1, "movenames");
+         var run = (ArrayRun)model.GetNextAnchor(address);
+         Assert.Equal(355, run.ElementCount);
+      }
+
+      [SkippableTheory]
+      [MemberData(nameof(PokemonGames))]
+      public void AbilitiyNamesAreFound(string game) {
+         var model = LoadModel(game);
+         var noChange = new NoDataChangeDeltaModel();
+
+         var address = model.GetAddressFromAnchor(noChange, -1, "abilitynames");
+         var run = (ArrayRun)model.GetNextAnchor(address);
+         Assert.Equal(78, run.ElementCount);
+      }
+
+      [SkippableTheory]
+      [MemberData(nameof(PokemonGames))]
+      public void ItemsAreFound(string game) {
+         var model = LoadModel(game);
+         var noChange = new NoDataChangeDeltaModel();
+
+         var address = model.GetAddressFromAnchor(noChange, -1, "items");
+         var run = (ArrayRun)model.GetNextAnchor(address);
+         if (game.Contains("Emerald"))   Assert.Equal(377, run.ElementCount);
+         if (game.Contains("FireRed"))   Assert.Equal(375, run.ElementCount);
+         if (game.Contains("LeafGreen")) Assert.Equal(375, run.ElementCount);
+         if (game.Contains("Ruby"))      Assert.Equal(349, run.ElementCount);
+         if (game.Contains("Sapphire"))  Assert.Equal(349, run.ElementCount);
+      }
+
+      [SkippableTheory]
+      [MemberData(nameof(PokemonGames))]
+      public void TrainerClassNamesAreFound(string game) {
+         var model = LoadModel(game);
+         var noChange = new NoDataChangeDeltaModel();
+
+         var address = model.GetAddressFromAnchor(noChange, -1, "trainerclassnames");
+         var run = (ArrayRun)model.GetNextAnchor(address);
+         if (game.Contains("Emerald"))   Assert.Equal(67, run.ElementCount);
+         if (game.Contains("FireRed"))   Assert.Equal(108, run.ElementCount);
+         if (game.Contains("LeafGreen")) Assert.Equal(108, run.ElementCount);
+         if (game.Contains("Ruby"))      Assert.Equal(59, run.ElementCount);
+         if (game.Contains("Sapphire"))  Assert.Equal(59, run.ElementCount);
+      }
+
+      /// <summary>
+      /// Loading the model can take a while.
+      /// We want to know that loading the model created the correct arrays,
+      /// But loading the same file into a model multiple times just wastes time.
+      /// Go ahead and cache a model loaded from a file the first time,
+      /// so each individual test doesn't have to do it again.
+      /// </summary>
+      private static IDictionary<string, AutoSearchModel> modelCache = new Dictionary<string, AutoSearchModel>();
+      private static AutoSearchModel LoadModel(string name) {
+         lock (modelCache) {
+            if (modelCache.TryGetValue(name, out var cachedModel)) return cachedModel;
+            Skip.IfNot(File.Exists(name));
+            var data = File.ReadAllBytes(name);
+            var model = new AutoSearchModel(data);
+            modelCache[name] = model;
+            return model;
+         }
+      }
+   }
+}

--- a/src/HexManiac.Tests/ChangeHistoryTests.cs
+++ b/src/HexManiac.Tests/ChangeHistoryTests.cs
@@ -195,7 +195,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanUndoFormatChange() {
          var data = new byte[0x100];
          var model = new PokemonModel(data);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", data), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(4, 0);
          viewPort.Edit("<000030>");
@@ -209,7 +209,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanUndoDataMove() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(8, 0);
          viewPort.Edit("<000030>");
@@ -229,7 +229,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanUndoFromToolChange() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("^bob\"\" ");
 
@@ -249,7 +249,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void UndoCanHandleNameMove() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          // operation 1
          viewPort.Edit("<bob> 03 08 24 16 <bob>");
@@ -280,7 +280,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void UndoWorksAfterMidPointerEdit() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("<000100>");
          viewPort.SelectionStart = new Point(1, 0);
@@ -294,7 +294,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void UndoRedoRestoresUnmappedNames() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("<bob>");
          viewPort.SelectionStart = new Point(0, 0);

--- a/src/HexManiac.Tests/HexManiac.Tests.csproj
+++ b/src/HexManiac.Tests/HexManiac.Tests.csproj
@@ -40,6 +40,9 @@
     <Reference Include="System.Delegation, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\HavenSoft.AutoImplement.1.1.1\lib\System.Delegation.dll</HintPath>
     </Reference>
+    <Reference Include="Validation, Version=2.4.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Validation.2.4.18\lib\net45\Validation.dll</HintPath>
+    </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -53,12 +56,16 @@
     <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
+    <Reference Include="Xunit.SkippableFact, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b2b52da82b58eb73, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Xunit.SkippableFact.1.3.12\lib\net452\Xunit.SkippableFact.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\artifacts\$(AssemblyName)\codegen\StubDataModel.cs">
       <Link>StubDataModel.cs</Link>
     </Compile>
     <Compile Include="ArrayRunTests.cs" />
+    <Compile Include="AutoSearchTests.cs" />
     <Compile Include="ChangeHistoryTests.cs" />
     <Compile Include="AsciiRunTests.cs" />
     <Compile Include="FindTests.cs" />
@@ -77,6 +84,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/HexManiac.Tests/NavigationTests.cs
+++ b/src/HexManiac.Tests/NavigationTests.cs
@@ -18,7 +18,7 @@ namespace HavenSoft.HexManiac.Tests {
 
       [Fact]
       public void AddressUpdateOnWidthChanged() {
-         var viewPort = new ViewPort(new LoadedFile("test.txt", new byte[0x200])) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort(new LoadedFile("test.txt", new byte[0x200])) { PreferredWidth = -1, Width = 0x10, Height = 0x10 };
          var changeCount = 0;
          viewPort.Headers.CollectionChanged += (sender, e) => changeCount += 1;
 

--- a/src/HexManiac.Tests/NavigationTests.cs
+++ b/src/HexManiac.Tests/NavigationTests.cs
@@ -198,7 +198,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void SearchFor6BytesAlsoFindsPointers() {
          var data = new byte[0x1200];
          var model = new PokemonModel(data);
-         var viewPort = new ViewPort(new LoadedFile("file.txt", data), model);
+         var viewPort = new ViewPort("file.txt", model);
 
          viewPort.Edit("<001060>");
          var results = viewPort.Find("001060");

--- a/src/HexManiac.Tests/NavigationTests.cs
+++ b/src/HexManiac.Tests/NavigationTests.cs
@@ -237,5 +237,15 @@ namespace HavenSoft.HexManiac.Tests {
          viewModel.MoveAutoCompleteSelectionUp.Execute();
          Assert.True(viewModel.AutoCompleteOptions[0].IsSelected);
       }
+
+      [Fact]
+      public void CanGotoUsingAtSymbol() {
+         var model = new PokemonModel(new byte[0x200]);
+         var viewPort = new ViewPort("unnamed.txt", model) { Width = 0x10, Height = 0x10 };
+
+         viewPort.Edit("@100 ");
+
+         Assert.Equal("000100", viewPort.Headers[0]);
+      }
    }
 }

--- a/src/HexManiac.Tests/PointerModelTests.cs
+++ b/src/HexManiac.Tests/PointerModelTests.cs
@@ -248,7 +248,7 @@ namespace HavenSoft.HexManiac.Tests {
 
          // as an alternative to being able to delete an anchor from the viewPort,
          // just edit the model directly and then scroll to force the viewPort to refresh
-         model.ClearFormat(token, 0xF, 2);
+         model.ClearFormatAndData(token, 0xF, 2);
          viewPort.ScrollValue = 1;
          viewPort.ScrollValue = 0;
 

--- a/src/HexManiac.Tests/PointerModelTests.cs
+++ b/src/HexManiac.Tests/PointerModelTests.cs
@@ -78,7 +78,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void ModelUpdatesWhenViewPortChanges() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model);
+         var viewPort = new ViewPort("file.txt", model);
 
          viewPort.Edit("<000020>");
 
@@ -90,7 +90,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void WritingNamedAnchorFollowedByPointerToNameWorks() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model);
+         var viewPort = new ViewPort("file.txt", model);
 
          viewPort.SelectionStart = new Point(0, 1);
          viewPort.Edit("^bob ");
@@ -104,7 +104,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void WritingPointerToNameFollowedByNamedAnchorWorks() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model);
+         var viewPort = new ViewPort("file.txt", model);
 
          viewPort.SelectionStart = new Point(0, 2);
          viewPort.Edit("<bob>");
@@ -118,7 +118,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanWriteAnchorToSameLocationAsPointerWithoutRemovingPointer() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model);
+         var viewPort = new ViewPort("file.txt", model);
 
          viewPort.SelectionStart = new Point(0, 2);
          viewPort.Edit("<000040>");
@@ -132,7 +132,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanWriteAnchorToSameLocationAsPointerPointingToThatAnchor() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model);
+         var viewPort = new ViewPort("file.txt", model);
 
          viewPort.SelectionStart = new Point(0, 2);
          viewPort.Edit("<bob>");
@@ -147,7 +147,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void WritingAnAnchorUpdatesPointersToUseThatName() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model);
+         var viewPort = new ViewPort("file.txt", model);
 
          viewPort.SelectionStart = new Point(0, 2);
          viewPort.Edit("<000004>");
@@ -215,7 +215,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void PointerCanPointToNameAfterThatNameGetsDeleted() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 16, Height = 16 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          var token = new ModelDelta();
 
          viewPort.SelectionStart = new Point(0, 1);
@@ -237,7 +237,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void PointerGetsSetToZeroAfterAnchorGetsDeleted() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 16, Height = 16 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          var token = new ModelDelta();
 
          viewPort.SelectionStart = new Point(0, 1);
@@ -259,7 +259,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void AnchorCarriesSourceInformation() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 16, Height = 16 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(0, 1);
          viewPort.Edit("<000020>");
@@ -271,7 +271,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void StartingAnAnchorAndGivingItNoNameClearsAnyAnchorNameAtThatPosition() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(0, 1);
          viewPort.Edit("<bob>");
@@ -290,7 +290,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanRemoveAnchorWithNoReferences() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(0, 2);
          viewPort.Edit("^bob ^ ");
@@ -302,7 +302,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void BackspaceClearsDataButNotFormats() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(0, 1);
          viewPort.Edit("01 02 03 04");                // 2x4 characters to clear
@@ -325,7 +325,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void WritingOverTwoPointersWorks() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(0, 1);
          viewPort.Edit("<000020>");
@@ -353,7 +353,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void PointerToUnknownLocationShowsUpDifferent() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(2, 1);
          viewPort.Edit("<bob>");
@@ -367,7 +367,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void AddingANewNamedPointerToNoLocationOverExistingNamedPointerToNoLocationWorks() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(2, 1);
          viewPort.Edit("<bob>");
@@ -382,7 +382,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanGotoAnchorName() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          int errorCalls = 0;
          viewPort.OnError += (sender, e) => errorCalls++;
@@ -398,7 +398,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanFindPointer() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(4, 1);
          viewPort.Edit("<000058> 23 19");
@@ -411,7 +411,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanUsePointerAsLink() {
          var buffer = new byte[0x200];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(4, 1);
          viewPort.Edit("<000120>");
@@ -424,7 +424,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void FindAllSourcesWorks() {
          var buffer = new byte[0x200];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          var editor = new EditorViewModel(new StubFileSystem());
          editor.Add(viewPort);
 
@@ -441,7 +441,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void NewAnchorWithSameNameMovesPointersToNewAnchor() {
          var buffer = new byte[0x200];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          // put some pointers in the file
          viewPort.SelectionStart = new Point(4, 1);
@@ -465,7 +465,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanCopyAndPastePointers() {
          var buffer = new byte[0x200];
          var fileSystem = new StubFileSystem();
-         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), new PokemonModel(buffer)) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", new PokemonModel(buffer)) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(0, 2);
 
@@ -495,7 +495,7 @@ namespace HavenSoft.HexManiac.Tests {
          var buffer = new byte[0x200];
          var model = new PokemonModel(buffer);
          var fileSystem = new StubFileSystem();
-         var viewPort = new ViewPort(new LoadedFile("file.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("<null>");
          viewPort.SelectionStart = new Point(0, 0);
@@ -521,7 +521,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void ArrowMovementWhileTypingAnchorRevertsChange() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("^bob"); // no trailing space: still under edit
 
@@ -534,7 +534,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void EscapeWhileTypingAnchorCancelsChange() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("^bob"); // no trailing space: still under edit
          viewPort.Edit(ConsoleKey.Escape);
@@ -547,7 +547,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void StartingAnAnchorOverAnAnchorClearsTheExistingAnchorInfo() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("^bob ");
          Assert.Equal("^bob", viewPort.AnchorText);
@@ -564,7 +564,7 @@ namespace HavenSoft.HexManiac.Tests {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
          model.ObserveAnchorWritten(new ModelDelta(), "bob", new NoInfoRun(0x08));
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(0x08, 0);
 
@@ -576,7 +576,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void AnchorEditTextUpdatesWhenTypingAnAnchor() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("^partialTe"); // in the middle of typing 'partialText'
 
@@ -589,7 +589,7 @@ namespace HavenSoft.HexManiac.Tests {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
          model.ObserveAnchorWritten(new ModelDelta(), "bob", new NoInfoRun(0x08));
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(0x08, 0);
          viewPort.AnchorText = "^bob\"\"";
@@ -602,7 +602,7 @@ namespace HavenSoft.HexManiac.Tests {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
          model.ObserveAnchorWritten(new ModelDelta(), "bob", new NoInfoRun(0x08));
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(0x08, 0);
          viewPort.AnchorText = "tom\"\"";
@@ -618,7 +618,7 @@ namespace HavenSoft.HexManiac.Tests {
          model.ObserveRunWritten(new ModelDelta(), new PointerRun(0x010));
          model.WritePointer(new ModelDelta(), 0x014, 0x120);
          model.ObserveRunWritten(new ModelDelta(), new PointerRun(0x014));
-         var viewPort = new ViewPort(new LoadedFile("test.txt", data), model) { Width = 0x8, Height = 0x8 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x8, Height = 0x8 };
 
          viewPort.SelectionStart = new Point(0, 2); // 0x010
          viewPort.Edit("00"); // this should remove the first pointer
@@ -631,7 +631,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CreatingAnOffsetPointerShouldCoerceToTheStartOfExistingPointer() {
          var data = new byte[0x200];
          var model = new PokemonModel(data);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", data), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("<000100>");
          viewPort.SelectionStart = new Point(2, 0);
@@ -647,7 +647,7 @@ namespace HavenSoft.HexManiac.Tests {
          var errors = new List<string>();
          var data = new byte[0x200];
          var model = new PokemonModel(data);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", data), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.OnError += (sender, message) => errors.Add(message);
          viewPort.Edit("<000400>");
@@ -659,7 +659,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void ClearingAPointerAlsoRemovesItsAnchor() {
          var data = new byte[0x200];
          var model = new PokemonModel(data);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", data), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("<000100>");
          model.ClearFormat(new ModelDelta(), 0x00, 4);
@@ -671,7 +671,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void TypingBracesOnDataTriesToInterpretThatDataAsPointer() {
          var data = new byte[0x200];
          var model = new PokemonModel(data);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", data), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("00 01 00 08");
          viewPort.SelectionStart = new Point(0, 0);
@@ -684,7 +684,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void StartingPointerEditAndThenMovingClearsAllEditedCells() {
          var data = new byte[0x200];
          var model = new PokemonModel(data);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", data), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("<");
          viewPort.SelectionStart = new Point(2, 2);
@@ -704,7 +704,7 @@ namespace HavenSoft.HexManiac.Tests {
          model.WritePointer(change, 0x23, 0x050); // a pointer that isn't 4-byte aligned, pointing to data that is
          model.WritePointer(change, 0x10, 0x087); // a pointer that is 4-byte aligned, but pointing to something that isn't
          model.WritePointer(change, 2, 0xA2);    // a pointer that isn't 4-byte aligned, pointing to something not 4-byte aligned
-         var viewPort = new ViewPort(new LoadedFile("test.txt", data), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          // got to 50 and write an anchor
          viewPort.SelectionStart = new Point(0x0, 0x5);

--- a/src/HexManiac.Tests/StringModelTests.cs
+++ b/src/HexManiac.Tests/StringModelTests.cs
@@ -244,7 +244,7 @@ namespace HavenSoft.HexManiac.Tests {
          var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.Edit("^bob\"\" \"Text and BULBASAUR!\"");
 
-         var results = viewPort.Find("\"bulbasaur\"");
+         var results = viewPort.Find("\"bulbasaur\"").Select(result => result.start).ToList(); ;
          Assert.Single(results);
          Assert.Equal(9, results[0]);
       }
@@ -257,7 +257,7 @@ namespace HavenSoft.HexManiac.Tests {
          var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.Edit("^bob\"\" \"Text and BULBASAUR!\"");
 
-         var results = viewPort.Find("bulbasaur");
+         var results = viewPort.Find("bulbasaur").Select(result => result.start).ToList();
          Assert.Single(results);
          Assert.Equal(9, results[0]);
       }

--- a/src/HexManiac.Tests/StringModelTests.cs
+++ b/src/HexManiac.Tests/StringModelTests.cs
@@ -28,7 +28,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanWriteString() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x100).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model);
+         var viewPort = new ViewPort("test.txt", model);
 
          viewPort.Edit("^bob\"\" \"Hello World!\"");
 
@@ -54,7 +54,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void TryingToWriteStringFormatToNonStringFormatDataFails() {
          var buffer = new byte[0x100];
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model);
+         var viewPort = new ViewPort("test.txt", model);
          var editor = new EditorViewModel(new StubFileSystem());
          editor.Add(viewPort);
 
@@ -66,7 +66,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanTruncateString() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x100).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("^bob\"\" \"Hello World!\"");
 
@@ -89,7 +89,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanAutoMoveWhenHittingAnchor() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x300).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(8, 0);
          viewPort.Edit("^bob FF FF FF FF <tom>");
@@ -114,7 +114,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanAutoMoveWhenHittingData() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(8, 0);
          viewPort.Edit("A1 B3 64 18 <tom>");
@@ -140,7 +140,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void AnchorWithNoNameIsNotValidIfNothingPointsToIt() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
          var errors = new List<string>();
          viewPort.OnError += (sender, e) => errors.Add(e);
 
@@ -160,7 +160,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void OpeningStringFormatIncludesOpeningQuote() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("^bob\"\" \"Hello World!\"");
          var anchor = (Anchor)viewPort[0, 0].Format;
@@ -173,7 +173,7 @@ namespace HavenSoft.HexManiac.Tests {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          for (int i = 0; i < 0x10; i++) buffer[i] = 0x00;
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
          var errors = new List<string>();
          viewPort.OnError += (sender, e) => errors.Add(e);
 
@@ -196,7 +196,7 @@ namespace HavenSoft.HexManiac.Tests {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          for (int i = 0; i < 0x10; i++) buffer[i] = 0x00;
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
 
          // add an anchor with some data on the 2nd line
          viewPort.SelectionStart = new Point(0, 1);
@@ -212,7 +212,7 @@ namespace HavenSoft.HexManiac.Tests {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          for (int i = 0; i < 0x10; i++) buffer[i] = 0x00;
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("^bob\"\" \"Some Content \\\\03More Content\"");
 
@@ -225,7 +225,7 @@ namespace HavenSoft.HexManiac.Tests {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          for (int i = 0; i < 0x10; i++) buffer[i] = 0x00;
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
          var fileSystem = new StubFileSystem();
 
          viewPort.Edit("^bob\"\" \"Hello World!\"");
@@ -241,7 +241,7 @@ namespace HavenSoft.HexManiac.Tests {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          for (int i = 0; i < 0x10; i++) buffer[i] = 0x00;
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.Edit("^bob\"\" \"Text and BULBASAUR!\"");
 
          var results = viewPort.Find("\"bulbasaur\"");
@@ -254,7 +254,7 @@ namespace HavenSoft.HexManiac.Tests {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          for (int i = 0; i < 0x10; i++) buffer[i] = 0x00;
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.Edit("^bob\"\" \"Text and BULBASAUR!\"");
 
          var results = viewPort.Find("bulbasaur");
@@ -272,7 +272,7 @@ namespace HavenSoft.HexManiac.Tests {
          buffer[3] = 0x08;
          Array.Copy(bytes, 0, buffer, 0x08, bytes.Length);
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(0x08, 0);
          viewPort.Edit("^");
@@ -291,7 +291,7 @@ namespace HavenSoft.HexManiac.Tests {
          buffer[3] = 0x08;
          Array.Copy(bytes, 0, buffer, 0x08, bytes.Length);
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(0x08, 0);
          viewPort.Edit("^");
@@ -306,7 +306,7 @@ namespace HavenSoft.HexManiac.Tests {
          var bytes = PCSString.Convert("Hello World!").ToArray();
          Array.Copy(bytes, 0, buffer, 0x08, bytes.Length);
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.SelectionStart = new Point(0x08, 0);
          viewPort.Edit("^bob ");
 
@@ -326,7 +326,7 @@ namespace HavenSoft.HexManiac.Tests {
          buffer[2] = 0x00;
          buffer[3] = 0x08;
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("test.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.SelectionStart = new Point(0x0C, 0);
          viewPort.Edit(ConsoleKey.Backspace);
@@ -349,6 +349,41 @@ namespace HavenSoft.HexManiac.Tests {
          var model = new PokemonModel(buffer);
 
          Assert.Equal(int.MaxValue, model.GetNextRun(0).Start);
+      }
+
+      [Fact]
+      public void StringSearchAutomaticallySearchesForPointersToResults() {
+         var text = "This is the song that never ends.";
+         var bytes = PCSString.Convert(text).ToArray();
+         var buffer = new byte[0x200];
+         Array.Copy(bytes, 0, buffer, 0x32, bytes.Length);                // the data itself, positioned at x32 (won't be automatically found on load)
+         Array.Copy(new byte[] { 0x32, 0, 0, 0x08 }, 0, buffer, 0x10, 4); // the pointer to the data. Pointer is aligned, but data is not.
+         var model = new PokemonModel(buffer);
+         var viewPort = new ViewPort("test.gba", model);
+
+         // the act of searching should find the anchor
+         var results = viewPort.Find("this is the song");
+
+         Assert.Single(results);
+         Assert.Single(model.GetNextRun(0x32).PointerSources);
+      }
+
+      [Fact]
+      public void UnnamedStringAnchorAutomaticallySearchesForPointersToAnchor() {
+         var text = "This is the song that never ends.";
+         var bytes = PCSString.Convert(text).ToArray();
+         var buffer = new byte[0x200];
+         Array.Copy(bytes, 0, buffer, 0x32, bytes.Length);                // the data itself, positioned at x32 (won't be automatically found on load)
+         Array.Copy(new byte[] { 0x32, 0, 0, 0x08 }, 0, buffer, 0x10, 4); // the pointer to the data. Pointer is aligned, but data is not.
+         var model = new PokemonModel(buffer);
+         var viewPort = new ViewPort("test.gba", model) { Width = 0x10, Height = 0x10 };
+
+         // the act of dropping an anchor should search for pointers
+         viewPort.SelectionStart = new Point(2, 3);
+         viewPort.Edit("^\"\" ");
+
+         Assert.Equal(0x32, model.GetNextRun(0x32).Start);
+         Assert.Single(model.GetNextRun(0x32).PointerSources);
       }
    }
 }

--- a/src/HexManiac.Tests/ToolTests.cs
+++ b/src/HexManiac.Tests/ToolTests.cs
@@ -21,7 +21,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void StringToolCanOpenOnChosenData() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.Edit("^bob\"\" \"Some Text\" 00 <000100>");
          var toolProperties = new List<string>();
          viewPort.Tools.PropertyChanged += (sender, e) => toolProperties.Add(e.PropertyName);
@@ -35,7 +35,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void StringToolEditsAreReflectedInViewPort() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.Edit("^bob\"\" \"Some Text\" 00 <000100>");
          viewPort.Tools.StringTool.Address = 0;
 
@@ -48,7 +48,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void StringToolCanMoveData() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.Edit("^bob\"\" \"Some Text\" 00 <000100>");
          var toolProperties = new List<string>();
          viewPort.Tools.StringTool.PropertyChanged += (sender, e) => toolProperties.Add(e.PropertyName);
@@ -63,7 +63,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void ViewPortMovesWhenStringToolMovesData() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.Edit("^bob\"\" \"Some Text\" 00 <000100>");
          viewPort.Tools.StringTool.Address = 0;
 
@@ -75,7 +75,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void StringToolMultiCharacterDeleteCleansUpUnusedBytes() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.Edit("^bob\"\" \"Some Text\" 00 <000100>");
          viewPort.Tools.StringTool.Address = 0;
 
@@ -100,7 +100,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void StringToolContentUpdatesWhenViewPortChange() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.Edit("^bob\"\" \"Some Text\"");
 
          viewPort.SelectionStart = new Point(3, 0);   // select the 'e' in 'Some'
@@ -114,7 +114,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void ToolSelectionChangeUpdatesViewPortSelection() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.Edit("^bob\"\" \"Some Text\"");
          viewPort.SelectionStart = new Point(3, 0);
          viewPort.FollowLink(3, 0);

--- a/src/HexManiac.Tests/ViewPortCursorTests.cs
+++ b/src/HexManiac.Tests/ViewPortCursorTests.cs
@@ -32,7 +32,7 @@ namespace HavenSoft.HexManiac.Tests {
       [Fact]
       public void MovingCursorRightFromRightEdgeMovesToNextLine() {
          var loadedFile = new LoadedFile("test", new byte[25]);
-         var viewPort = new ViewPort(loadedFile) { Width = 5, Height = 5 };
+         var viewPort = new ViewPort(loadedFile) { PreferredWidth = -1, Width = 5, Height = 5 };
          viewPort.SelectionStart = new Point(4, 0);
 
          viewPort.MoveSelectionStart.Execute(Direction.Right);
@@ -43,7 +43,7 @@ namespace HavenSoft.HexManiac.Tests {
       [Fact]
       public void MovingCursorDownFromBottomRowScrolls() {
          var loadedFile = new LoadedFile("test", new byte[25]);
-         var viewPort = new ViewPort(loadedFile) { Width = 5, Height = 4 };
+         var viewPort = new ViewPort(loadedFile) { PreferredWidth = -1, Width = 5, Height = 4 };
          viewPort.SelectionStart = new Point(0, 3);
 
          viewPort.MoveSelectionStart.Execute(Direction.Down);
@@ -54,7 +54,7 @@ namespace HavenSoft.HexManiac.Tests {
       [Fact]
       public void CursorCanMoveOutsideDataRangeButNotOutsideScrollRange() {
          var loadedFile = new LoadedFile("test", new byte[25]);
-         var viewPort = new ViewPort(loadedFile) { Width = 5, Height = 5 };
+         var viewPort = new ViewPort(loadedFile) { PreferredWidth = -1, Width = 5, Height = 5 };
          viewPort.Scroll.Execute(Direction.Right);
          viewPort.SelectionStart = new Point(0, 0);
 
@@ -140,7 +140,7 @@ namespace HavenSoft.HexManiac.Tests {
       [Fact]
       public void ScrollingBeforeStartOfDataMovesSelectionOnlyWhenDataMoves() {
          var loadedFile = new LoadedFile("test", new byte[25]);
-         var viewPort = new ViewPort(loadedFile) { Width = 5, Height = 5 };
+         var viewPort = new ViewPort(loadedFile) { PreferredWidth = -1, Width = 5, Height = 5 };
 
          viewPort.Scroll.Execute(Direction.Right); // move the first byte out of view
          viewPort.Scroll.Execute(Direction.Up);    // scroll up, so we can see the first byte again
@@ -159,7 +159,7 @@ namespace HavenSoft.HexManiac.Tests {
       [Fact]
       public void ChangingWidthKeepsSameDataSelected() {
          var loadedFile = new LoadedFile("test", new byte[25]);
-         var viewPort = new ViewPort(loadedFile) { Width = 5, Height = 5 };
+         var viewPort = new ViewPort(loadedFile) { PreferredWidth = -1, Width = 5, Height = 5 };
          viewPort.SelectionEnd = new Point(2, 2); // 13 cells selected
          viewPort.Width += 1;
 
@@ -184,7 +184,7 @@ namespace HavenSoft.HexManiac.Tests {
       [Fact]
       public void CannotSelectFarAfterLastByte() {
          var loadedFile = new LoadedFile("test", new byte[20]);
-         var viewPort = new ViewPort(loadedFile) { Width = 5, Height = 5 };
+         var viewPort = new ViewPort(loadedFile) { PreferredWidth = -1, Width = 5, Height = 5 };
 
          viewPort.SelectionStart = new Point(4, 4);
 

--- a/src/HexManiac.Tests/ViewPortCursorTests.cs
+++ b/src/HexManiac.Tests/ViewPortCursorTests.cs
@@ -214,7 +214,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanExpandSelection() {
          var data = new byte[0x200];
          var model = new PokemonModel(data);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", data), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("<000100>");
          viewPort.SelectionStart = new Point(1, 0);

--- a/src/HexManiac.Tests/ViewPortEditTests.cs
+++ b/src/HexManiac.Tests/ViewPortEditTests.cs
@@ -24,7 +24,7 @@ namespace HavenSoft.HexManiac.Tests {
       [Fact]
       public void CanEditMultipleBytesInARow() {
          var loadedFile = new LoadedFile("test", new byte[25]);
-         var viewPort = new ViewPort(loadedFile) { Width = 5, Height = 5 };
+         var viewPort = new ViewPort(loadedFile) { PreferredWidth = -1, Width = 5, Height = 5 };
 
          viewPort.SelectionStart = new Point(2, 2);
          viewPort.Edit("DEADBEEF");
@@ -230,7 +230,7 @@ namespace HavenSoft.HexManiac.Tests {
       [Fact]
       public void CanEnterDataAfterLastByte() {
          var loadedFile = new LoadedFile("test", new byte[20]);
-         var viewPort = new ViewPort(loadedFile) { Width = 5, Height = 5 };
+         var viewPort = new ViewPort(loadedFile) { PreferredWidth = -1, Width = 5, Height = 5 };
 
          viewPort.SelectionStart = new Point(0, 4);
          viewPort.Edit("00");

--- a/src/HexManiac.Tests/ViewPortEditTests.cs
+++ b/src/HexManiac.Tests/ViewPortEditTests.cs
@@ -242,7 +242,7 @@ namespace HavenSoft.HexManiac.Tests {
       [Fact]
       public void CanClearData() {
          var loadedFile = new LoadedFile("test", new byte[1000]);
-         var viewPort = new ViewPort(loadedFile, new PokemonModel(loadedFile.Contents)) { Width = 5, Height = 5 };
+         var viewPort = new ViewPort(loadedFile.Name, new PokemonModel(loadedFile.Contents)) { PreferredWidth = -1, Width = 5, Height = 5 };
 
          viewPort.SelectionStart = new Point(0, 0);
          viewPort.SelectionEnd = new Point(3, 3);
@@ -302,7 +302,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void ClearRemovesFormats() {
          var data = new byte[0x200];
          var model = new PokemonModel(data);
-         var viewPort = new ViewPort(new LoadedFile("file.txt", data), model);
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("<000100>");
          viewPort.SelectionStart = new Point(2, 0);

--- a/src/HexManiac.Tests/ViewPortSaveTests.cs
+++ b/src/HexManiac.Tests/ViewPortSaveTests.cs
@@ -303,7 +303,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void CanSaveAndLoadNamesAndFormats() {
          var buffer = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          var model = new PokemonModel(buffer);
-         var viewPort = new ViewPort(new LoadedFile("test.txt", buffer), model) { Width = 0x10, Height = 0x10 };
+         var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          StoredMetadata metadata = null;
          var fileSystem = new StubFileSystem { Save = (file, md) => { metadata = md; return true; } };
 
@@ -311,7 +311,7 @@ namespace HavenSoft.HexManiac.Tests {
          viewPort.Save.Execute(fileSystem);
 
          var model2 = new PokemonModel(buffer, metadata);
-         var viewPort2 = new ViewPort(new LoadedFile("test.txt", buffer), model2) { Width = 0x10, Height = 0x10 };
+         var viewPort2 = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          Assert.Equal("bob", ((Anchor)viewPort2[0, 0].Format).Name);
       }

--- a/src/HexManiac.Tests/ViewPortScrollTests.cs
+++ b/src/HexManiac.Tests/ViewPortScrollTests.cs
@@ -44,7 +44,7 @@ namespace HavenSoft.HexManiac.Tests {
       [Fact]
       public void ViewPortScrollingDoesNotAllowEmptyScreen() {
          var loadedFile = new LoadedFile("test", new byte[25]);
-         var viewPort = new ViewPort(loadedFile) { Width = 5, Height = 5 };
+         var viewPort = new ViewPort(loadedFile) { PreferredWidth = -1, Width = 5, Height = 5 };
 
          Assert.Equal(0, viewPort.MinimumScroll);
          Assert.Equal(4, viewPort.MaximumScroll);
@@ -75,7 +75,7 @@ namespace HavenSoft.HexManiac.Tests {
       public void ChangingWidthUpdatesScrollValueIfNeeded() {
          // ScrollValue=0 is always the line that contains the first byte of the file.
          var loadedFile = new LoadedFile("test", new byte[25]);
-         var viewPort = new ViewPort(loadedFile) { Width = 5, Height = 5 };
+         var viewPort = new ViewPort(loadedFile) { PreferredWidth = -1, Width = 5, Height = 5 };
 
          viewPort.ScrollValue++; // scroll down one line
          viewPort.Width--;      // decrease the width so that there is data 2 lines above
@@ -97,7 +97,7 @@ namespace HavenSoft.HexManiac.Tests {
       [Fact]
       public void ResizingCannotLeaveTotallyBlankLineAtTop() {
          var loadedFile = new LoadedFile("test", new byte[36]);
-         var viewPort = new ViewPort(loadedFile) { Width = 6, Height = 6 };
+         var viewPort = new ViewPort(loadedFile) { PreferredWidth = -1, Width = 6, Height = 6 };
 
          viewPort.ScrollValue++;   // scroll down one line
          viewPort.Width--;         // decrease the width so that there is data 2 lines above
@@ -124,7 +124,7 @@ namespace HavenSoft.HexManiac.Tests {
       [Fact]
       public void RequestingOutOfRangeDataReturnsUndefinedFormat() {
          var loadedFile = new LoadedFile("test", new byte[25]);
-         var viewPort = new ViewPort(loadedFile) { Width = 5, Height = 5 };
+         var viewPort = new ViewPort(loadedFile) { PreferredWidth = -1, Width = 5, Height = 5 };
 
          Assert.Equal(HexElement.Undefined, viewPort[0, -1]);
          Assert.Equal(HexElement.Undefined, viewPort[5, 0]);
@@ -135,7 +135,7 @@ namespace HavenSoft.HexManiac.Tests {
       [Fact]
       public void MaximumScrollChangesBasedOnDataOffset() {
          var loadedFile = new LoadedFile("test", new byte[26]);
-         var viewPort = new ViewPort(loadedFile) { Width = 5, Height = 5 };
+         var viewPort = new ViewPort(loadedFile) { PreferredWidth = -1, Width = 5, Height = 5 };
 
          // initial condition: given 4 data per row, there should be 7 rows (0-6) because 7*4=28
          viewPort.Width--;

--- a/src/HexManiac.Tests/app.config
+++ b/src/HexManiac.Tests/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.4.1.0" newVersion="2.4.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.execution.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.4.1.0" newVersion="2.4.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/HexManiac.Tests/packages.config
+++ b/src/HexManiac.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="HavenSoft.AutoImplement" version="1.1.1" targetFramework="net472" />
+  <package id="Validation" version="2.4.18" targetFramework="net472" />
   <package id="xunit" version="2.4.1" targetFramework="net471" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net471" />
   <package id="xunit.analyzers" version="0.10.0" targetFramework="net471" />
@@ -9,4 +10,5 @@
   <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net471" />
   <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net471" />
   <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net471" developmentDependency="true" />
+  <package id="Xunit.SkippableFact" version="1.3.12" targetFramework="net472" />
 </packages>

--- a/src/HexManiac.WPF/Controls/HexContent.cs
+++ b/src/HexManiac.WPF/Controls/HexContent.cs
@@ -203,13 +203,14 @@ namespace HavenSoft.HexManiac.WPF.Controls {
             var format = ViewPort[p.X, p.Y].Format;
 
             if (ViewPort is ViewPort editableViewPort) {
+               if (!editableViewPort.IsSelected(p)) editableViewPort.SelectionStart = p;
                if (format is Anchor && p.Equals(downPoint)) {
                   children.AddRange(GetAnchorChildren(p));
                   format = ((Anchor)format).OriginalFormat;
                }
                if (format is PCS pcs) children.AddRange(GetStringChildren(p));
                if (format is Pointer pointer) children.AddRange(GetPointerChildren(p));
-               if (!(format is None || format is Undefined)) children.AddRange(GetClearFormattingChildren(p));
+               if (editableViewPort.FormattedDataIsSelected) children.AddRange(GetClearFormattingChildren(p));
             } else {
                children.AddRange(GetSearchChildren(p));
             }
@@ -364,7 +365,7 @@ namespace HavenSoft.HexManiac.WPF.Controls {
          yield return new Button {
             Content = new TextBlock { Text = "Clear Format" },
          }.SetEvent(ButtonBase.ClickEvent, (sender, e) => {
-            ((ViewPort)ViewPort).ClearFormat(p);
+            ((ViewPort)ViewPort).ClearFormat();
             recentMenu.IsOpen = false;
          });
       }

--- a/src/HexManiac.WPF/Controls/HexContent.cs
+++ b/src/HexManiac.WPF/Controls/HexContent.cs
@@ -32,7 +32,7 @@ namespace HavenSoft.HexManiac.WPF.Controls {
 
       public static readonly Pen BorderPen = new Pen(Solarized.Brushes.Green, 1);
 
-
+      private Popup recentMenu;
       private ModelPoint downPoint;
       private ModelPoint mouseOverPoint;
 
@@ -54,11 +54,13 @@ namespace HavenSoft.HexManiac.WPF.Controls {
          if (e.OldValue is IViewPort oldViewPort) {
             oldViewPort.CollectionChanged -= OnViewPortContentChanged;
             oldViewPort.PropertyChanged -= OnViewPortPropertyChanged;
+            oldViewPort.RequestMenuClose -= OnViewPortRequestMenuClose;
          }
 
          if (e.NewValue is IViewPort newViewPort) {
             newViewPort.CollectionChanged += OnViewPortContentChanged;
             newViewPort.PropertyChanged += OnViewPortPropertyChanged;
+            newViewPort.RequestMenuClose += OnViewPortRequestMenuClose;
             UpdateViewPortSize();
          }
 
@@ -78,6 +80,11 @@ namespace HavenSoft.HexManiac.WPF.Controls {
          if (propertyChangesThatRequireRedraw.Contains(e.PropertyName)) {
             InvalidateVisual();
          }
+      }
+
+      private void OnViewPortRequestMenuClose(object sender, EventArgs e) {
+         if (recentMenu == null) return;
+         recentMenu.IsOpen = false;
       }
 
       #endregion
@@ -288,8 +295,6 @@ namespace HavenSoft.HexManiac.WPF.Controls {
             e.Handled = true;
          }
       }
-
-      Popup recentMenu;
 
       private IEnumerable<FrameworkElement> GetAnchorChildren(ModelPoint p) {
          var anchor = (Anchor)ViewPort[p.X, p.Y].Format;

--- a/src/HexManiac.WPF/Implementations/FormatDrawer.cs
+++ b/src/HexManiac.WPF/Implementations/FormatDrawer.cs
@@ -59,7 +59,7 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
 
       public void Visit(Pointer dataFormat, byte data) {
          var brush = Solarized.Brushes.Blue;
-         if (dataFormat.Destination == Pointer.NULL) brush = Solarized.Brushes.Red;
+         if (dataFormat.Destination < 0) brush = Solarized.Brushes.Red;
          Underline(brush, dataFormat.Position == 0, dataFormat.Position == 3);
 
          var typeface = new Typeface("Consolas");

--- a/src/HexManiac.WPF/Windows/App.xaml.cs
+++ b/src/HexManiac.WPF/Windows/App.xaml.cs
@@ -42,7 +42,7 @@ namespace HavenSoft.HexManiac.WPF.Windows {
          var loadedFile = fileSystem.LoadFile(fileName);
          var metadata = fileSystem.MetadataFor(fileName);
          var model = new AutoSearchModel(loadedFile.Contents, metadata);
-         editor.Add(new ViewPort(loadedFile, model));
+         editor.Add(new ViewPort(loadedFile.Name, model));
          return editor;
       }
    }

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml
@@ -182,7 +182,7 @@
                <Separator />
                <MenuItem Header="Cu_t" Command="{Binding Cut}" InputGestureText="Ctrl+X"/>
                <MenuItem Header="_Copy" Command="{Binding Copy}" InputGestureText="Ctrl+C"/>
-               <MenuItem Header="_Paste" Command="{Binding Paste}" InputGestureText="Ctrl+V"/>
+               <MenuItem Header="_Paste / Replace" Command="{Binding Paste}" InputGestureText="Ctrl+V"/>
                <MenuItem Header="_Delete" Command="{Binding Delete}" InputGestureText="Del"/>
                <Separator />
                <MenuItem Header="_Find" Command="{Binding ShowFind}" InputGestureText="Ctrl+F">

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml
@@ -254,13 +254,19 @@
                      <!-- Anchor Editor -->
                      <Border DockPanel.Dock="Top" Height="19" BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Backlight}">
                         <DockPanel Visibility="{Binding AnchorTextVisible, Converter={StaticResource BoolToVisibility}}" >
-                           <TextBlock Width="60" Text="Anchor: " TextAlignment="Right">
+                           <TextBlock Width="60" Text="Anchor: " TextAlignment="Right" ToolTipService.ShowDuration="15000">
                               <TextBlock.ToolTip>
                                  <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{solarized:Theme Blue}" BorderThickness="1">
                                     <TextBlock TextAlignment="Left">
-                                       Anchor metadata improves UI for known data types.
-                                       <LineBreak />
-                                       Modifying it will change how the data is displayed.
+                                       <Bold>Anchor Editor</Bold> <LineBreak/>
+                                       Anchors can have a name and a format. <LineBreak/>
+                                       <LineBreak/>
+                                       Named anchors persist between sessions. <LineBreak/>
+                                       You can also use names in pointers and with Goto <Italic Foreground="{DynamicResource Secondary}">(Ctrl+G)</Italic>. <LineBreak/>
+                                       <LineBreak/>
+                                       Formats change how the data is displayed and edited. <LineBreak/>
+                                       For example, "" formats data as text. <LineBreak/>
+                                       To learn more about formats, visit the Wiki.
                                     </TextBlock>
                                  </ToolTip>
                               </TextBlock.ToolTip>

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml
@@ -251,8 +251,22 @@
             <TabControl.ContentTemplate>
                <DataTemplate>
                   <DockPanel>
+                     <!-- Anchor Editor -->
                      <Border DockPanel.Dock="Top" Height="19" BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Backlight}">
-                        <TextBox Text="{Binding AnchorText, UpdateSourceTrigger=PropertyChanged}" Visibility="{Binding AnchorTextVisible, Converter={StaticResource BoolToVisibility}}" Margin="60,0,25,0"/>
+                        <DockPanel Visibility="{Binding AnchorTextVisible, Converter={StaticResource BoolToVisibility}}" >
+                           <TextBlock Width="60" Text="Anchor: " TextAlignment="Right">
+                              <TextBlock.ToolTip>
+                                 <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{solarized:Theme Blue}" BorderThickness="1">
+                                    <TextBlock TextAlignment="Left">
+                                       Anchor metadata improves UI for known data types.
+                                       <LineBreak />
+                                       Modifying it will change how the data is displayed.
+                                    </TextBlock>
+                                 </ToolTip>
+                              </TextBlock.ToolTip>
+                           </TextBlock>
+                           <TextBox Text="{Binding AnchorText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,25,0"/>
+                        </DockPanel>
                      </Border>
                      <!-- Headers -->
                      <ItemsControl DockPanel.Dock="Left" Width="60" ItemsSource="{Binding Headers}" Background="{DynamicResource Backlight}" MouseDown="HeaderMouseDown">
@@ -263,6 +277,7 @@
                         </ItemsControl.ItemTemplate>
                      </ItemsControl>
                      <Line Width="1" DockPanel.Dock="Left" Stroke="{DynamicResource Background}"/>
+                     <!-- Tool Headers -->
                      <StackPanel DockPanel.Dock="Right" Visibility="{Binding HasTools, Converter={StaticResource BoolToVisibility}}">
                         <Button Content="Text" Command="{Binding Tools.StringToolCommand}" Margin="0,2">
                            <Button.LayoutTransform>

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -2,9 +2,9 @@
 
 [assembly: AssemblyCompany("HavenSoft")]
 [assembly: AssemblyProduct("HavenSoft")]
-[assembly: AssemblyCopyright("Copyright © HavenSoft 2018")]
+[assembly: AssemblyCopyright("Copyright © HavenSoft 2019")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.1.2.0")]
-[assembly: AssemblyFileVersion("0.1.2.0")]
+[assembly: AssemblyVersion("0.1.3.0")]
+[assembly: AssemblyFileVersion("0.1.3.0")]


### PR DESCRIPTION
* Usability improvements based on suggestions and personal annoyances
* You can now goto from the data by typing the @ character.
-> this is useful for copying a chunk, moving into the hex editor, and pasting, and knowing that
   the chunk will go to the right place. Example: `@123456 <poknames>`
* arrays can now handle pointers!
* HMA will now automatically search for the item data on first load. Tested with all 5 vanilla roms.
* added skippable unit test for auto-search, to make sure I don't break it as I keep changing stuff.
