### PR TITLE
Anchors pointing within arrays

### DIFF
--- a/src/HexManiac.Core/Models/AutoSearchModel.cs
+++ b/src/HexManiac.Core/Models/AutoSearchModel.cs
@@ -52,42 +52,48 @@ namespace HavenSoft.HexManiac.Core.Models {
 
       private void DecodeNameArrays() {
          // movenames
-         if (TrySearch(this, "[name\"\"13]", out var movenames)) {
+         if (TrySearch(this, noChangeDelta, "[name\"\"13]", out var movenames)) {
             ObserveAnchorWritten(noChangeDelta, "movenames", movenames);
          }
 
          // pokenames
-         if (TrySearch(this, "[name\"\"11]", out var pokenames)) {
+         if (TrySearch(this, noChangeDelta, "[name\"\"11]", out var pokenames)) {
             ObserveAnchorWritten(noChangeDelta, "pokenames", pokenames);
          }
 
          // abilitynames / trainer names
          if (gameCode == Ruby || gameCode == Sapphire || gameCode == Emerald) {
-            if (TrySearch(this, "[name\"\"13]", out var abilitynames)) {
+            if (TrySearch(this, noChangeDelta, "[name\"\"13]", out var abilitynames)) {
                ObserveAnchorWritten(noChangeDelta, "abilitynames", abilitynames);
             }
-            if (TrySearch(this, "[name\"\"13]", out var trainerclassnames)) {
+            if (TrySearch(this, noChangeDelta, "[name\"\"13]", out var trainerclassnames)) {
                ObserveAnchorWritten(noChangeDelta, "trainerclassnames", trainerclassnames);
             }
          } else {
-            if (TrySearch(this, "[name\"\"13]", out var trainerclassnames)) {
+            if (TrySearch(this, noChangeDelta, "[name\"\"13]", out var trainerclassnames)) {
                ObserveAnchorWritten(noChangeDelta, "trainerclassnames", trainerclassnames);
             }
-            if (TrySearch(this, "[name\"\"13]", out var abilitynames)) {
+            if (TrySearch(this, noChangeDelta, "[name\"\"13]", out var abilitynames)) {
                ObserveAnchorWritten(noChangeDelta, "abilitynames", abilitynames);
             }
          }
 
-         // types[name""7]18
-         // this one is weird, because things actually point to each individual name, as well as being in an array
+         // types
+         if (TrySearch(this, noChangeDelta, "^[name\"\"7]", out var typenames)) { // the type names are sometimes pointed to directly, instead of in the array
+            ObserveAnchorWritten(noChangeDelta, "types", typenames);
+         }
       }
 
       private void DecodeDataArrays() {
-         // abilitydescriptions[description<"">]abilitynames
-
-         if (TrySearch(this, "[name\"\"14 a: b: c: d<> e: f: g<> h: i: j<> k: l:]", out var itemdata)) {
+         if (TrySearch(this, noChangeDelta, "[name\"\"14 index: price: holdeffect: description<> keyitemvalue. bagkeyitem. pocket. type. fieldeffect<> battleusage:: battleeffect<> battleextra::]", out var itemdata)) {
             ObserveAnchorWritten(noChangeDelta, "items", itemdata);
          }
+
+         // ^pokestats[hp. attack. def. speed. spatk. spdef. catchrate. runrate. a:: b:: c:: d:: e::]pokenames
+
+         // abilitydescriptions[description<"">]abilitynames
+
+         // @3D4294 ^itemicons[image<> palette<>]items
       }
    }
 }

--- a/src/HexManiac.Core/Models/IDataModel.cs
+++ b/src/HexManiac.Core/Models/IDataModel.cs
@@ -38,7 +38,7 @@ namespace HavenSoft.HexManiac.Core.Models {
       void Load(byte[] newData, StoredMetadata metadata);
       void ExpandData(ModelDelta changeToken, int minimumLength);
 
-      IReadOnlyList<int> SearchForPointersToAnchor(ModelDelta changeToken, int address);
+      IReadOnlyList<int> SearchForPointersToAnchor(ModelDelta changeToken, params int[] addresses);
       void WritePointer(ModelDelta changeToken, int address, int pointerDestination);
       void WriteValue(ModelDelta changeToken, int address, int value);
       int ReadPointer(int address);
@@ -98,7 +98,7 @@ namespace HavenSoft.HexManiac.Core.Models {
 
       public abstract IFormattedRun RelocateForExpansion(ModelDelta changeToken, IFormattedRun run, int minimumLength);
 
-      public abstract IReadOnlyList<int> SearchForPointersToAnchor(ModelDelta changeToken, int address);
+      public abstract IReadOnlyList<int> SearchForPointersToAnchor(ModelDelta changeToken, params int[] addresses);
 
       public abstract void UpdateArrayPointer(ModelDelta currentChange, int index, int fullValue);
 
@@ -147,7 +147,7 @@ namespace HavenSoft.HexManiac.Core.Models {
          for (int i = 0; i < length; i++) changeToken.ChangeData(this, start + i, 0xFF);
       }
 
-      public override IReadOnlyList<int> SearchForPointersToAnchor(ModelDelta changeToken, int address) => throw new NotImplementedException();
+      public override IReadOnlyList<int> SearchForPointersToAnchor(ModelDelta changeToken, params int[] addresses) => throw new NotImplementedException();
 
       public override void UpdateArrayPointer(ModelDelta changeToken, int address, int destination) {
          WritePointer(changeToken, address, destination);

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -151,7 +151,7 @@ namespace HavenSoft.HexManiac.Core.Models {
          var errorInfo = TryParseFormat(model, format, dataIndex, out var runToWrite);
          if (errorInfo.HasError) return errorInfo;
 
-         errorInfo = ValidateAnchorNameAndFormat(model, runToWrite, name, format, dataIndex, allowAnchorOverwrite: true);
+         errorInfo = ValidateAnchorNameAndFormat(model, runToWrite, name, format, dataIndex, allowAnchorOverwrite);
          if (!errorInfo.HasError) model.ObserveAnchorWritten(changeToken, name, runToWrite);
 
          return errorInfo;

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -717,7 +717,9 @@ namespace HavenSoft.HexManiac.Core.Models {
          string format = string.Empty;
          int split = -1;
 
-         if (name.Contains(ArrayStart)) {
+         if (name.Contains(AnchorStart.ToString() + ArrayStart)) {
+            split = name.IndexOf(AnchorStart);
+         } else if (name.Contains(ArrayStart)) {
             split = name.IndexOf(ArrayStart);
          } else if (name.Contains(StringDelimeter)) {
             split = name.IndexOf(StringDelimeter);

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -291,6 +291,17 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          return new ArrayRun(owner, FormatString, newStart, ElementCount, ElementContent, PointerSources, PointerSourcesForInnerElements);
       }
 
+      public override IFormattedRun RemoveSource(int source) {
+         if (!SupportsPointersToElements) return base.RemoveSource(source);
+         var newPointerSources = PointerSources.Where(item => item != source).ToList();
+         var newInnerPointerSources = new List<IReadOnlyList<int>>();
+         foreach (var list in PointerSourcesForInnerElements) {
+            newInnerPointerSources.Add(list.Where(item => item != source).ToList());
+         }
+
+         return new ArrayRun(owner, FormatString, Start, ElementCount, ElementContent, newPointerSources, newInnerPointerSources);
+      }
+
       protected override IFormattedRun Clone(IReadOnlyList<int> newPointerSources) {
          // since the inner pointer sources includes the first row, update the first row
          List<IReadOnlyList<int>> newInnerPointerSources = null;

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -88,12 +88,23 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
 
       public string LengthFromAnchor { get; }
 
+      public bool SupportsPointersToElements { get; }
+
+      /// <summary>
+      /// For Arrays that support pointers to individual elements within the array,
+      /// This is the set of sources that points to each index of the array.
+      /// The first set of sources (PointerSourcesForInnerElements[0]) should always be the same as PointerSources.
+      /// </summary>
+      public IReadOnlyList<IReadOnlyList<int>> PointerSourcesForInnerElements { get; }
+
       // composition of each element
       public IReadOnlyList<ArrayRunElementSegment> ElementContent { get; }
 
       private ArrayRun(IDataModel data, string format, int start, IReadOnlyList<int> pointerSources) : base(start, pointerSources) {
          owner = data;
          FormatString = format;
+         SupportsPointersToElements = format.StartsWith(AnchorStart.ToString());
+         if (SupportsPointersToElements) format = format.Substring(1);
          var closeArray = format.LastIndexOf(ArrayEnd.ToString());
          if (!format.StartsWith(ArrayStart.ToString()) || closeArray == -1) throw new ArrayRunParseException($"Array Content must be wrapped in {ArrayStart}{ArrayEnd}.");
          var segments = format.Substring(1, closeArray - 1);
@@ -123,7 +134,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          Length = ElementLength * ElementCount;
       }
 
-      private ArrayRun(IDataModel data, string format, int start, int elementCount, IReadOnlyList<ArrayRunElementSegment> segments, IReadOnlyList<int> pointerSources) : base(start, pointerSources) {
+      private ArrayRun(IDataModel data, string format, int start, int elementCount, IReadOnlyList<ArrayRunElementSegment> segments, IReadOnlyList<int> pointerSources, IReadOnlyList<IReadOnlyList<int>> pointerSourcesForInnerElements) : base(start, pointerSources) {
          owner = data;
          FormatString = format;
          ElementContent = segments;
@@ -131,6 +142,8 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          ElementCount = elementCount;
          LengthFromAnchor = string.Empty;
          Length = ElementLength * ElementCount;
+         SupportsPointersToElements = pointerSourcesForInnerElements != null;
+         PointerSourcesForInnerElements = pointerSourcesForInnerElements;
       }
 
       public static ErrorInfo TryParse(IDataModel data, string format, int start, IReadOnlyList<int> pointerSources, out ArrayRun self) {
@@ -144,8 +157,10 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          return ErrorInfo.NoError;
       }
 
-      public static bool TrySearch(IDataModel data, string format, out ArrayRun self) {
+      public static bool TrySearch(IDataModel data, ModelDelta changeToken, string format, out ArrayRun self) {
          self = null;
+         var allowPointersToEntries = format.StartsWith(AnchorStart.ToString());
+         if (allowPointersToEntries) format = format.Substring(1);
          var closeArray = format.LastIndexOf(ArrayEnd.ToString());
          if (!format.StartsWith(ArrayStart.ToString()) || closeArray == -1) throw new ArrayRunParseException($"Array Content must be wrapped in {ArrayStart}{ArrayEnd}");
          var segments = format.Substring(1, closeArray - 1);
@@ -186,7 +201,8 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
 
          if (bestAddress == Pointer.NULL) return false;
 
-         self = new ArrayRun(data, format + bestLength, bestAddress, bestLength, elementContent, data.GetNextRun(bestAddress).PointerSources);
+         self = new ArrayRun(data, format + bestLength, bestAddress, bestLength, elementContent, data.GetNextRun(bestAddress).PointerSources, null);
+         if (allowPointersToEntries) self = self.AddSourcesPointingWithinArray(changeToken);
          return true;
       }
 
@@ -234,7 +250,29 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          var lastArrayCharacterIndex = FormatString.LastIndexOf(ArrayEnd);
          var newFormat = FormatString.Substring(0, lastArrayCharacterIndex + 1);
          if (newFormat != FormatString) newFormat += ElementCount + elementCount;
-         return new ArrayRun(owner, newFormat, Start, ElementCount + elementCount, ElementContent, PointerSources);
+         return new ArrayRun(owner, newFormat, Start, ElementCount + elementCount, ElementContent, PointerSources, PointerSourcesForInnerElements);
+      }
+
+      public ArrayRun AddSourcesPointingWithinArray(ModelDelta changeToken) {
+         if (ElementCount < 2) return this;
+
+         var destinations = new int[ElementCount - 1];
+         for (int i = 1; i < ElementCount; i++) destinations[i - 1] = Start + ElementLength * i;
+
+         var sources = owner.SearchForPointersToAnchor(changeToken, destinations);
+
+         var results = new List<List<int>>();
+         results.Add(PointerSources.ToList());
+         for (int i = 1; i < ElementCount; i++) results.Add(new List<int>());
+
+         foreach (var source in sources) {
+            var destination = owner.ReadPointer(source);
+            int destinationIndex = (destination - Start) / ElementLength;
+            results[destinationIndex].Add(source);
+         }
+
+         var pointerSourcesForInnerElements = results.Cast<IReadOnlyList<int>>().ToList();
+         return new ArrayRun(owner, FormatString, Start, ElementCount, ElementContent, PointerSources, pointerSourcesForInnerElements);
       }
 
       public void AppendTo(IReadOnlyList<byte> data, StringBuilder text) {
@@ -250,11 +288,19 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       }
 
       public IFormattedRun Move(int newStart) {
-         return new ArrayRun(owner, FormatString, newStart, ElementCount, ElementContent, PointerSources);
+         return new ArrayRun(owner, FormatString, newStart, ElementCount, ElementContent, PointerSources, PointerSourcesForInnerElements);
       }
 
       protected override IFormattedRun Clone(IReadOnlyList<int> newPointerSources) {
-         return new ArrayRun(owner, FormatString, Start, ElementCount, ElementContent, newPointerSources);
+         // since the inner pointer sources includes the first row, update the first row
+         List<IReadOnlyList<int>> newInnerPointerSources = null;
+         if (PointerSourcesForInnerElements != null) {
+            newInnerPointerSources = new List<IReadOnlyList<int>>();
+            newInnerPointerSources.Add(newPointerSources);
+            for (int i = 1; i < PointerSourcesForInnerElements.Count; i++) newInnerPointerSources.Add(PointerSourcesForInnerElements[i]);
+         }
+
+         return new ArrayRun(owner, FormatString, Start, ElementCount, ElementContent, newPointerSources, newInnerPointerSources);
       }
 
       private static List<ArrayRunElementSegment> ParseSegments(string segments) {

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -72,6 +72,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       public const char ArrayEnd = ']';
       public const char SingleByteIntegerFormat = '.';
       public const char DoubleByteIntegerFormat = ':';
+      public const char ArrayAnchorSeparator = '/';
 
       private readonly IDataModel owner;
 
@@ -252,6 +253,16 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          var newFormat = FormatString.Substring(0, lastArrayCharacterIndex + 1);
          if (newFormat != FormatString) newFormat += ElementCount + elementCount;
          return new ArrayRun(owner, newFormat, Start, ElementCount + elementCount, ElementContent, PointerSources, PointerSourcesForInnerElements);
+      }
+
+      public ArrayRun AddSourcePointingWithinArray(int source) {
+         var destination = owner.ReadPointer(source);
+         var index = (destination - Start) / ElementLength;
+         if (index < 0 || index >= ElementCount) throw new IndexOutOfRangeException();
+         if (index == 0) throw new NotImplementedException();
+         var newInnerPointerSources = PointerSourcesForInnerElements.ToList();
+         newInnerPointerSources[index] = newInnerPointerSources[index].Concat(new[] { source }).ToList();
+         return new ArrayRun(owner, FormatString, Start, ElementCount, ElementContent, PointerSources, newInnerPointerSources);
       }
 
       public ArrayRun AddSourcesPointingWithinArray(ModelDelta changeToken) {

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -157,8 +157,9 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          return ErrorInfo.NoError;
       }
 
-      public static bool TrySearch(IDataModel data, ModelDelta changeToken, string format, out ArrayRun self) {
+      public static bool TrySearch(IDataModel data, ModelDelta changeToken, string originalFormat, out ArrayRun self) {
          self = null;
+         var format = originalFormat;
          var allowPointersToEntries = format.StartsWith(AnchorStart.ToString());
          if (allowPointersToEntries) format = format.Substring(1);
          var closeArray = format.LastIndexOf(ArrayEnd.ToString());
@@ -201,7 +202,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
 
          if (bestAddress == Pointer.NULL) return false;
 
-         self = new ArrayRun(data, format + bestLength, bestAddress, bestLength, elementContent, data.GetNextRun(bestAddress).PointerSources, null);
+         self = new ArrayRun(data, originalFormat + bestLength, bestAddress, bestLength, elementContent, data.GetNextRun(bestAddress).PointerSources, null);
          if (allowPointersToEntries) self = self.AddSourcesPointingWithinArray(changeToken);
          return true;
       }
@@ -262,7 +263,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          var sources = owner.SearchForPointersToAnchor(changeToken, destinations);
 
          var results = new List<List<int>>();
-         results.Add(PointerSources.ToList());
+         results.Add(PointerSources?.ToList() ?? new List<int>());
          for (int i = 1; i < ElementCount; i++) results.Add(new List<int>());
 
          foreach (var source in sources) {

--- a/src/HexManiac.Core/Models/Runs/IFormattedRun.cs
+++ b/src/HexManiac.Core/Models/Runs/IFormattedRun.cs
@@ -57,7 +57,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          return Clone(sources.Concat(PointerSources).Distinct().OrderBy(i => i).ToList());
       }
 
-      public IFormattedRun RemoveSource(int source) {
+      public virtual IFormattedRun RemoveSource(int source) {
          return Clone(PointerSources.Except(new[] { source }).ToList());
       }
 

--- a/src/HexManiac.Core/ViewModels/Selection.cs
+++ b/src/HexManiac.Core/ViewModels/Selection.cs
@@ -170,7 +170,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
       private void GotoAddressHelper(int address) {
          var destinationRun = model.GetNextRun(address) as ArrayRun;
-         var destinationIsArray = destinationRun != null && destinationRun.Start == address;
+         var destinationIsArray = destinationRun != null;
 
          if (destinationIsArray) {
             PreferredWidth = destinationRun.ElementLength;

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -749,7 +749,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          } else if (underEdit.CurrentText.StartsWith(PointerStart.ToString())) {
             return char.IsLetterOrDigit(input) || input == ArrayAnchorSeparator || input == PointerEnd;
          } else if (underEdit.CurrentText.StartsWith(GotoMarker.ToString())) {
-            return char.IsLetterOrDigit(input) || char.IsWhiteSpace(input);
+            return char.IsLetterOrDigit(input) || input == ArrayAnchorSeparator || char.IsWhiteSpace(input);
          } else if (underEdit.CurrentText.StartsWith(AnchorStart.ToString())) {
             return
                char.IsLetterOrDigit(input) ||

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -747,7 +747,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                return true;
             }
          } else if (underEdit.CurrentText.StartsWith(PointerStart.ToString())) {
-            return char.IsLetterOrDigit(input) || input == PointerEnd;
+            return char.IsLetterOrDigit(input) || input == ArrayAnchorSeparator || input == PointerEnd;
          } else if (underEdit.CurrentText.StartsWith(GotoMarker.ToString())) {
             return char.IsLetterOrDigit(input) || char.IsWhiteSpace(input);
          } else if (underEdit.CurrentText.StartsWith(AnchorStart.ToString())) {

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -1170,10 +1170,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          var run = Model.GetNextRun(index);
          if (index < run.Start) { currentView[p.X, p.Y] = new HexElement(Model[index], None.Instance); return; }
          var format = run.CreateDataFormat(Model, index);
-         if (run.PointerSources != null && run.Start == index) {
-            var name = Model.GetAnchorFromAddress(-1, run.Start);
-            format = new Anchor(format, name, run.FormatString, run.PointerSources);
-         }
+         format = WrapFormat(run, format, index);
          currentView[p.X, p.Y] = new HexElement(Model[index], format);
       }
 
@@ -1188,10 +1185,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                   currentView[x, y] = HexElement.Undefined;
                } else if (index >= run.Start) {
                   var format = run.CreateDataFormat(Model, index);
-                  if (run.PointerSources != null && run.Start == index) {
-                     var name = Model.GetAnchorFromAddress(-1, run.Start);
-                     format = new Anchor(format, name, run.FormatString, run.PointerSources);
-                  }
+                  format = WrapFormat(run, format, index);
                   currentView[x, y] = new HexElement(Model[index], format);
                } else {
                   currentView[x, y] = new HexElement(Model[index], None.Instance);
@@ -1200,6 +1194,23 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          }
 
          NotifyCollectionChanged(ResetArgs);
+      }
+
+      private IDataFormat WrapFormat(IFormattedRun run, IDataFormat format, int dataIndex) {
+         if (run.PointerSources != null && run.Start == dataIndex) {
+            var name = Model.GetAnchorFromAddress(-1, run.Start);
+            return new Anchor(format, name, run.FormatString, run.PointerSources);
+         }
+
+         if (run is ArrayRun array && array.SupportsPointersToElements && (dataIndex - run.Start) % array.ElementLength == 0) {
+            var arrayIndex = (dataIndex - run.Start) / array.ElementLength;
+            var pointerSources = array.PointerSourcesForInnerElements[arrayIndex];
+            if (pointerSources == null || pointerSources.Count == 0) return format;
+            var name = Model.GetAnchorFromAddress(-1, dataIndex);
+            return new Anchor(format, name, string.Empty, pointerSources);
+         }
+
+         return format;
       }
 
       private void NotifyCollectionChanged(NotifyCollectionChangedEventArgs args) => CollectionChanged?.Invoke(this, args);

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -754,6 +754,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
             return
                char.IsLetterOrDigit(input) ||
                char.IsWhiteSpace(input) ||
+               input == AnchorStart ||
                input == ArrayStart ||
                input == ArrayEnd ||
                input == StringDelimeter ||

--- a/src/HexManiac.Tests/ArrayRunTests.cs
+++ b/src/HexManiac.Tests/ArrayRunTests.cs
@@ -588,6 +588,22 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.StartsWith("^", run.FormatString);
       }
 
+      [Fact]
+      public void CanCreateNewPointerUsingArrayNameAndIndex() {
+         var data = new byte[0x200];
+         var changeToken = new ModelDelta();
+         var model = new PokemonModel(data);
+         var viewport = new ViewPort("name", model) { Width = 0x10, Height = 0x10 };
+
+         viewport.Edit("^array^[content\"\"8]8 ");
+
+         viewport.SelectionStart = new Point(0, 6);
+         viewport.Edit("<array/3>");
+
+         var run = (ArrayRun)model.GetNextRun(0);
+         Assert.Single(run.PointerSourcesForInnerElements[3]);
+      }
+
       private static void WriteStrings(byte[] buffer, int start, params string[] content) {
          foreach (var item in content) {
             var bytes = PCSString.Convert(item).ToArray();

--- a/src/HexManiac.Tests/ArrayRunTests.cs
+++ b/src/HexManiac.Tests/ArrayRunTests.cs
@@ -575,6 +575,19 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.Empty(array.PointerSourcesForInnerElements[1]);
       }
 
+      [Fact]
+      public void CanCreateArraySupportingInnerAnchorsFromViewModel() {
+         var data = new byte[0x200];
+         var changeToken = new ModelDelta();
+         var model = new PokemonModel(data);
+         var viewport = new ViewPort("name", model) { Width = 0x10, Height = 0x10 };
+
+         viewport.Edit("^array^[content\"\"16]16 ");
+         var run = (ArrayRun)model.GetNextRun(0);
+
+         Assert.StartsWith("^", run.FormatString);
+      }
+
       private static void WriteStrings(byte[] buffer, int start, params string[] content) {
          foreach (var item in content) {
             var bytes = PCSString.Convert(item).ToArray();

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -57,6 +57,17 @@ namespace HavenSoft.HexManiac.Tests {
 
       [SkippableTheory]
       [MemberData(nameof(PokemonGames))]
+      public void TypesAreFound(string game) {
+         var model = LoadModel(game);
+         var noChange = new NoDataChangeDeltaModel();
+
+         var address = model.GetAddressFromAnchor(noChange, -1, "types");
+         var run = (ArrayRun)model.GetNextAnchor(address);
+         Assert.Equal(18, run.ElementCount);
+      }
+
+      [SkippableTheory]
+      [MemberData(nameof(PokemonGames))]
       public void ItemsAreFound(string game) {
          var model = LoadModel(game);
          var noChange = new NoDataChangeDeltaModel();


### PR DESCRIPTION
I had imagined that this feature wouldn't be needed... until I found data in the roms that needs it.

Basically, until now, anchors have only been able to point at the start of a run. This is generally all that's needed. However, some arrays might have pointers pointing to specific elements within the array, as well as having a consistent format that the entire array uses. We'd like the array to be treated as a single thing. Moving it should move all pointers within it as well. Pointers pointing into it should be based on the name of the array and the index (example: <types/2> ).

This pull request adds this feature, as well as the required unit tests and the types array to the auto-search as an example of it being used.

The current format for these arrays is the same as normal arrays, but with a ^ prepended. For example, ^types^[name""7]18. Note that the ^ at the front marks that we're adding an anchor, while marking the ^ before the [] indicates that this array supports inner anchors.