### PR TITLE
Updates from usability test

### DIFF
--- a/src/HexManiac.Core/Models/IDataModel.cs
+++ b/src/HexManiac.Core/Models/IDataModel.cs
@@ -111,14 +111,7 @@ namespace HavenSoft.HexManiac.Core.Models {
 
       public abstract void UpdateArrayPointer(ModelDelta currentChange, int index, int fullValue);
 
-      public int ReadValue(int index) {
-         int word = 0;
-         word |= RawData[index + 0] << 0;
-         word |= RawData[index + 1] << 8;
-         word |= RawData[index + 2] << 16;
-         word |= RawData[index + 3] << 24;
-         return word;
-      }
+      public int ReadValue(int index) => BitConverter.ToInt32(RawData, index);
 
       public void WriteValue(ModelDelta changeToken, int index, int word) {
          changeToken.ChangeData(this, index + 0, (byte)(word >> 0));

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -785,7 +785,7 @@ namespace HavenSoft.HexManiac.Core.Models {
             } else {
                var childNames = run.ElementNames;
                if (childNames != null && childNames.Count > 0) {
-                  foreach(var childName in childNames) {
+                  foreach (var childName in childNames) {
                      var full = $"{name}{ArrayAnchorSeparator}{childName}";
                      if (IsPartialMatch(full, partial)) results.Add(full);
                   }

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -426,15 +426,19 @@ namespace HavenSoft.HexManiac.Core.Models {
       public override void ObserveAnchorWritten(ModelDelta changeToken, string anchorName, IFormattedRun run) {
          int location = run.Start;
          int index = BinarySearch(location);
-         if (index < 0) {
+
+         var existingRun = (index >= 0 && index < runs.Count) ? runs[index] : null;
+
+         if (existingRun == null) {
             // no format starts exactly at this anchor, so clear any format that goes over this anchor.
             ClearFormat(changeToken, location, run.Length);
          } else if (!(run is NoInfoRun)) {
-            // a format starts exactly at this anchor, but this new format may extend further. Clear everything but the anchor.
-            ClearFormat(changeToken, run.Start, run.Length);
+            // a format starts exactly at this anchor.
+            // but the new format may extend further. If so, clear the existing format.
+            if (existingRun.Length < run.Length) {
+               ClearFormat(changeToken, run.Start, run.Length);
+            }
          }
-
-         var existingRun = (index >= 0 && index < runs.Count) ? runs[index] : null;
 
          if (anchorForAddress.TryGetValue(location, out string oldAnchorName)) {
             anchorForAddress.Remove(location);

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -873,7 +873,7 @@ namespace HavenSoft.HexManiac.Core.Models {
       }
 
       private static (string, string) SplitNameAndFormat(string text) {
-         var name = text.Substring(1).Trim();
+         var name = text.Substring(1).Trim(); // lop off leading ^
          string format = string.Empty;
          int split = -1;
 

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using static HavenSoft.HexManiac.Core.Models.Runs.ArrayRun;
 using static HavenSoft.HexManiac.Core.Models.Runs.AsciiRun;
 using static HavenSoft.HexManiac.Core.Models.Runs.BaseRun;
@@ -818,48 +819,62 @@ namespace HavenSoft.HexManiac.Core.Models {
       public override IReadOnlyList<int> SearchForPointersToAnchor(ModelDelta changeToken, params int[] addresses) {
          var results = new List<int>();
 
-         for (int i = 3; i < RawData.Length; i++) {
-            if (RawData[i] != 0x08 && RawData[i] != 0x09) continue;
-            int destination = ReadPointer(i - 3);
-            if (!addresses.Contains(destination)) continue;
-            // I have to lock this whole block, because I need to know that 'index' remains consistent until I can call runs.Insert
-            lock (runs) {
-               var index = BinarySearch(i - 3);
-               if (index >= 0) {
-                  if (runs[index] is PointerRun) results.Add(i - 3);
-                  if (runs[index] is ArrayRun arrayRun && arrayRun.ElementContent[0].Type == ElementContentType.Pointer) results.Add(i - 3);
-                  if (runs[index] is NoInfoRun) {
-                     var pointerRun = new PointerRun(i - 3, runs[index].PointerSources);
-                     changeToken.RemoveRun(runs[index]);
-                     changeToken.AddRun(pointerRun);
-                     runs[index] = pointerRun;
-                     results.Add(i - 3);
-                  }
-                  continue;
+         var chunkLength = 0x10000;
+         var groups = (int)Math.Ceiling((double)RawData.Length / chunkLength);
+         Parallel.For(0, groups, group => {
+            var data = RawData;
+            var chunkEnd = chunkLength * (group + 1);
+            chunkEnd = Math.Min(chunkEnd, data.Length);
+            for (int i = chunkLength * group + 3; i < chunkEnd; i++) {
+               if (data[i] != 0x08 && data[i] != 0x09) continue;
+               var destination = ReadPointer(i - 3);
+               if (!addresses.Contains(destination)) continue;
+               if (IsValidResult(changeToken, i)) {
+                  lock (results) results.Add(i - 3);
                }
-               index = ~index;
-               if (index < runs.Count && runs[index].Start <= i) continue; // can't add a pointer run if an existing run starts during the new one
-
-               // can't add a pointer run if the new one starts during an existing one
-               if (index > 0 && runs[index - 1].Start + runs[index - 1].Length > i - 3) {
-                  // ah, but if that run is an array and there's already a pointer here...
-                  var array = runs[index - 1] as ArrayRun;
-                  if (array != null) {
-                     var offsets = array.ConvertByteOffsetToArrayOffset(i);
-                     if (array.ElementContent[offsets.SegmentIndex].Type == ElementContentType.Pointer) {
-                        results.Add(i - 3);
-                     }
-                  }
-                  continue;
-               }
-               var newRun = new PointerRun(i - 3);
-               runs.Insert(index, newRun);
-               changeToken.AddRun(newRun);
             }
-            results.Add(i - 3);
-         }
+         });
 
          return results;
+      }
+
+      private bool IsValidResult(ModelDelta changeToken, int i) {
+         // I have to lock this whole block, because I need to know that 'index' remains consistent until I can call runs.Insert
+         lock (runs) {
+            var index = BinarySearch(i - 3);
+            if (index >= 0) {
+               if (runs[index] is PointerRun) return true;
+               if (runs[index] is ArrayRun arrayRun && arrayRun.ElementContent[0].Type == ElementContentType.Pointer) return true;
+               if (runs[index] is NoInfoRun) {
+                  var pointerRun = new PointerRun(i - 3, runs[index].PointerSources);
+                  changeToken.RemoveRun(runs[index]);
+                  changeToken.AddRun(pointerRun);
+                  runs[index] = pointerRun;
+                  return true;
+               }
+               return false;
+            }
+            index = ~index;
+            if (index < runs.Count && runs[index].Start <= i) return false; // can't add a pointer run if an existing run starts during the new one
+
+            // can't add a pointer run if the new one starts during an existing one
+            if (index > 0 && runs[index - 1].Start + runs[index - 1].Length > i - 3) {
+               // ah, but if that run is an array and there's already a pointer here...
+               var array = runs[index - 1] as ArrayRun;
+               if (array != null) {
+                  var offsets = array.ConvertByteOffsetToArrayOffset(i);
+                  if (array.ElementContent[offsets.SegmentIndex].Type == ElementContentType.Pointer) {
+                     return true;
+                  }
+               }
+               return false;
+            }
+            var newRun = new PointerRun(i - 3);
+            runs.Insert(index, newRun);
+            changeToken.AddRun(newRun);
+         }
+
+         return true;
       }
 
       private static bool IsPartialMatch(string full, string partial) {

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -73,8 +73,8 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       }
 
       public bool TryParse(IDataModel model, string text, out int value) {
-         value = -1;
          text = text.Trim();
+         if (int.TryParse(text, out value)) return true;
          if (text.StartsWith("\"") && text.EndsWith("\"")) text = text.Substring(1, text.Length - 2);
          var partialMatches = new List<string>();
          var matches = new List<string>();

--- a/src/HexManiac.Core/Models/SearchByte.cs
+++ b/src/HexManiac.Core/Models/SearchByte.cs
@@ -9,7 +9,7 @@ namespace HavenSoft.HexManiac.Core.Models {
    public class SearchByte : ISearchByte {
       private readonly byte value;
       public SearchByte(int value) => this.value = (byte)value;
-      public static explicit operator SearchByte (byte value) => new SearchByte(value);
+      public static explicit operator SearchByte(byte value) => new SearchByte(value);
       public bool Match(byte value) => value == this.value;
    }
    public class PCSSearchByte : ISearchByte {

--- a/src/HexManiac.Core/ViewModels/ChangeHistory.cs
+++ b/src/HexManiac.Core/ViewModels/ChangeHistory.cs
@@ -4,6 +4,11 @@ using System.Runtime.CompilerServices;
 using System.Windows.Input;
 
 namespace HavenSoft.HexManiac.Core.ViewModels {
+   public interface IChangeToken {
+      bool HasDataChange { get; }
+      event EventHandler OnNewDataChange;
+   }
+
    /// <summary>
    /// Represents a history of changes that can undo / redo.
    /// The change can be reperesented by any class with an empty constructor.
@@ -17,7 +22,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
    /// However, since ChangeHistory is not responsible for saving, you have to tell it whenever the data is saved.
    /// This is accomplished via the TagAsSaved() method.
    /// </remarks>
-   public class ChangeHistory<T> : ViewModelCore where T : class, new() {
+   public class ChangeHistory<T> : ViewModelCore where T : class, IChangeToken, new() {
       private readonly Func<T, T> revert;
       private readonly StubCommand undo, redo;
       private readonly Stack<T>
@@ -43,6 +48,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
             if (currentChange == null) {
                bool notifyIsSavedChanged = IsSaved;
                currentChange = new T();
+               currentChange.OnNewDataChange += OnCurrentTokenDataChanged;
                if (undoStack.Count == 0) undo.CanExecuteChanged.Invoke(undo, EventArgs.Empty);
                if (notifyIsSavedChanged) NotifyPropertyChanged(nameof(IsSaved));
             }
@@ -52,6 +58,22 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       }
 
       public bool IsSaved => undoStackSizeAtSaveTag == undoStack.Count && currentChange == null;
+
+      public bool HasDataChange {
+         get {
+            if (IsSaved) return false;
+            var addedElements = undoStack.Count - undoStackSizeAtSaveTag;
+            var undoItems = undoStack.ToArray();
+            var redoItems = redoStack.ToArray();
+            for (int i = 0; i < addedElements; i++) {
+               if (undoItems[undoStackSizeAtSaveTag + i].HasDataChange) return true;
+            }
+            for (int i = 0; i < -addedElements; i++) {
+               if (redoItems[redoItems.Length - 1 - i].HasDataChange) return true;
+            }
+            return currentChange?.HasDataChange ?? false;
+         }
+      }
 
       public ChangeHistory(Func<T, T> revertChange) {
          revert = revertChange;
@@ -69,18 +91,26 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          if (currentChange == null) return;
          VerifyRevertNotInProgress();
          undoStack.Push(currentChange);
+         currentChange.OnNewDataChange -= OnCurrentTokenDataChanged;
          currentChange = null;
       }
 
       public void TagAsSaved() {
          ChangeCompleted();
-         TryUpdate(ref undoStackSizeAtSaveTag, undoStack.Count, nameof(IsSaved));
+         if(TryUpdate(ref undoStackSizeAtSaveTag, undoStack.Count, nameof(IsSaved))) {
+            NotifyPropertyChanged(nameof(HasDataChange));
+         }
+      }
+
+      private void OnCurrentTokenDataChanged(object sender, EventArgs e) {
+         NotifyPropertyChanged(nameof(HasDataChange));
       }
 
       private void UndoExecuted() {
          ChangeCompleted();
          if (undoStack.Count == 0) return;
          bool previouslyWasSaved = IsSaved;
+         bool previouslyHadDataChanged = HasDataChange;
 
          using (CreateRevertScope()) {
             var originalChange = undoStack.Pop();
@@ -91,11 +121,13 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          }
 
          if (previouslyWasSaved != IsSaved) NotifyPropertyChanged(nameof(IsSaved));
+         if (previouslyHadDataChanged != HasDataChange) NotifyPropertyChanged(nameof(HasDataChange));
       }
 
       private void RedoExecuted() {
          if (redoStack.Count == 0) return;
          bool previouslyWasSaved = IsSaved;
+         bool previouslyHadDataChanged = HasDataChange;
          VerifyRevertNotInProgress();
 
          using (CreateRevertScope()) {
@@ -107,6 +139,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          }
 
          if (previouslyWasSaved != IsSaved) NotifyPropertyChanged(nameof(IsSaved));
+         if (previouslyHadDataChanged != HasDataChange) NotifyPropertyChanged(nameof(HasDataChange));
       }
 
       private void VerifyRevertNotInProgress([CallerMemberName]string caller = null) {

--- a/src/HexManiac.Core/ViewModels/ChildViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ChildViewPort.cs
@@ -7,7 +7,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
    public class ChildViewPort : ViewPort, IChildViewPort {
       public IViewPort Parent { get; }
 
-      public ChildViewPort(IViewPort viewPort) : base(string.Empty, viewPort.Model) {
+      public ChildViewPort(IViewPort viewPort) : base(viewPort.FileName, viewPort.Model) {
          Parent = viewPort;
          Width = Parent.Width;
       }

--- a/src/HexManiac.Core/ViewModels/EditorViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/EditorViewModel.cs
@@ -141,7 +141,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          get => useTableEntryHeaders;
          set {
             if (!TryUpdate(ref useTableEntryHeaders, value)) return;
-            foreach(var tab in tabs) {
+            foreach (var tab in tabs) {
                if (tab is ViewPort viewModel) viewModel.UseCustomHeaders = useTableEntryHeaders;
             }
          }
@@ -500,7 +500,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
             var args = (ExtendedPropertyChangedEventArgs)e;
             var oldHeight = (int)args.OldValue;
             var height = viewPort2.Height;
-            foreach(var tab in this) {
+            foreach (var tab in this) {
                if (tab == viewPort2) continue;
                if (!(tab is IViewPort viewPort3)) continue;
                RemoveContentListeners(tab);

--- a/src/HexManiac.Core/ViewModels/EditorViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/EditorViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using HavenSoft.HexManiac.Core.Models;
+using HavenSoft.HexManiac.Core.ViewModels.Tools;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -157,6 +158,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
             if (TryUpdate(ref infoMessage, value)) ShowMessage = !string.IsNullOrEmpty(InformationMessage);
          }
       }
+
+      public IToolTrayViewModel Tools => (SelectedTab as IViewPort)?.Tools;
 
       public event EventHandler<Action> RequestDelayedWork;
 
@@ -474,6 +477,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          GotoViewModel.PropertyChanged -= GotoPropertyChanged;
          GotoViewModel = new GotoControlViewModel(SelectedTab);
          GotoViewModel.PropertyChanged += GotoPropertyChanged;
+         NotifyPropertyChanged(nameof(Tools));
       }
 
       private void ForwardDelayedWork(object sender, Action e) => RequestDelayedWork?.Invoke(this, e);

--- a/src/HexManiac.Core/ViewModels/EditorViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/EditorViewModel.cs
@@ -490,6 +490,22 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
             if (!string.IsNullOrEmpty(oldName)) fileSystem.RemoveListenerForFile(oldName, viewPort.ConsiderReload);
             if (!string.IsNullOrEmpty(viewPort.FileName)) fileSystem.AddListenerToFile(viewPort.FileName, viewPort.ConsiderReload);
          }
+
+         // when one tab's height updates, update other tabs by the same amount.
+         // this isn't perfect, since tabs shouldn't nessisarily change height at the same pixel.
+         // but it'll keep the tabs that are out of view from getting totally out of sync.
+         if (e.PropertyName == nameof(IViewPort.Height) && sender is IViewPort viewPort2) {
+            var args = (ExtendedPropertyChangedEventArgs)e;
+            var oldHeight = (int)args.OldValue;
+            var height = viewPort2.Height;
+            foreach(var tab in this) {
+               if (tab == viewPort2) continue;
+               if (!(tab is IViewPort viewPort3)) continue;
+               RemoveContentListeners(tab);
+               viewPort3.Height += height - oldHeight;
+               AddContentListeners(tab);
+            }
+         }
       }
 
       private void GotoPropertyChanged(object sender, PropertyChangedEventArgs e) {

--- a/src/HexManiac.Core/ViewModels/EditorViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/EditorViewModel.cs
@@ -129,6 +129,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                gotoViewModel.ControlVisible = false;
                FindControlVisible = false;
                ShowError = false;
+            } else {
+               infoMessage = string.Empty;
             }
             if (TryUpdate(ref showMessage, value)) clearMessage.CanExecuteChanged.Invoke(clearMessage, EventArgs.Empty);
          }

--- a/src/HexManiac.Core/ViewModels/IViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/IViewPort.cs
@@ -21,6 +21,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       int DataOffset { get; }
       ICommand Scroll { get; } // parameter: Direction to scroll
 
+      string SelectedAddress { get; }
       string AnchorText { get; }
       bool AnchorTextVisible { get; }
 

--- a/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
@@ -154,7 +154,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
             // probably doesn't have labels yet but is about to get them. We don't know how big the
             // labels will be, but they will probably push all the data down quite a bit.
             // compensate by scrolling slightly
-            if (parent.Height == Height) parent.ScrollValue++;
+            if (parent.Height == Height) parent.ScrollValue += 2;
          } else {
             var dataOffset = Math.Max(0, child.DataOffset - (y - line) * child.Width);
             parent.Goto.Execute(dataOffset.ToString("X6"));

--- a/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
@@ -235,6 +235,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       public IDisposable DeferUpdates => new StubDisposable();
       public event PropertyChangedEventHandler PropertyChanged;
       public void Schedule(Action action) => action();
+      public void RefreshContent() { }
 
       public IToolViewModel this[int index] => null;
       public int SelectedIndex { get => -1; set { } }

--- a/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
@@ -148,10 +148,17 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          var child = children[childIndex];
          var parent = child.Parent;
          if (child.Model.GetNextRun(child.DataOffset) is ArrayRun array) {
-            // TODO
+            parent.Goto.Execute(child.DataOffset.ToString("X6"));
+            parent.ScrollValue += line - y + Height - parent.Height;
+            // heuristic: if the parent height matches the search results height, then the parent
+            // probably doesn't have labels yet but is about to get them. We don't know how big the
+            // labels will be, but they will probably push all the data down quite a bit.
+            // compensate by scrolling slightly
+            if (parent.Height == Height) parent.ScrollValue++;
+         } else {
+            var dataOffset = Math.Max(0, child.DataOffset - (y - line) * child.Width);
+            parent.Goto.Execute(dataOffset.ToString("X6"));
          }
-         var dataOffset = Math.Max(0, child.DataOffset - (y - line) * child.Width);
-         parent.Goto.Execute(dataOffset.ToString("X6"));
 
          if (parent is ViewPort viewPort) {
             viewPort.SelectionStart = viewPort.ConvertAddressToViewPoint(childrenSelection[childIndex].start);
@@ -204,7 +211,6 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          }
          return (childIndex, line);
       }
-
    }
 
    public class SearchResultsTools : IToolTrayViewModel {

--- a/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
@@ -2,9 +2,11 @@
 using HavenSoft.HexManiac.Core.Models.Runs;
 using HavenSoft.HexManiac.Core.ViewModels.Tools;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows.Input;
 
@@ -73,7 +75,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
       public bool HasTools => false;
 
-      public IToolTrayViewModel Tools => null;
+      public IToolTrayViewModel Tools { get; } = new SearchResultsTools();
 
       public string AnchorText { get; set; }
 
@@ -200,5 +202,25 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          return (childIndex, line);
       }
 
+   }
+
+   public class SearchResultsTools : IToolTrayViewModel {
+      public ICommand HideCommand { get; } = new StubCommand();
+      public ICommand StringToolCommand { get; } = new StubCommand();
+      public ICommand TableToolCommand { get; } = new StubCommand();
+      public ICommand Tool3Command { get; } = new StubCommand();
+
+      public PCSTool StringTool => null;
+      public TableTool TableTool => null;
+
+      public IDisposable DeferUpdates => new StubDisposable();
+      public event PropertyChangedEventHandler PropertyChanged;
+      public void Schedule(Action action) => action();
+
+      public IToolViewModel this[int index] => null;
+      public int SelectedIndex { get => -1; set { } }
+      public int Count => 0;
+      public IEnumerator<IToolViewModel> GetEnumerator() => new List<IToolViewModel>().GetEnumerator();
+      IEnumerator IEnumerable.GetEnumerator() => new List<IToolViewModel>().GetEnumerator();
    }
 }

--- a/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
@@ -147,6 +147,9 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
          var child = children[childIndex];
          var parent = child.Parent;
+         if (child.Model.GetNextRun(child.DataOffset) is ArrayRun array) {
+            // TODO
+         }
          var dataOffset = Math.Max(0, child.DataOffset - (y - line) * child.Width);
          parent.Goto.Execute(dataOffset.ToString("X6"));
 

--- a/src/HexManiac.Core/ViewModels/Selection.cs
+++ b/src/HexManiac.Core/ViewModels/Selection.cs
@@ -174,9 +174,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       private void GotoAddressHelper(int address) {
          var destinationRun = model.GetNextRun(address) as ArrayRun;
          var destinationIsArray = destinationRun != null;
-
-         int preferredWidth = 0;
-
+         int preferredWidth;
          if (destinationIsArray) {
             preferredWidth = destinationRun.ElementLength;
          } else {

--- a/src/HexManiac.Core/ViewModels/Tools/IToolTrayViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/IToolTrayViewModel.cs
@@ -10,6 +10,11 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
    public interface IToolTrayViewModel : IReadOnlyList<IToolViewModel>, INotifyPropertyChanged {
       int SelectedIndex { get; set; }
 
+      ICommand HideCommand { get; }
+      ICommand StringToolCommand { get; }
+      ICommand TableToolCommand { get; }
+      ICommand Tool3Command { get; }
+
       PCSTool StringTool { get; }
 
       TableTool TableTool { get; }

--- a/src/HexManiac.Core/ViewModels/Tools/IToolTrayViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/IToolTrayViewModel.cs
@@ -22,6 +22,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
       IDisposable DeferUpdates { get; }
 
       void Schedule(Action action);
+      void RefreshContent();
    }
 
    public class ToolTray : ViewModelCore, IToolTrayViewModel {
@@ -105,6 +106,10 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
          } else {
             action();
          }
+      }
+
+      public void RefreshContent() {
+         TableTool.DataForCurrentRunChanged();
       }
 
       public IEnumerator<IToolViewModel> GetEnumerator() => tools.GetEnumerator();

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -604,7 +604,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       private bool TryParsePointerSearchSegment(List<ISearchByte> searchBytes, string cleanedSearchString, ref int i) {
          var pointerEnd = cleanedSearchString.IndexOf(PointerEnd, i);
          if (pointerEnd == -1) { OnError(this, "Search mismatch: no closing >"); return false; }
-         var pointerContents = cleanedSearchString.Substring(i + 1, pointerEnd - i - 2);
+         var pointerContents = cleanedSearchString.Substring(i + 1, pointerEnd - i - 1);
          var address = Model.GetAddressFromAnchor(history.CurrentChange, -1, pointerContents);
          if (address != Pointer.NULL) {
             searchBytes.Add((SearchByte)(address >> 0));

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -544,7 +544,6 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          var parallelLock = new object();
          var currentChange = history.CurrentChange;
          Parallel.ForEach(searchResults, result => {
-         // foreach (var result in searchResults) {
             var nextRun = Model.GetNextRun(result);
             if (nextRun.Start < result) return;
             if (nextRun.Start == result && !(nextRun is NoInfoRun)) return;
@@ -1114,7 +1113,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
          var visitedNames = new List<string>();
          while (arrayRun.LengthFromAnchor != string.Empty) {
-            if (visitedNames.Contains(arrayRun.LengthFromAnchor)){
+            if (visitedNames.Contains(arrayRun.LengthFromAnchor)) {
                // We kept going up the chain of tables but didn't find a top table. Either the table length definitions are circular or very deep.
                OnError?.Invoke(this, $"Could not extend table safely. Table length has a circular dependency involving {arrayRun.LengthFromAnchor}.");
                return;
@@ -1140,7 +1139,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          newRun = newRun.Append(1);
          Model.ObserveRunWritten(history.CurrentChange, newRun);
 
-         foreach(var child in GetDependantArrays(newRun)) {
+         foreach (var child in GetDependantArrays(newRun)) {
             ExtendArrayAndChildren(child);
          }
       }

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -275,6 +275,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                         selection.PropertyChanged -= SelectionPropertyChanged;
                         Goto.Execute(index.ToString("X2"));
                         selection.PropertyChanged += SelectionPropertyChanged;
+                        UpdateColumnHeaders();
+                        Tools.RefreshContent();
                      }
                      RefreshBackingData();
                   } else {

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -89,7 +89,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                if (Math.Abs(scroll.DataIndex - previous) % Width != 0) UpdateColumnHeaders();
             }
          } else if (e.PropertyName != nameof(scroll.DataLength)) {
-            NotifyPropertyChanged(e.PropertyName);
+            NotifyPropertyChanged(((ExtendedPropertyChangedEventArgs)e).OldValue, e.PropertyName);
          }
 
          if (e.PropertyName == nameof(Width) || e.PropertyName == nameof(Height)) {

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -133,7 +133,9 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
             var element = currentView[location.X, location.Y];
             var underEdit = element.Format as UnderEdit;
             if (underEdit != null) {
-               currentView[location.X, location.Y] = new HexElement(element.Value, underEdit.Edit(" "));
+               var endEdit = " ";
+               if (underEdit.CurrentText.Count(c => c == '"') % 2 == 1) endEdit = "\"";
+               currentView[location.X, location.Y] = new HexElement(element.Value, underEdit.Edit(endEdit));
                if (!TryCompleteEdit(location)) ClearEdits(location);
             }
          }
@@ -1035,11 +1037,17 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                return false;
             } else if (originalFormat is IntegerEnum integerEnum) {
                var currentText = underEdit.CurrentText;
-               // must end in whitespace, and must have matching quotation marks (ex. "Mr. Mime")
-               if (char.IsWhiteSpace(currentText.Last()) && currentText.Count(c => c == '"') % 2 == 0) {
+
+               // must end in whitespace or must have matching quotation marks (ex. "Mr. Mime")
+               var quoteCount = currentText.Count(c => c == '"');
+               if (quoteCount == 2) {
+                  CompleteIntegerEnumEdit(point, currentText);
+                  return true;
+               } else if (quoteCount == 0 && char.IsWhiteSpace(currentText.Last())) {
                   CompleteIntegerEnumEdit(point, currentText);
                   return true;
                }
+
                return false;
             }
 

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -855,7 +855,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
             if (innerFormat is Integer) return char.IsNumber(input);
 
-            if (innerFormat is IntegerEnum) return char.IsLetter(input) ||
+            if (innerFormat is IntegerEnum) return char.IsLetterOrDigit(input) ||
                input == StringDelimeter ||
                "?-".Contains(input);
 

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -40,7 +40,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          get {
             var name = Path.GetFileNameWithoutExtension(FileName);
             if (string.IsNullOrEmpty(name)) name = "Untitled";
-            if (!history.IsSaved) name += "*";
+            if (history.HasDataChange) name += "*";
             return name;
          }
       }
@@ -192,9 +192,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       }
 
       private void HistoryPropertyChanged(object sender, PropertyChangedEventArgs e) {
-         if (e.PropertyName != nameof(history.IsSaved)) return;
-         save.CanExecuteChanged.Invoke(save, EventArgs.Empty);
-         NotifyPropertyChanged(nameof(Name));
+         if (e.PropertyName == nameof(history.IsSaved)) save.CanExecuteChanged.Invoke(save, EventArgs.Empty);
+         if (e.PropertyName == nameof(history.HasDataChange)) NotifyPropertyChanged(nameof(Name));
       }
 
       #endregion

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -144,6 +144,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          NotifyPropertyChanged(e.PropertyName);
          var dataIndex = scroll.ViewPointToDataIndex(SelectionStart);
          UpdateToolsFromSelection(dataIndex);
+         SelectedAddress = "Address: " + dataIndex.ToString("X6");
       }
 
       private void UpdateToolsFromSelection(int dataIndex) {
@@ -163,6 +164,12 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          } else {
             AnchorTextVisible = false;
          }
+      }
+
+      private string selectedAddress;
+      public string SelectedAddress {
+         get => selectedAddress;
+         set => TryUpdate(ref selectedAddress, value);
       }
 
       #endregion

--- a/src/HexManiac.Tests/ArrayColumnHeaderTests.cs
+++ b/src/HexManiac.Tests/ArrayColumnHeaderTests.cs
@@ -1,0 +1,51 @@
+﻿using HavenSoft.HexManiac.Core.Models;
+using HavenSoft.HexManiac.Core.Models.Runs;
+using HavenSoft.HexManiac.Core.ViewModels;
+using HavenSoft.HexManiac.Core.ViewModels.Tools;
+using System.Collections.Generic;
+using Xunit;
+
+namespace HavenSoft.HexManiac.Tests {
+   public class ArrayColumnHeaderTests {
+      readonly List<string> errors = new List<string>();
+      readonly List<string> messages = new List<string>();
+      readonly byte[] data = new byte[0x200];
+      readonly PokemonModel model;
+      readonly ViewPort viewPort;
+
+      public ArrayColumnHeaderTests() {
+         model = new PokemonModel(data);
+         viewPort = new ViewPort("test.gba", model) { Width = 0x10, Height = 0x10 };
+         viewPort.Edit("^array[data1. data2.]8 ");
+         viewPort.OnError += (sender, e) => { if (!string.IsNullOrEmpty(e)) errors.Add(e); };
+         viewPort.OnMessage += (sender, e) => messages.Add(e);
+      }
+
+      [Fact]
+      public void AnchorFormatAutoCompletesToSingleByte() {
+         viewPort.AnchorText = "^array[data1. b data2.]8";
+         var array = (ArrayRun)model.GetNextRun(0);
+         Assert.Equal(3, array.ElementLength);
+         Assert.Empty(errors);
+      }
+
+      [Fact]
+      public void HeadersChangeWhenAnchorChanges() {
+         viewPort.AnchorText = "^array[data1. b data2.]8";
+         Assert.Equal(0, viewPort.ColumnHeaders[0].ColumnHeaders.Count % 3);
+
+         viewPort.AnchorText = "^array[data1. bc data2.]8";
+         Assert.Equal("bc", viewPort.ColumnHeaders[0].ColumnHeaders[1].ColumnTitle);
+         Assert.Equal(1, viewPort.ColumnHeaders[0].ColumnHeaders[1].ByteWidth);
+      }
+
+      [Fact]
+      public void TableToolUpdatesAfterAnchorChange() {
+         viewPort.AnchorText = "^array[data1. b data2.]8";
+         Assert.Equal(3, viewPort.Tools.TableTool.Children.Count);
+
+         viewPort.AnchorText = "^array[data1. bc data2.]8";
+         Assert.Equal("bc", ((FieldArrayElementViewModel)viewPort.Tools.TableTool.Children[1]).Name);
+      }
+   }
+}

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -85,11 +85,11 @@ namespace HavenSoft.HexManiac.Tests {
 
          var address = model.GetAddressFromAnchor(noChange, -1, "items");
          var run = (ArrayRun)model.GetNextAnchor(address);
-         if (game.Contains("Emerald"))   Assert.Equal(377, run.ElementCount);
-         if (game.Contains("FireRed"))   Assert.Equal(375, run.ElementCount);
+         if (game.Contains("Emerald")) Assert.Equal(377, run.ElementCount);
+         if (game.Contains("FireRed")) Assert.Equal(375, run.ElementCount);
          if (game.Contains("LeafGreen")) Assert.Equal(375, run.ElementCount);
-         if (game.Contains("Ruby"))      Assert.Equal(349, run.ElementCount);
-         if (game.Contains("Sapphire"))  Assert.Equal(349, run.ElementCount);
+         if (game.Contains("Ruby")) Assert.Equal(349, run.ElementCount);
+         if (game.Contains("Sapphire")) Assert.Equal(349, run.ElementCount);
       }
 
       [SkippableTheory]
@@ -100,11 +100,11 @@ namespace HavenSoft.HexManiac.Tests {
 
          var address = model.GetAddressFromAnchor(noChange, -1, "trainerclassnames");
          var run = (ArrayRun)model.GetNextAnchor(address);
-         if (game.Contains("Emerald"))   Assert.Equal(67, run.ElementCount);
-         if (game.Contains("FireRed"))   Assert.Equal(108, run.ElementCount);
+         if (game.Contains("Emerald")) Assert.Equal(67, run.ElementCount);
+         if (game.Contains("FireRed")) Assert.Equal(108, run.ElementCount);
          if (game.Contains("LeafGreen")) Assert.Equal(108, run.ElementCount);
-         if (game.Contains("Ruby"))      Assert.Equal(59, run.ElementCount);
-         if (game.Contains("Sapphire"))  Assert.Equal(59, run.ElementCount);
+         if (game.Contains("Ruby")) Assert.Equal(59, run.ElementCount);
+         if (game.Contains("Sapphire")) Assert.Equal(59, run.ElementCount);
       }
 
       [SkippableTheory]

--- a/src/HexManiac.Tests/FindTests.cs
+++ b/src/HexManiac.Tests/FindTests.cs
@@ -343,7 +343,7 @@ namespace HavenSoft.HexManiac.Tests {
 
          editor.Find.Execute("This is the song");
          var resultsTab = (IViewPort)editor[editor.SelectedIndex];
-         resultsTab.FollowLink(0, 0);
+         resultsTab.FollowLink(0, 1);
 
          Assert.NotEqual(viewPort.SelectionStart, viewPort.SelectionEnd);
       }

--- a/src/HexManiac.Tests/HexManiac.Tests.csproj
+++ b/src/HexManiac.Tests/HexManiac.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="..\..\artifacts\$(AssemblyName)\codegen\StubDataModel.cs">
       <Link>StubDataModel.cs</Link>
     </Compile>
+    <Compile Include="ArrayColumnHeaderTests.cs" />
     <Compile Include="ArrayRunTests.cs" />
     <Compile Include="AutoSearchTests.cs" />
     <Compile Include="ChangeHistoryTests.cs" />

--- a/src/HexManiac.Tests/NavigationTests.cs
+++ b/src/HexManiac.Tests/NavigationTests.cs
@@ -210,11 +210,13 @@ namespace HavenSoft.HexManiac.Tests {
       public void GotoAutoCompleteNavigationCommandsWork() {
          var tab = new StubViewPort {
             Goto = new StubCommand { CanExecute = ICommandExtensions.CanAlwaysExecute },
-            Model = new StubDataModel { GetAutoCompleteAnchorNameOptions = str => new List<string> {
-               "Option 1",
-               "Option 2",
-               "Option 3",
-            } },
+            Model = new StubDataModel {
+               GetAutoCompleteAnchorNameOptions = str => new List<string> {
+                  "Option 1",
+                  "Option 2",
+                  "Option 3",
+               }
+            },
          };
          var viewModel = new GotoControlViewModel(tab);
 

--- a/src/HexManiac.WPF/Controls/HexContent.cs
+++ b/src/HexManiac.WPF/Controls/HexContent.cs
@@ -212,7 +212,11 @@ namespace HavenSoft.HexManiac.WPF.Controls {
          }
 
          if (ViewPort is ViewPort editableViewPort) {
-            if (Keyboard.Modifiers == ModifierKeys.Shift) {
+            var point = e.GetPosition(this);
+            if (point.X < 0) {
+               editableViewPort.SelectionStart = downPoint;
+               editableViewPort.SelectionEnd = new ModelPoint(editableViewPort.Width - 1, downPoint.Y);
+            } else if (Keyboard.Modifiers == ModifierKeys.Shift) {
                editableViewPort.SelectionEnd = downPoint;
             } else {
                editableViewPort.SelectionStart = downPoint;
@@ -229,8 +233,17 @@ namespace HavenSoft.HexManiac.WPF.Controls {
             InvalidateVisual();
          }
          if (!IsMouseCaptured) return;
+         if (!(ViewPort is ViewPort viewPort)) return;
 
-         ((ViewPort)ViewPort).SelectionEnd = ControlCoordinatesToModelCoordinates(e);
+
+         var point = e.GetPosition(this);
+         var modelPoint = ControlCoordinatesToModelCoordinates(e);
+         if (point.X < 0) {
+            viewPort.SelectionEnd = new ModelPoint(viewPort.Width - 1, modelPoint.Y);
+         } else {
+            viewPort.SelectionEnd = modelPoint;
+         }
+
       }
 
       protected override void OnMouseUp(MouseButtonEventArgs e) {
@@ -492,8 +505,8 @@ namespace HavenSoft.HexManiac.WPF.Controls {
 
       private ModelPoint ControlCoordinatesToModelCoordinates(MouseEventArgs e) {
          var point = e.GetPosition(this);
-         point = new System.Windows.Point(Math.Max(0, point.X), Math.Max(0, point.Y)); // out of bounds to the left/top clamps to 0 (useful for headers)
-         return new Core.Models.Point((int)(point.X / CellWidth), (int)(point.Y / CellHeight));
+         point = new ScreenPoint(Math.Max(0, point.X), Math.Max(0, point.Y)); // out of bounds to the left/top clamps to 0 (useful for headers)
+         return new ModelPoint((int)(point.X / CellWidth), (int)(point.Y / CellHeight));
       }
    }
 

--- a/src/HexManiac.WPF/Controls/HorizontalSlantedTextControl.cs
+++ b/src/HexManiac.WPF/Controls/HorizontalSlantedTextControl.cs
@@ -95,7 +95,9 @@ namespace HavenSoft.HexManiac.WPF.Controls {
          int maxLength = 1;
          if (HeaderRows.Count > 0) maxLength = HeaderRows.Max(row => row.ColumnHeaders.Max(header => header.ColumnTitle.Length));
          var sampleFormat = Format(new string('0', maxLength));
-         var heightPerRow = Math.Max(sampleFormat.Width * Math.Sin(SlantAngle * Math.PI / 180), sampleFormat.Height);
+         var angle = SlantAngle * Math.PI / 180;
+         var heightPerRow = Math.Max(sampleFormat.Width * Math.Sin(angle) + sampleFormat.Height * Math.Cos(angle), sampleFormat.Height);
+         var angledTextHeight = sampleFormat.Height * Math.Cos(SlantAngle * Math.PI / 180);
          var pen = new Pen(Solarized.Theme.Backlight, 1);
 
          double yOffset = heightPerRow;
@@ -103,18 +105,19 @@ namespace HavenSoft.HexManiac.WPF.Controls {
          for (var i = 0; i < HeaderRows.Count; i++) {
             var row = HeaderRows[i];
             double xOffset = 70.0;
+            var height = ActualHeight - (HeaderRows.Count - i - 1) * heightPerRow;
             foreach (var header in row.ColumnHeaders) {
                var theta = (90 - SlantAngle) * Math.PI / 180;
                var separatorLength = sampleFormat.Width * Math.Cos(SlantAngle * Math.PI / 180) * 2 / 3;
-               var height = ActualHeight - (HeaderRows.Count - i - 1) * heightPerRow;
                drawingContext.DrawLine(pen, new Point(xOffset, height), new Point(xOffset + Math.Sin(theta) * separatorLength, height - Math.Cos(theta) * separatorLength));
 
                xOffset += header.ByteWidth * ColumnWidth / 2;
 
                var text = Format(header.ColumnTitle);
-               var additionalOffsetForTilt = header.ColumnTitle.Length > 1 ? 3 : -2;
+               var additionalXOffsetForTilt = header.ColumnTitle.Length > 1 ? 3 : -2;
+               var additionalYOffsetForTilt = header.ColumnTitle.Length > 1 ? angledTextHeight : sampleFormat.Height;
 
-               drawingContext.PushTransform(new TranslateTransform(xOffset + additionalOffsetForTilt, yOffset));
+               drawingContext.PushTransform(new TranslateTransform(xOffset + additionalXOffsetForTilt, yOffset - additionalYOffsetForTilt));
                if (header.ColumnTitle.Length > 1) drawingContext.PushTransform(new RotateTransform(-SlantAngle));
                drawingContext.DrawText(text, new Point());
                if (header.ColumnTitle.Length > 1) drawingContext.Pop();
@@ -131,9 +134,10 @@ namespace HavenSoft.HexManiac.WPF.Controls {
       private void UpdateDesiredHeight() {
          var maxLength = (HeaderRows?.Count ?? 0) == 0 ? 1 : HeaderRows.Max(row => row.ColumnHeaders.Max(header => header.ColumnTitle.Length));
          var formattedText = Format(new string('0', maxLength));
-         var rows = HeaderRows?.Count ?? 0;
-         var heightPerRow = Math.Max(formattedText.Width * Math.Sin(SlantAngle * Math.PI / 180), formattedText.Height);
-         var finalHeight = Math.Ceiling(heightPerRow * rows) + 10;
+         var rows = HeaderRows?.Count ?? 1;
+         var angle = SlantAngle * Math.PI / 180;
+         var heightPerRow = Math.Max(formattedText.Width * Math.Sin(angle) + formattedText.Height * Math.Cos(angle), formattedText.Height);
+         var finalHeight = Math.Ceiling(heightPerRow * rows);
          Height = finalHeight;
       }
 

--- a/src/HexManiac.WPF/Controls/StartScreen.xaml
+++ b/src/HexManiac.WPF/Controls/StartScreen.xaml
@@ -9,9 +9,11 @@
              d:DesignHeight="450" d:DesignWidth="800">
    <Grid.ColumnDefinitions>
       <ColumnDefinition/>
+      <ColumnDefinition Width="20"/>
       <ColumnDefinition Width="400"/>
+      <ColumnDefinition Width="20"/>
    </Grid.ColumnDefinitions>
-   <TextBlock Grid.Column="0" Foreground="{DynamicResource Primary}" HorizontalAlignment="Center" VerticalAlignment="Center">
+   <TextBlock Grid.Column="0" Foreground="{DynamicResource Primary}" HorizontalAlignment="Center" TextWrapping="Wrap" VerticalAlignment="Center">
       Drag-n-Drop to open a file.
       <LineBreak/> <LineBreak/>
       Tip: Try typing these words into Goto <Italic>(Ctrl+G)</Italic>. <LineBreak/>
@@ -26,7 +28,7 @@
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>abilitydescriptions<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>movedata<LineBreak/>
    </TextBlock>
-   <StackPanel Grid.Column="1" VerticalAlignment="Center" TextBlock.Foreground="{DynamicResource Primary}" >
+   <StackPanel Grid.Column="2" VerticalAlignment="Center" TextBlock.Foreground="{DynamicResource Primary}" >
       <Border Margin="5" Padding="5" Background="{DynamicResource Background}" BorderBrush="{DynamicResource Secondary}" CornerRadius="5,5,5,5" BorderThickness="1" Cursor="Hand" MouseLeftButtonDown="PointerHelp">
          <Grid>
             <Grid.RowDefinitions>

--- a/src/HexManiac.WPF/Windows/App.xaml
+++ b/src/HexManiac.WPF/Windows/App.xaml
@@ -21,7 +21,7 @@
                      BorderThickness="{TemplateBinding BorderThickness}"
                      BorderBrush="{TemplateBinding BorderBrush}"
                      Background="{TemplateBinding Background}">
-                     <ContentPresenter/>
+                     <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                   </Border>
                   <ControlTemplate.Triggers>
                      <Trigger SourceName="Border" Property="IsMouseOver" Value="True">

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml
@@ -9,7 +9,7 @@
         xmlns:hsg3hvmtr="clr-namespace:HavenSoft.HexManiac.Core.ViewModels.Tools;assembly=HexManiac.Core"
         Icon="..\Resources\AppIcon.ico"
         PreviewMouseDown="RunDeferredActions"
-        Title="Hex Maniac Advance" Height="450" Width="870" AllowDrop="True" Background="{DynamicResource Backlight}">
+        Title="Hex Maniac Advance" Height="470" Width="880" AllowDrop="True" Background="{DynamicResource Backlight}">
    <Window.Resources>
       <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
       <hsg3hv:IntegerToBooleanViaMatchConverter x:Key="IndexMatch"/>
@@ -55,413 +55,416 @@
    <Window.CommandBindings>
       <CommandBinding Command="ToggleBullets" Executed="ToggleTheme"/>
    </Window.CommandBindings>
-   <DockPanel>
-      <DockPanel DockPanel.Dock="Top" Background="{DynamicResource Background}">
-         <DockPanel.Resources>
-            <Style TargetType="Panel" x:Key="AnimateOnVisibilityChanged">
-               <Setter Property="HorizontalAlignment" Value="Right"/>
-               <Setter Property="DockPanel.Dock" Value="Right"/>
-               <Setter Property="Background" Value="{DynamicResource Backlight}"/>
-               <Style.Triggers>
-                  <Trigger Property="Visibility" Value="Visible">
-                     <Trigger.EnterActions>
-                        <BeginStoryboard>
-                           <Storyboard>
-                              <ThicknessAnimation Storyboard.TargetProperty="Margin" From="0,0,40,0" To="0,0,0,0" Duration="0:0:0.2"/>
-                              <DoubleAnimation Storyboard.TargetProperty="Opacity" From="0" To="1" Duration="0:0:0.2"/>
-                           </Storyboard>
-                        </BeginStoryboard>
-                     </Trigger.EnterActions>
-                  </Trigger>
-               </Style.Triggers>
-            </Style>
-         </DockPanel.Resources>
-         <!-- Menu -->
-         <Menu DockPanel.Dock="Left">
-            <MenuItem Header="_File">
-               <MenuItem Header="_New" Command="{Binding New}" InputGestureText="Ctrl+N">
-                  <MenuItem.Icon>
-                     <Path Data="{hsv:Icon New}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
-                  </MenuItem.Icon>
-               </MenuItem>
-               <MenuItem Header="_Open" Command="{Binding Open}" InputGestureText="Ctrl+O">
-                  <MenuItem.Icon>
-                     <Path Data="{hsv:Icon Open}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
-                  </MenuItem.Icon>
-               </MenuItem>
-               <Separator />
-               <MenuItem Header="_Save" Command="{Binding Save}" InputGestureText="Ctrl+S">
-                  <MenuItem.Icon>
-                     <Path Data="{hsv:Icon Save}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
-                  </MenuItem.Icon>
-               </MenuItem>
-               <MenuItem Header="Save _As" Command="{Binding SaveAs}" InputGestureText="Ctrl+Shift+S" />
-               <MenuItem Header="Save A_ll" Command="{Binding SaveAll}" InputGestureText="Ctrl+Shift+A" />
-               <Separator />
-               <MenuItem Header="_Close Current Tab" Command="{Binding Close}" CommandParameter="{DynamicResource FileSystem}" InputGestureText="Ctrl+W" />
-               <MenuItem Header="E_xit" Click="ExitClicked" InputGestureText="Alt+F4">
-                  <MenuItem.Icon>
-                     <Path Data="{hsv:Icon Exit}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
-                  </MenuItem.Icon>
-               </MenuItem>
-            </MenuItem>
-            <MenuItem Header="_Edit">
-               <MenuItem Header="_Undo" Command="{Binding Undo}" InputGestureText="Ctrl+Z">
-                  <MenuItem.Icon>
-                     <Path Data="{hsv:Icon UndoArrow}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
-                  </MenuItem.Icon>
-               </MenuItem>
-               <MenuItem Header="_Redo" Command="{Binding Redo}" InputGestureText="Ctrl+Y">
-                  <MenuItem.Icon>
-                     <Path Data="{hsv:Icon RedoArrow}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
-                  </MenuItem.Icon>
-               </MenuItem>
-               <Separator />
-               <MenuItem Header="Cu_t" Command="{Binding Cut}" InputGestureText="Ctrl+X"/>
-               <MenuItem Header="_Copy" Command="{Binding Copy}" InputGestureText="Ctrl+C"/>
-               <MenuItem Header="_Paste / Replace" Command="{Binding Paste}" InputGestureText="Ctrl+V"/>
-               <MenuItem Header="_Delete" Command="{Binding Delete}" InputGestureText="Del"/>
-               <Separator />
-               <MenuItem Header="_Find" Command="{Binding ShowFind}" InputGestureText="Ctrl+F">
-                  <MenuItem.CommandParameter>
-                     <sys:Boolean>true</sys:Boolean>
-                  </MenuItem.CommandParameter>
-               </MenuItem>
-               <MenuItem Header="Find _Next" Command="{Binding FindNext}" CommandParameter="{Binding Text, ElementName=FindBox}" InputGestureText="F3"/>
-               <MenuItem Header="Find _Previous" Command="{Binding FindPrevious}" CommandParameter="{Binding Text, ElementName=FindBox}" InputGestureText="Shift+F3"/>
-               <MenuItem Header="_Goto" Command="{Binding GotoViewModel.ShowGoto}" InputGestureText="Ctrl+G">
-                  <MenuItem.CommandParameter>
-                     <sys:Boolean>true</sys:Boolean>
-                  </MenuItem.CommandParameter>
-               </MenuItem>
-               <MenuItem Header="Go _Back" Command="{Binding Back}" InputGestureText="Ctrl+-"/>
-               <MenuItem Header="Go _Forward" Command="{Binding Forward}" InputGestureText="Ctrl+Shift+-"/>
-            </MenuItem>
-            <MenuItem Header="_View">
-               <MenuItem Header="_Toggle Theme" Click="ToggleTheme" InputGestureText="Ctrl+T"/>
-               <MenuItem Header="Toggle _Matrix Grid" Command="{Binding ToggleMatrix}" InputGestureText="Ctrl+M"/>
-               <MenuItem Header="Toggle Custom _Headers" Command="{Binding ToggleTableHeaders}" InputGestureText="Ctrl+H" ToolTipService.ShowDuration="15000">
-                  <MenuItem.ToolTip>
-                     <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{solarized:Theme Blue}" BorderThickness="1">
-                        <TextBlock TextAlignment="Left">
-                           <Bold>Table Headers</Bold> <LineBreak/>
-                           Tables with data can show entry names instead of addresses. <LineBreak/>
-                           By default, tables will show the names of entries when possible. <LineBreak/>
-                           Toggling this will cause the table to show address of entries instead.
-                        </TextBlock>
-                     </ToolTip>
-                  </MenuItem.ToolTip>
-               </MenuItem>
-               <MenuItem Header="_Clear Error" Command="{Binding ClearError}" InputGestureText="Esc"/>
-            </MenuItem>
-            <MenuItem Header="_Tools">
-               <MenuItem Header="_Hide All Tools" Command="{Binding Tools.HideCommand}"/>
-               <Separator/>
-               <MenuItem Header="Toggle _Text Tool" Command="{Binding Tools.StringToolCommand}"/>
-               <MenuItem Header="Toggle T_able Tool" Command="{Binding Tools.TableToolCommand}"/>
-               <MenuItem Header="Toggle _Extra Tool" Command="{Binding Tools.Tool3Command}"/>
-            </MenuItem>
-            <MenuItem Header="_Help">
-               <MenuItem Header="_Wiki" Click="WikiClick"/>
-               <MenuItem Header="_Report an Issue" Click="ReportIssueClick"/>
-               <MenuItem Header="_About" Click="AboutClick"/>
-            </MenuItem>
-         </Menu>
-         <!-- Goto -->
-         <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" Visibility="{Binding GotoViewModel.ControlVisible, Converter={StaticResource BoolToVisibility}}">
-            <TextBlock Text="Goto :" Margin="10,0" />
-            <TextBox Name="GotoBox" Text="{Binding GotoViewModel.Text, UpdateSourceTrigger=PropertyChanged}" MinWidth="200" IsVisibleChanged="EditBoxVisibilityChanged">
-               <TextBox.InputBindings>
-                  <KeyBinding Key="Esc" Command="{Binding GotoViewModel.ShowGoto}">
-                     <KeyBinding.CommandParameter>
-                        <sys:Boolean>false</sys:Boolean>
-                     </KeyBinding.CommandParameter>
-                  </KeyBinding>
-                  <KeyBinding Key="Up" Command="{Binding GotoViewModel.MoveAutoCompleteSelectionUp}"/>
-                  <KeyBinding Key="Down" Command="{Binding GotoViewModel.MoveAutoCompleteSelectionDown}"/>
-                  <KeyBinding Key="Return" Command="{Binding GotoViewModel.Goto}"/>
-               </TextBox.InputBindings>
-            </TextBox>
-            <Popup IsOpen="{Binding GotoViewModel.ShowAutoCompleteOptions}" PlacementTarget="{Binding ElementName=GotoBox}">
-               <ItemsControl ItemsSource="{Binding GotoViewModel.AutoCompleteOptions}" Background="{DynamicResource Backlight}">
-                  <ItemsControl.ItemTemplate>
-                     <DataTemplate>
-                        <Button Content="{Binding CompletionText}" Command="{Binding ElementName=GotoBox, Path=DataContext.GotoViewModel.Goto}" CommandParameter="{Binding CompletionText}">
-                           <Button.Style>
-                              <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
-                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
-                                       <Setter Property="BorderBrush" Value="{solarized:Theme Blue}"/>
-                                    </DataTrigger>
-                                 </Style.Triggers>
-                              </Style>
-                           </Button.Style>
-                        </Button>
-                     </DataTemplate>
-                  </ItemsControl.ItemTemplate>
-               </ItemsControl>
-            </Popup>
-         </StackPanel>
-         <!-- Find -->
-         <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" Visibility="{Binding FindControlVisible, Converter={StaticResource BoolToVisibility}}">
-            <TextBlock Text="Find :" Margin="10,0" />
-            <TextBox Name="FindBox" MinWidth="200" IsVisibleChanged="EditBoxVisibilityChanged">
-               <TextBox.InputBindings>
-                  <KeyBinding Key="Esc" Command="{Binding ShowFind}">
-                     <KeyBinding.CommandParameter>
-                        <sys:Boolean>false</sys:Boolean>
-                     </KeyBinding.CommandParameter>
-                  </KeyBinding>
-                  <KeyBinding Key="Return" Command="{Binding Find}" CommandParameter="{Binding Text, ElementName=FindBox}"/>
-               </TextBox.InputBindings>
-            </TextBox>
-         </StackPanel>
-         <!-- Message -->
-         <StackPanel Visibility="{Binding ShowMessage, Converter={StaticResource BoolToVisibility}}" Style="{StaticResource AnimateOnVisibilityChanged}" Orientation="Horizontal">
-            <TextBlock Margin="10,0" VerticalAlignment="Center" Text="{Binding InformationMessage}" Foreground="{solarized:Theme Primary}"/>
-            <Button Command="{Binding ClearMessage}" Width="15">
-               <Path Data="{hsv:Icon Exit}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
-            </Button>
-         </StackPanel>
-         <!-- Error -->
-         <Grid Visibility="{Binding ShowError, Converter={StaticResource BoolToVisibility}}" Style="{StaticResource AnimateOnVisibilityChanged}">
-            <Grid.ColumnDefinitions>
-               <ColumnDefinition/>
-               <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-            <Grid.InputBindings>
-               <MouseBinding MouseAction="MiddleClick" Command="{Binding ClearError}"/>
-            </Grid.InputBindings>
-            <TextBlock Margin="10,0" VerticalAlignment="Center" Text="{Binding ErrorMessage}" TextWrapping="Wrap" TextAlignment="Right" Foreground="{solarized:Theme Red}"/>
-            <Button Command="{Binding ClearError}" Width="15" Grid.Column="1">
-               <Path Data="{hsv:Icon Exit}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
-            </Button>
-         </Grid>
-      </DockPanel>
-      <Grid>
-         <hsg3hv:StartScreen>
-            <hsg3hv:StartScreen.Style>
-               <Style TargetType="FrameworkElement">
-                  <Setter Property="Visibility" Value="Collapsed"/>
-                  <Style.Triggers>
-                     <DataTrigger Binding="{Binding ElementName=Tabs, Path=SelectedIndex}" Value="-1">
-                        <Setter Property="Visibility" Value="Visible"/>
-                     </DataTrigger>
-                  </Style.Triggers>
-               </Style>
-            </hsg3hv:StartScreen.Style>
-         </hsg3hv:StartScreen>
-         <TabControl Name="Tabs" ItemsSource="{Binding}" SelectedIndex="{Binding SelectedIndex}">
-            <TabControl.Style>
-               <Style TargetType="TabControl" BasedOn="{StaticResource {x:Type TabControl}}">
-                  <Style.Triggers>
-                     <Trigger Property="SelectedIndex" Value="-1">
-                        <Setter Property="Visibility" Value="Collapsed"/>
+   <Grid>
+      <DockPanel>
+         <DockPanel DockPanel.Dock="Top" Background="{DynamicResource Background}">
+            <DockPanel.Resources>
+               <Style TargetType="Panel" x:Key="AnimateOnVisibilityChanged">
+                  <Setter Property="HorizontalAlignment" Value="Right"/>
+                  <Setter Property="DockPanel.Dock" Value="Right"/>
+                  <Setter Property="Background" Value="{DynamicResource Backlight}"/>
+                  <!--<Style.Triggers>
+                     <Trigger Property="Visibility" Value="Visible">
+                        <Trigger.EnterActions>
+                           <BeginStoryboard>
+                              <Storyboard>
+                                 <ThicknessAnimation Storyboard.TargetProperty="Margin" From="0,0,40,0" To="0,0,0,0" Duration="0:0:0.2"/>
+                                 <DoubleAnimation Storyboard.TargetProperty="Opacity" From="0" To="1" Duration="0:0:0.2"/>
+                              </Storyboard>
+                           </BeginStoryboard>
+                        </Trigger.EnterActions>
                      </Trigger>
-                  </Style.Triggers>
+                  </Style.Triggers>-->
                </Style>
-            </TabControl.Style>
-            <TabControl.InputBindings>
-               <KeyBinding Key="Esc" Command="{Binding HideSearchControls}"/>
-            </TabControl.InputBindings>
-            <TabControl.ItemTemplate>
-               <DataTemplate>
-                  <StackPanel Orientation="Horizontal">
-                     <TextBlock Name="TabTextBlock" Background="Transparent" Text="{Binding Name}" Foreground="{DynamicResource Primary}" MouseDown="TabMouseDown" MouseMove="TabMouseMove" MouseUp="TabMouseUp">
-                        <TextBlock.InputBindings>
-                           <MouseBinding MouseAction="MiddleClick" Command="{Binding Close}" CommandParameter="{DynamicResource FileSystem}"/>
-                        </TextBlock.InputBindings>
-                     </TextBlock>
-                     <Button Command="{Binding Close}" CommandParameter="{DynamicResource FileSystem}" Width="15" Margin="5,0,0,0" VerticalAlignment="Stretch" Background="{DynamicResource Background}" BorderBrush="{DynamicResource Background}">
+            </DockPanel.Resources>
+            <!-- Menu -->
+            <Menu DockPanel.Dock="Left">
+               <MenuItem Header="_File">
+                  <MenuItem Header="_New" Command="{Binding New}" InputGestureText="Ctrl+N">
+                     <MenuItem.Icon>
+                        <Path Data="{hsv:Icon New}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
+                     </MenuItem.Icon>
+                  </MenuItem>
+                  <MenuItem Header="_Open" Command="{Binding Open}" InputGestureText="Ctrl+O">
+                     <MenuItem.Icon>
+                        <Path Data="{hsv:Icon Open}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
+                     </MenuItem.Icon>
+                  </MenuItem>
+                  <Separator />
+                  <MenuItem Header="_Save" Command="{Binding Save}" InputGestureText="Ctrl+S">
+                     <MenuItem.Icon>
+                        <Path Data="{hsv:Icon Save}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
+                     </MenuItem.Icon>
+                  </MenuItem>
+                  <MenuItem Header="Save _As" Command="{Binding SaveAs}" InputGestureText="Ctrl+Shift+S" />
+                  <MenuItem Header="Save A_ll" Command="{Binding SaveAll}" InputGestureText="Ctrl+Shift+A" />
+                  <Separator />
+                  <MenuItem Header="_Close Current Tab" Command="{Binding Close}" CommandParameter="{DynamicResource FileSystem}" InputGestureText="Ctrl+W" />
+                  <MenuItem Header="E_xit" Click="ExitClicked" InputGestureText="Alt+F4">
+                     <MenuItem.Icon>
                         <Path Data="{hsv:Icon Exit}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
-                     </Button>
-                  </StackPanel>
-               </DataTemplate>
-            </TabControl.ItemTemplate>
-            <TabControl.ContentTemplate>
-               <DataTemplate>
-                  <DockPanel>
-                     <!-- Bottom Bar -->
-                     <TextBlock DockPanel.Dock="Bottom" Text="{Binding SelectedAddress}"/>
-                     <!-- Tool Headers -->
-                     <StackPanel DockPanel.Dock="Left" Visibility="{Binding HasTools, Converter={StaticResource BoolToVisibility}}">
-                        <Button Content="Text" Command="{Binding Tools.StringToolCommand}" Margin="0,2">
-                           <Button.LayoutTransform>
-                              <RotateTransform Angle="-90"/>
-                           </Button.LayoutTransform>
-                           <Button.Style>
-                              <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
-                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Tools.SelectedIndex}" Value="0">
-                                       <Setter Property="BorderBrush" Value="{solarized:Theme Blue}"/>
-                                    </DataTrigger>
-                                 </Style.Triggers>
-                              </Style>
-                           </Button.Style>
-                        </Button>
-                        <Button Content="Table" Command="{Binding Tools.TableToolCommand}" Margin="0,2">
-                           <Button.LayoutTransform>
-                              <RotateTransform Angle="-90"/>
-                           </Button.LayoutTransform>
-                           <Button.Style>
-                              <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
-                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Tools.SelectedIndex}" Value="1">
-                                       <Setter Property="BorderBrush" Value="{solarized:Theme Blue}"/>
-                                    </DataTrigger>
-                                 </Style.Triggers>
-                              </Style>
-                           </Button.Style>
-                        </Button>
-                        <Button Content="Tool3" Command="{Binding Tools.Tool3Command}" Margin="0,2">
-                           <Button.LayoutTransform>
-                              <RotateTransform Angle="-90"/>
-                           </Button.LayoutTransform>
-                           <Button.Style>
-                              <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
-                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Tools.SelectedIndex}" Value="2">
-                                       <Setter Property="BorderBrush" Value="{solarized:Theme Blue}"/>
-                                    </DataTrigger>
-                                 </Style.Triggers>
-                              </Style>
-                           </Button.Style>
+                     </MenuItem.Icon>
+                  </MenuItem>
+               </MenuItem>
+               <MenuItem Header="_Edit">
+                  <MenuItem Header="_Undo" Command="{Binding Undo}" InputGestureText="Ctrl+Z">
+                     <MenuItem.Icon>
+                        <Path Data="{hsv:Icon UndoArrow}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
+                     </MenuItem.Icon>
+                  </MenuItem>
+                  <MenuItem Header="_Redo" Command="{Binding Redo}" InputGestureText="Ctrl+Y">
+                     <MenuItem.Icon>
+                        <Path Data="{hsv:Icon RedoArrow}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
+                     </MenuItem.Icon>
+                  </MenuItem>
+                  <Separator />
+                  <MenuItem Header="Cu_t" Command="{Binding Cut}" InputGestureText="Ctrl+X"/>
+                  <MenuItem Header="_Copy" Command="{Binding Copy}" InputGestureText="Ctrl+C"/>
+                  <MenuItem Header="_Paste / Replace" Command="{Binding Paste}" InputGestureText="Ctrl+V"/>
+                  <MenuItem Header="_Delete" Command="{Binding Delete}" InputGestureText="Del"/>
+                  <Separator />
+                  <MenuItem Header="_Find" Command="{Binding ShowFind}" InputGestureText="Ctrl+F">
+                     <MenuItem.CommandParameter>
+                        <sys:Boolean>true</sys:Boolean>
+                     </MenuItem.CommandParameter>
+                  </MenuItem>
+                  <MenuItem Header="Find _Next" Command="{Binding FindNext}" CommandParameter="{Binding Text, ElementName=FindBox}" InputGestureText="F3"/>
+                  <MenuItem Header="Find _Previous" Command="{Binding FindPrevious}" CommandParameter="{Binding Text, ElementName=FindBox}" InputGestureText="Shift+F3"/>
+                  <MenuItem Header="_Goto" Command="{Binding GotoViewModel.ShowGoto}" InputGestureText="Ctrl+G">
+                     <MenuItem.CommandParameter>
+                        <sys:Boolean>true</sys:Boolean>
+                     </MenuItem.CommandParameter>
+                  </MenuItem>
+                  <MenuItem Header="Go _Back" Command="{Binding Back}" InputGestureText="Ctrl+-"/>
+                  <MenuItem Header="Go _Forward" Command="{Binding Forward}" InputGestureText="Ctrl+Shift+-"/>
+               </MenuItem>
+               <MenuItem Header="_View">
+                  <MenuItem Header="_Toggle Theme" Click="ToggleTheme" InputGestureText="Ctrl+T"/>
+                  <MenuItem Header="Toggle _Matrix Grid" Command="{Binding ToggleMatrix}" InputGestureText="Ctrl+M"/>
+                  <MenuItem Header="Toggle Custom _Headers" Command="{Binding ToggleTableHeaders}" InputGestureText="Ctrl+H" ToolTipService.ShowDuration="15000">
+                     <MenuItem.ToolTip>
+                        <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{solarized:Theme Blue}" BorderThickness="1">
+                           <TextBlock TextAlignment="Left">
+                              <Bold>Table Headers</Bold> <LineBreak/>
+                              Tables with data can show entry names instead of addresses. <LineBreak/>
+                              By default, tables will show the names of entries when possible. <LineBreak/>
+                              Toggling this will cause the table to show address of entries instead.
+                           </TextBlock>
+                        </ToolTip>
+                     </MenuItem.ToolTip>
+                  </MenuItem>
+                  <MenuItem Header="_Clear Error" Command="{Binding ClearError}" InputGestureText="Esc"/>
+               </MenuItem>
+               <MenuItem Header="_Tools">
+                  <MenuItem Header="_Hide All Tools" Command="{Binding Tools.HideCommand}"/>
+                  <Separator/>
+                  <MenuItem Header="Toggle _Text Tool" Command="{Binding Tools.StringToolCommand}"/>
+                  <MenuItem Header="Toggle T_able Tool" Command="{Binding Tools.TableToolCommand}"/>
+                  <MenuItem Header="Toggle _Extra Tool" Command="{Binding Tools.Tool3Command}"/>
+               </MenuItem>
+               <MenuItem Header="_Help">
+                  <MenuItem Header="_Wiki" Click="WikiClick"/>
+                  <MenuItem Header="_Report an Issue" Click="ReportIssueClick"/>
+                  <MenuItem Header="_About" Click="AboutClick"/>
+               </MenuItem>
+            </Menu>
+            <!-- Goto -->
+            <StackPanel Name="GotoPanel" Orientation="Horizontal" DockPanel.Dock="Right" Visibility="{Binding GotoViewModel.ControlVisible, Converter={StaticResource BoolToVisibility}}">
+               <TextBlock Text="Goto :" Margin="10,0" />
+               <TextBox Name="GotoBox" Text="{Binding GotoViewModel.Text, UpdateSourceTrigger=PropertyChanged}" MinWidth="200" IsVisibleChanged="EditBoxVisibilityChanged">
+                  <TextBox.InputBindings>
+                     <KeyBinding Key="Esc" Command="{Binding GotoViewModel.ShowGoto}">
+                        <KeyBinding.CommandParameter>
+                           <sys:Boolean>false</sys:Boolean>
+                        </KeyBinding.CommandParameter>
+                     </KeyBinding>
+                     <KeyBinding Key="Up" Command="{Binding GotoViewModel.MoveAutoCompleteSelectionUp}"/>
+                     <KeyBinding Key="Down" Command="{Binding GotoViewModel.MoveAutoCompleteSelectionDown}"/>
+                     <KeyBinding Key="Return" Command="{Binding GotoViewModel.Goto}"/>
+                  </TextBox.InputBindings>
+               </TextBox>
+               <Popup IsOpen="{Binding GotoViewModel.ShowAutoCompleteOptions}" PlacementTarget="{Binding ElementName=GotoBox}">
+                  <ItemsControl ItemsSource="{Binding GotoViewModel.AutoCompleteOptions}" Background="{DynamicResource Backlight}">
+                     <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                           <Button Content="{Binding CompletionText}" Command="{Binding ElementName=GotoBox, Path=DataContext.GotoViewModel.Goto}" CommandParameter="{Binding CompletionText}">
+                              <Button.Style>
+                                 <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                                    <Style.Triggers>
+                                       <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                          <Setter Property="BorderBrush" Value="{solarized:Theme Blue}"/>
+                                       </DataTrigger>
+                                    </Style.Triggers>
+                                 </Style>
+                              </Button.Style>
+                           </Button>
+                        </DataTemplate>
+                     </ItemsControl.ItemTemplate>
+                  </ItemsControl>
+               </Popup>
+            </StackPanel>
+            <!-- Find -->
+            <StackPanel Name="FindPanel" Orientation="Horizontal" DockPanel.Dock="Right" Visibility="{Binding FindControlVisible, Converter={StaticResource BoolToVisibility}}">
+               <TextBlock Text="Find :" Margin="10,0" />
+               <TextBox Name="FindBox" MinWidth="200" IsVisibleChanged="EditBoxVisibilityChanged">
+                  <TextBox.InputBindings>
+                     <KeyBinding Key="Esc" Command="{Binding ShowFind}">
+                        <KeyBinding.CommandParameter>
+                           <sys:Boolean>false</sys:Boolean>
+                        </KeyBinding.CommandParameter>
+                     </KeyBinding>
+                     <KeyBinding Key="Return" Command="{Binding Find}" CommandParameter="{Binding Text, ElementName=FindBox}"/>
+                  </TextBox.InputBindings>
+               </TextBox>
+            </StackPanel>
+            <!-- Message -->
+            <StackPanel Name="MessagePanel" Visibility="{Binding ShowMessage, Converter={StaticResource BoolToVisibility}}" Style="{StaticResource AnimateOnVisibilityChanged}" Orientation="Horizontal">
+               <TextBlock Margin="10,0" VerticalAlignment="Center" Text="{Binding InformationMessage}" Foreground="{solarized:Theme Primary}"/>
+               <Button Command="{Binding ClearMessage}" Width="15">
+                  <Path Data="{hsv:Icon Exit}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
+               </Button>
+            </StackPanel>
+            <!-- Error -->
+            <Grid Name="ErrorPanel" Visibility="{Binding ShowError, Converter={StaticResource BoolToVisibility}}" Style="{StaticResource AnimateOnVisibilityChanged}">
+               <Grid.ColumnDefinitions>
+                  <ColumnDefinition/>
+                  <ColumnDefinition Width="Auto"/>
+               </Grid.ColumnDefinitions>
+               <Grid.InputBindings>
+                  <MouseBinding MouseAction="MiddleClick" Command="{Binding ClearError}"/>
+               </Grid.InputBindings>
+               <TextBlock Margin="10,0" VerticalAlignment="Center" Text="{Binding ErrorMessage}" TextWrapping="Wrap" TextAlignment="Right" Foreground="{solarized:Theme Red}"/>
+               <Button Command="{Binding ClearError}" Width="15" Grid.Column="1">
+                  <Path Data="{hsv:Icon Exit}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
+               </Button>
+            </Grid>
+         </DockPanel>
+         <Grid>
+            <hsg3hv:StartScreen>
+               <hsg3hv:StartScreen.Style>
+                  <Style TargetType="FrameworkElement">
+                     <Setter Property="Visibility" Value="Collapsed"/>
+                     <Style.Triggers>
+                        <DataTrigger Binding="{Binding ElementName=Tabs, Path=SelectedIndex}" Value="-1">
+                           <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                     </Style.Triggers>
+                  </Style>
+               </hsg3hv:StartScreen.Style>
+            </hsg3hv:StartScreen>
+            <TabControl Name="Tabs" ItemsSource="{Binding}" SelectedIndex="{Binding SelectedIndex}">
+               <TabControl.Style>
+                  <Style TargetType="TabControl" BasedOn="{StaticResource {x:Type TabControl}}">
+                     <Style.Triggers>
+                        <Trigger Property="SelectedIndex" Value="-1">
+                           <Setter Property="Visibility" Value="Collapsed"/>
+                        </Trigger>
+                     </Style.Triggers>
+                  </Style>
+               </TabControl.Style>
+               <TabControl.InputBindings>
+                  <KeyBinding Key="Esc" Command="{Binding HideSearchControls}"/>
+               </TabControl.InputBindings>
+               <TabControl.ItemTemplate>
+                  <DataTemplate>
+                     <StackPanel Orientation="Horizontal">
+                        <TextBlock Name="TabTextBlock" Background="Transparent" Text="{Binding Name}" Foreground="{DynamicResource Primary}" MouseDown="TabMouseDown" MouseMove="TabMouseMove" MouseUp="TabMouseUp">
+                           <TextBlock.InputBindings>
+                              <MouseBinding MouseAction="MiddleClick" Command="{Binding Close}" CommandParameter="{DynamicResource FileSystem}"/>
+                           </TextBlock.InputBindings>
+                        </TextBlock>
+                        <Button Command="{Binding Close}" CommandParameter="{DynamicResource FileSystem}" Width="15" Margin="5,0,0,0" VerticalAlignment="Stretch" Background="{DynamicResource Background}" BorderBrush="{DynamicResource Background}">
+                           <Path Data="{hsv:Icon Exit}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
                         </Button>
                      </StackPanel>
-                     <!-- Tools -->
-                     <Grid DockPanel.Dock="Left" DataContext="{Binding Tools}">
-                        <Grid.Style>
-                           <Style TargetType="Grid">
-                              <Style.Triggers>
-                                 <DataTrigger Binding="{Binding SelectedIndex}" Value="-1">
-                                    <Setter Property="Visibility" Value="Collapsed"/>
-                                 </DataTrigger>
-                              </Style.Triggers>
-                           </Style>
-                        </Grid.Style>
-                        <DockPanel Name="StringToolPanel">
-                           <DockPanel.Style>
-                              <Style TargetType="DockPanel">
-                                 <Setter Property="Visibility" Value="Collapsed"/>
-                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding SelectedIndex}" Value="0">
-                                       <Setter Property="Visibility" Value="Visible"/>
-                                    </DataTrigger>
-                                 </Style.Triggers>
-                              </Style>
-                           </DockPanel.Style>
-                           <TextBlock Text="Address:" Margin="5,15,0,0" DockPanel.Dock="Top"/>
-                           <TextBox Text="{Binding StringTool.Address, Converter={StaticResource Hex}}" Margin="5" DockPanel.Dock="Top"/>
-                           <TextBlock Text="Content:" Margin="5,30,0,0" DockPanel.Dock="Top"/>
-                           <TextBox Margin="5,5" AcceptsReturn="True" MinHeight="50" Width="255" TextWrapping="Wrap" FontFamily="Consolas" VerticalScrollBarVisibility="Auto"
-                              SelectionChanged="StringToolContentSelectionChanged"
-                              IsEnabled="{Binding StringTool.Enabled}"
-                              Text="{Binding StringTool.Content, UpdateSourceTrigger=PropertyChanged}" />
-                        </DockPanel>
-                        <ScrollViewer Width="265" Name="TableToolPanel" VerticalScrollBarVisibility="Visible">
-                           <ScrollViewer.Style>
-                              <Style TargetType="ScrollViewer">
-                                 <Setter Property="Visibility" Value="Collapsed"/>
-                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding SelectedIndex}" Value="1">
-                                       <Setter Property="Visibility" Value="Visible"/>
-                                    </DataTrigger>
-                                 </Style.Triggers>
-                              </Style>
-                           </ScrollViewer.Style>
-                           <StackPanel>
-                              <TextBlock Text="{Binding TableTool.CurrentElementName}" HorizontalAlignment="Center" Margin="0,2" MaxWidth="200" TextWrapping="Wrap" TextAlignment="Center"/>
-                              <Grid>
-                                 <Button Margin="5" Content="Previous" Command="{Binding TableTool.Previous}" HorizontalAlignment="Left"/>
-                                 <Button Margin="5" Content="Next" Command="{Binding TableTool.Next}" HorizontalAlignment="Right"/>
-                              </Grid>
-                              <ItemsControl ItemsSource="{Binding TableTool.Children}" Grid.IsSharedSizeScope="True">
-                                 <ItemsControl.Resources>
-                                    <DataTemplate DataType="{x:Type hsg3hvmtr:FieldArrayElementViewModel}">
-                                       <Grid HorizontalAlignment="Stretch" Margin="2">
-                                          <Grid.ColumnDefinitions>
-                                             <ColumnDefinition Width="Auto" SharedSizeGroup="LeftColumn"/>
-                                             <ColumnDefinition Width="*"/>
-                                          </Grid.ColumnDefinitions>
-                                          <TextBlock Text="{Binding Name}" Margin="5,0" Grid.Column="0"/>
-                                          <TextBox Text="{Binding Content, UpdateSourceTrigger=PropertyChanged}" Grid.Column="1"/>
-                                       </Grid>
-                                    </DataTemplate>
-                                    <DataTemplate DataType="{x:Type hsg3hvmtr:ComboBoxArrayElementViewModel}">
-                                       <Grid HorizontalAlignment="Stretch" Margin="2">
-                                          <Grid.ColumnDefinitions>
-                                             <ColumnDefinition Width="Auto" SharedSizeGroup="LeftColumn"/>
-                                             <ColumnDefinition Width="*"/>
-                                          </Grid.ColumnDefinitions>
-                                          <TextBlock Text="{Binding Name}" Margin="5,0" Grid.Column="0"/>
-                                          <ComboBox SelectedIndex="{Binding SelectedIndex}" ItemsSource="{Binding Options}" Grid.Column="1"/>
-                                       </Grid>
-                                    </DataTemplate>
-                                 </ItemsControl.Resources>
-                              </ItemsControl>
-                           </StackPanel>
-                        </ScrollViewer>
-                        <StackPanel Name="Tool3Panel">
-                           <StackPanel.Style>
-                              <Style TargetType="StackPanel">
-                                 <Setter Property="Visibility" Value="Collapsed"/>
-                                 <Style.Triggers>
-                                    <DataTrigger Binding="{Binding SelectedIndex}" Value="2">
-                                       <Setter Property="Visibility" Value="Visible"/>
-                                    </DataTrigger>
-                                 </Style.Triggers>
-                              </Style>
-                           </StackPanel.Style>
-                           <TextBlock Text="Coming Soon!" Margin="5,15,0,0"/>
+                  </DataTemplate>
+               </TabControl.ItemTemplate>
+               <TabControl.ContentTemplate>
+                  <DataTemplate>
+                     <DockPanel>
+                        <!-- Bottom Bar -->
+                        <TextBlock DockPanel.Dock="Bottom" Text="{Binding SelectedAddress}"/>
+                        <!-- Tool Headers -->
+                        <StackPanel DockPanel.Dock="Left" Visibility="{Binding HasTools, Converter={StaticResource BoolToVisibility}}">
+                           <Button Content="Text" Command="{Binding Tools.StringToolCommand}" Margin="0,2">
+                              <Button.LayoutTransform>
+                                 <RotateTransform Angle="-90"/>
+                              </Button.LayoutTransform>
+                              <Button.Style>
+                                 <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                                    <Style.Triggers>
+                                       <DataTrigger Binding="{Binding Tools.SelectedIndex}" Value="0">
+                                          <Setter Property="BorderBrush" Value="{solarized:Theme Blue}"/>
+                                       </DataTrigger>
+                                    </Style.Triggers>
+                                 </Style>
+                              </Button.Style>
+                           </Button>
+                           <Button Content="Table" Command="{Binding Tools.TableToolCommand}" Margin="0,2">
+                              <Button.LayoutTransform>
+                                 <RotateTransform Angle="-90"/>
+                              </Button.LayoutTransform>
+                              <Button.Style>
+                                 <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                                    <Style.Triggers>
+                                       <DataTrigger Binding="{Binding Tools.SelectedIndex}" Value="1">
+                                          <Setter Property="BorderBrush" Value="{solarized:Theme Blue}"/>
+                                       </DataTrigger>
+                                    </Style.Triggers>
+                                 </Style>
+                              </Button.Style>
+                           </Button>
+                           <Button Content="Tool3" Command="{Binding Tools.Tool3Command}" Margin="0,2">
+                              <Button.LayoutTransform>
+                                 <RotateTransform Angle="-90"/>
+                              </Button.LayoutTransform>
+                              <Button.Style>
+                                 <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                                    <Style.Triggers>
+                                       <DataTrigger Binding="{Binding Tools.SelectedIndex}" Value="2">
+                                          <Setter Property="BorderBrush" Value="{solarized:Theme Blue}"/>
+                                       </DataTrigger>
+                                    </Style.Triggers>
+                                 </Style>
+                              </Button.Style>
+                           </Button>
                         </StackPanel>
-                     </Grid>
-                     <!-- Anchor Editor -->
-                     <Border DockPanel.Dock="Top" Height="19" BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Backlight}">
-                        <DockPanel Visibility="{Binding AnchorTextVisible, Converter={StaticResource BoolToVisibility}}" >
-                           <TextBlock Width="70" Text="Anchor: " TextAlignment="Right" ToolTipService.ShowDuration="15000">
-                              <TextBlock.ToolTip>
-                                 <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{solarized:Theme Blue}" BorderThickness="1">
-                                    <TextBlock TextAlignment="Left">
-                                       <Bold>Anchor Editor</Bold> <LineBreak/>
-                                       Anchors can have a name and a format. <LineBreak/>
-                                       <LineBreak/>
-                                       Named anchors persist between sessions. <LineBreak/>
-                                       You can also use names in pointers and with Goto <Italic Foreground="{DynamicResource Secondary}">(Ctrl+G)</Italic>. <LineBreak/>
-                                       <LineBreak/>
-                                       Formats change how the data is displayed and edited. <LineBreak/>
-                                       For example, "" formats data as text. <LineBreak/>
-                                       To learn more about formats, visit the Wiki.
-                                    </TextBlock>
-                                 </ToolTip>
-                              </TextBlock.ToolTip>
-                           </TextBlock>
-                           <TextBox Text="{Binding AnchorText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,25,0"/>
-                        </DockPanel>
-                     </Border>
-                     <!-- Column Headers -->
-                     <hsg3hv:HorizontalSlantedTextControl DockPanel.Dock="Top" HeaderRows="{Binding ColumnHeaders}" ColumnWidth="{x:Static hsg3hv:HexContent.CellWidth}" HorizontalOffset="{Binding ElementName=HexContent, Path=HorizontalScrollValue}"/>
-                     <!-- Row Headers -->
-                     <ItemsControl DockPanel.Dock="Left" Width="70" ItemsSource="{Binding Headers}" Background="{DynamicResource Backlight}" MouseDown="HeaderMouseDown">
-                        <ItemsControl.ItemTemplate>
-                           <DataTemplate>
-                              <Viewbox Height="{x:Static hsg3hv:HexContent.CellHeight}" HorizontalAlignment="Right" Margin="0,0,2,0">
-                                 <TextBlock Foreground="{DynamicResource Secondary}" Text="{Binding}" FontFamily="Consolas" Padding="1"/>
-                              </Viewbox>
-                           </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                     </ItemsControl>
-                     <Line Width="1" DockPanel.Dock="Left" Stroke="{DynamicResource Background}"/>
-                     <ScrollBar DockPanel.Dock="Right"
-                        Minimum="{Binding MinimumScroll}" Maximum="{Binding MaximumScroll}" Value="{Binding ScrollValue}"
-                        SmallChange="1" LargeChange="{Binding Height}" />
-                     <ScrollBar DockPanel.Dock="Bottom" Orientation="Horizontal" SmallChange="10" LargeChange="{x:Static hsg3hv:HexContent.CellWidth}"
-                        Minimum="0" Maximum="{Binding HorizontalScrollMaximum, ElementName=HexContent}" Value="{Binding HorizontalScrollValue, ElementName=HexContent}"
-                        Visibility="{Binding ShowHorizontalScroll, ElementName=HexContent, Converter={StaticResource BoolToVisibility}}" />
-                     <hsg3hv:HexContent x:Name="HexContent" ViewPort="{Binding}" ShowGrid="{Binding DataContext.ShowMatrix, RelativeSource={RelativeSource AncestorType=hsg3ww:MainWindow}}" Margin=".5,.5,0,0"/>
-                  </DockPanel>
-               </DataTemplate>
-            </TabControl.ContentTemplate>
-         </TabControl>
-      </Grid>
-   </DockPanel>
+                        <!-- Tools -->
+                        <Grid DockPanel.Dock="Left" DataContext="{Binding Tools}">
+                           <Grid.Style>
+                              <Style TargetType="Grid">
+                                 <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SelectedIndex}" Value="-1">
+                                       <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                 </Style.Triggers>
+                              </Style>
+                           </Grid.Style>
+                           <DockPanel Name="StringToolPanel">
+                              <DockPanel.Style>
+                                 <Style TargetType="DockPanel">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                       <DataTrigger Binding="{Binding SelectedIndex}" Value="0">
+                                          <Setter Property="Visibility" Value="Visible"/>
+                                       </DataTrigger>
+                                    </Style.Triggers>
+                                 </Style>
+                              </DockPanel.Style>
+                              <TextBlock Text="Address:" Margin="5,15,0,0" DockPanel.Dock="Top"/>
+                              <TextBox Text="{Binding StringTool.Address, Converter={StaticResource Hex}}" Margin="5" DockPanel.Dock="Top"/>
+                              <TextBlock Text="Content:" Margin="5,30,0,0" DockPanel.Dock="Top"/>
+                              <TextBox Margin="5,5" AcceptsReturn="True" MinHeight="50" Width="255" TextWrapping="Wrap" FontFamily="Consolas" VerticalScrollBarVisibility="Auto"
+                                 SelectionChanged="StringToolContentSelectionChanged"
+                                 IsEnabled="{Binding StringTool.Enabled}"
+                                 Text="{Binding StringTool.Content, UpdateSourceTrigger=PropertyChanged}" />
+                           </DockPanel>
+                           <ScrollViewer Width="265" Name="TableToolPanel" VerticalScrollBarVisibility="Visible">
+                              <ScrollViewer.Style>
+                                 <Style TargetType="ScrollViewer">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                       <DataTrigger Binding="{Binding SelectedIndex}" Value="1">
+                                          <Setter Property="Visibility" Value="Visible"/>
+                                       </DataTrigger>
+                                    </Style.Triggers>
+                                 </Style>
+                              </ScrollViewer.Style>
+                              <StackPanel>
+                                 <TextBlock Text="{Binding TableTool.CurrentElementName}" HorizontalAlignment="Center" Margin="0,2" MaxWidth="200" TextWrapping="Wrap" TextAlignment="Center"/>
+                                 <Grid>
+                                    <Button Margin="5" Content="Previous" Command="{Binding TableTool.Previous}" HorizontalAlignment="Left"/>
+                                    <Button Margin="5" Content="Next" Command="{Binding TableTool.Next}" HorizontalAlignment="Right"/>
+                                 </Grid>
+                                 <ItemsControl ItemsSource="{Binding TableTool.Children}" Grid.IsSharedSizeScope="True">
+                                    <ItemsControl.Resources>
+                                       <DataTemplate DataType="{x:Type hsg3hvmtr:FieldArrayElementViewModel}">
+                                          <Grid HorizontalAlignment="Stretch" Margin="2">
+                                             <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" SharedSizeGroup="LeftColumn"/>
+                                                <ColumnDefinition Width="*"/>
+                                             </Grid.ColumnDefinitions>
+                                             <TextBlock Text="{Binding Name}" Margin="5,0" Grid.Column="0"/>
+                                             <TextBox Text="{Binding Content, UpdateSourceTrigger=PropertyChanged}" Grid.Column="1"/>
+                                          </Grid>
+                                       </DataTemplate>
+                                       <DataTemplate DataType="{x:Type hsg3hvmtr:ComboBoxArrayElementViewModel}">
+                                          <Grid HorizontalAlignment="Stretch" Margin="2">
+                                             <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" SharedSizeGroup="LeftColumn"/>
+                                                <ColumnDefinition Width="*"/>
+                                             </Grid.ColumnDefinitions>
+                                             <TextBlock Text="{Binding Name}" Margin="5,0" Grid.Column="0"/>
+                                             <ComboBox SelectedIndex="{Binding SelectedIndex}" ItemsSource="{Binding Options}" Grid.Column="1"/>
+                                          </Grid>
+                                       </DataTemplate>
+                                    </ItemsControl.Resources>
+                                 </ItemsControl>
+                              </StackPanel>
+                           </ScrollViewer>
+                           <StackPanel Name="Tool3Panel">
+                              <StackPanel.Style>
+                                 <Style TargetType="StackPanel">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                       <DataTrigger Binding="{Binding SelectedIndex}" Value="2">
+                                          <Setter Property="Visibility" Value="Visible"/>
+                                       </DataTrigger>
+                                    </Style.Triggers>
+                                 </Style>
+                              </StackPanel.Style>
+                              <TextBlock Text="Coming Soon!" Margin="5,15,0,0"/>
+                           </StackPanel>
+                        </Grid>
+                        <!-- Anchor Editor -->
+                        <Border DockPanel.Dock="Top" Height="19" BorderThickness="0,0,0,1" BorderBrush="{DynamicResource Backlight}">
+                           <DockPanel Visibility="{Binding AnchorTextVisible, Converter={StaticResource BoolToVisibility}}" >
+                              <TextBlock Width="70" Text="Anchor: " TextAlignment="Right" ToolTipService.ShowDuration="15000">
+                                 <TextBlock.ToolTip>
+                                    <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{solarized:Theme Blue}" BorderThickness="1">
+                                       <TextBlock TextAlignment="Left">
+                                          <Bold>Anchor Editor</Bold> <LineBreak/>
+                                          Anchors can have a name and a format. <LineBreak/>
+                                          <LineBreak/>
+                                          Named anchors persist between sessions. <LineBreak/>
+                                          You can also use names in pointers and with Goto <Italic Foreground="{DynamicResource Secondary}">(Ctrl+G)</Italic>. <LineBreak/>
+                                          <LineBreak/>
+                                          Formats change how the data is displayed and edited. <LineBreak/>
+                                          For example, "" formats data as text. <LineBreak/>
+                                          To learn more about formats, visit the Wiki.
+                                       </TextBlock>
+                                    </ToolTip>
+                                 </TextBlock.ToolTip>
+                              </TextBlock>
+                              <TextBox Text="{Binding AnchorText, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,25,0"/>
+                           </DockPanel>
+                        </Border>
+                        <!-- Column Headers -->
+                        <hsg3hv:HorizontalSlantedTextControl DockPanel.Dock="Top" HeaderRows="{Binding ColumnHeaders}" ColumnWidth="{x:Static hsg3hv:HexContent.CellWidth}" HorizontalOffset="{Binding ElementName=HexContent, Path=HorizontalScrollValue}"/>
+                        <!-- Row Headers -->
+                        <ItemsControl DockPanel.Dock="Left" Width="70" ItemsSource="{Binding Headers}" Background="{DynamicResource Backlight}" MouseDown="HeaderMouseDown">
+                           <ItemsControl.ItemTemplate>
+                              <DataTemplate>
+                                 <Viewbox Height="{x:Static hsg3hv:HexContent.CellHeight}" HorizontalAlignment="Right" Margin="0,0,2,0">
+                                    <TextBlock Foreground="{DynamicResource Secondary}" Text="{Binding}" FontFamily="Consolas" Padding="1"/>
+                                 </Viewbox>
+                              </DataTemplate>
+                           </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                        <Line Width="1" DockPanel.Dock="Left" Stroke="{DynamicResource Background}"/>
+                        <ScrollBar DockPanel.Dock="Right"
+                           Minimum="{Binding MinimumScroll}" Maximum="{Binding MaximumScroll}" Value="{Binding ScrollValue}"
+                           SmallChange="1" LargeChange="{Binding Height}" />
+                        <ScrollBar DockPanel.Dock="Bottom" Orientation="Horizontal" SmallChange="10" LargeChange="{x:Static hsg3hv:HexContent.CellWidth}"
+                           Minimum="0" Maximum="{Binding HorizontalScrollMaximum, ElementName=HexContent}" Value="{Binding HorizontalScrollValue, ElementName=HexContent}"
+                           Visibility="{Binding ShowHorizontalScroll, ElementName=HexContent, Converter={StaticResource BoolToVisibility}}" />
+                        <hsg3hv:HexContent x:Name="HexContent" ViewPort="{Binding}" ShowGrid="{Binding DataContext.ShowMatrix, RelativeSource={RelativeSource AncestorType=hsg3ww:MainWindow}}" Margin=".5,.5,0,0"/>
+                     </DockPanel>
+                  </DataTemplate>
+               </TabControl.ContentTemplate>
+            </TabControl>
+         </Grid>
+      </DockPanel>
+      <Rectangle Name="FocusAnimationElement" StrokeThickness="2" Stroke="{solarized:Theme Blue}" Visibility="Visible" HorizontalAlignment="Right" VerticalAlignment="Top"/>
+   </Grid>
 </Window>

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml
@@ -273,7 +273,8 @@
                               <MouseBinding MouseAction="MiddleClick" Command="{Binding Close}" CommandParameter="{DynamicResource FileSystem}"/>
                            </TextBlock.InputBindings>
                         </TextBlock>
-                        <Button Command="{Binding Close}" CommandParameter="{DynamicResource FileSystem}" Width="15" Margin="5,0,0,0" VerticalAlignment="Stretch" Background="{DynamicResource Background}" BorderBrush="{DynamicResource Background}">
+                        <Button Command="{Binding Close}" CommandParameter="{DynamicResource FileSystem}" Width="15" Margin="5,0,0,0" Background="{DynamicResource Background}" BorderBrush="{DynamicResource Background}"
+                           VerticalAlignment="Stretch" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch">
                            <Path Data="{hsv:Icon Exit}" Fill="{DynamicResource Secondary}" Stretch="Uniform"/>
                         </Button>
                      </StackPanel>

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml
@@ -281,6 +281,8 @@
             <TabControl.ContentTemplate>
                <DataTemplate>
                   <DockPanel>
+                     <!-- Bottom Bar -->
+                     <TextBlock DockPanel.Dock="Bottom" Text="{Binding SelectedAddress}"/>
                      <!-- Tool Headers -->
                      <StackPanel DockPanel.Dock="Left" Visibility="{Binding HasTools, Converter={StaticResource BoolToVisibility}}">
                         <Button Content="Text" Command="{Binding Tools.StringToolCommand}" Margin="0,2">

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Animation;
 
 namespace HavenSoft.HexManiac.WPF.Windows {
    partial class MainWindow {
@@ -27,6 +28,11 @@ namespace HavenSoft.HexManiac.WPF.Windows {
          viewModel.MoveFocusToFind += (sender, e) => FocusTextBox(FindBox);
          viewModel.GotoViewModel.MoveFocusToGoto += FocusGotoBox;
          viewModel.PropertyChanged += ViewModelPropertyChanged;
+
+         GotoPanel.IsVisibleChanged += AnimateFocusToCorner;
+         FindPanel.IsVisibleChanged += AnimateFocusToCorner;
+         MessagePanel.IsVisibleChanged += AnimateFocusToCorner;
+         ErrorPanel.IsVisibleChanged += AnimateFocusToCorner;
       }
 
       protected override void OnDrop(DragEventArgs e) {
@@ -162,6 +168,20 @@ namespace HavenSoft.HexManiac.WPF.Windows {
          if (tools == null || tools.StringTool == null) return;
          tools.StringTool.ContentIndex = textbox.SelectionStart;
          tools.StringTool.ContentSelectionLength = textbox.SelectionLength;
+      }
+
+      private void AnimateFocusToCorner(object sender, DependencyPropertyChangedEventArgs e) {
+         var element = (FrameworkElement)sender;
+         if (element.Visibility != Visibility.Visible) return;
+         element.Arrange(new Rect());
+
+         FocusAnimationElement.Visibility = Visibility.Visible;
+         var widthAnimation = new DoubleAnimation(ActualWidth, element.ActualWidth, TimeSpan.FromSeconds(.3));
+         var heightAnimation = new DoubleAnimation(ActualHeight, element.ActualHeight, TimeSpan.FromSeconds(.3));
+         heightAnimation.Completed += (sender1, e1) => FocusAnimationElement.Visibility = Visibility.Collapsed;
+
+         FocusAnimationElement.BeginAnimation(WidthProperty, widthAnimation);
+         FocusAnimationElement.BeginAnimation(HeightProperty, heightAnimation);
       }
    }
 }

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
@@ -158,7 +158,7 @@ namespace HavenSoft.HexManiac.WPF.Windows {
 
       private void StringToolContentSelectionChanged(object sender, RoutedEventArgs e) {
          var textbox = (TextBox)sender;
-         var tools = (ToolTray)textbox.DataContext;
+         var tools = textbox.DataContext as ToolTray;
          if (tools == null || tools.StringTool == null) return;
          tools.StringTool.ContentIndex = textbox.SelectionStart;
          tools.StringTool.ContentSelectionLength = textbox.SelectionLength;

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -6,5 +6,5 @@
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.1.4.0")]
-[assembly: AssemblyFileVersion("0.1.4.0")]
+[assembly: AssemblyVersion("0.1.5.0")]
+[assembly: AssemblyFileVersion("0.1.5.0")]


### PR DESCRIPTION
* improved auto-alignment when jumping to tables from search results
* table headers and table tool update more accurately
* automatic text recognition works better
* you can type in numbers for enums to get values outside the expected range
* multi-tab resizing behaves better
* search results specify the source file that the result came from
* currently selected hex address shown on a bottom bar
* more visibility for showing find/goto/errors/messages
* improved "do you want to save" dialog
* tab X button increased visibility
* improve loading performance
* better heuristic for showing the '*' in the tab
* table editing is more error tolerant
