### PR TITLE
Level-Up Move support

### DIFF
--- a/src/HexManiac.Core/HexManiac.Core.csproj
+++ b/src/HexManiac.Core/HexManiac.Core.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Models\Runs\AsciiRun.cs" />
     <Compile Include="Models\Runs\EggMoveRun.cs" />
     <Compile Include="Models\Runs\HeaderRow.cs" />
+    <Compile Include="Models\Runs\PLMRun.cs" />
     <Compile Include="ViewModels\AutoCompleteSelectionItem.cs" />
     <Compile Include="ViewModels\Visitors\CompleteEditOperation.cs" />
     <Compile Include="ViewModels\Visitors\ContextItemFactory.cs" />

--- a/src/HexManiac.Core/Models/AutoSearchModel.cs
+++ b/src/HexManiac.Core/Models/AutoSearchModel.cs
@@ -114,7 +114,7 @@ namespace HavenSoft.HexManiac.Core.Models {
                var abilityDescriptionsAddress = ReadPointer(firstPointerToAbilityDescriptions);
                var existingRun = GetNextAnchor(abilityDescriptionsAddress);
                if (!(existingRun is ArrayRun) && existingRun.Start == abilityDescriptionsAddress) {
-                  var error = TryParse(this, "[description<\"\">]abilitynames", existingRun.Start, existingRun.PointerSources, out var abilityDescriptions);
+                  var error = TryParse(this, $"[description<{PCSRun.SharedFormatString}>]abilitynames", existingRun.Start, existingRun.PointerSources, out var abilityDescriptions);
                   if (!error.HasError) ObserveAnchorWritten(noChangeDelta, "abilitydescriptions", abilityDescriptions);
                }
             }

--- a/src/HexManiac.Core/Models/AutoSearchModel.cs
+++ b/src/HexManiac.Core/Models/AutoSearchModel.cs
@@ -87,7 +87,7 @@ namespace HavenSoft.HexManiac.Core.Models {
       }
 
       private void DecodeDataArrays() {
-         if (TrySearch(this, noChangeDelta, $"[name\"\"14 index: price: holdeffect: description<> keyitemvalue. bagkeyitem. pocket. type. fieldeffect<> battleusage:: battleeffect<> battleextra::]", out var itemdata)) {
+         if (TrySearch(this, noChangeDelta, $"[name\"\"14 index: price: holdeffect: description<{PCSRun.SharedFormatString}> keyitemvalue. bagkeyitem. pocket. type. fieldeffect<> battleusage:: battleeffect<> battleextra::]", out var itemdata)) {
             ObserveAnchorWritten(noChangeDelta, "items", itemdata);
          }
 

--- a/src/HexManiac.Core/Models/AutoSearchModel.cs
+++ b/src/HexManiac.Core/Models/AutoSearchModel.cs
@@ -114,7 +114,7 @@ namespace HavenSoft.HexManiac.Core.Models {
                var abilityDescriptionsAddress = ReadPointer(firstPointerToAbilityDescriptions);
                var existingRun = GetNextAnchor(abilityDescriptionsAddress);
                if (!(existingRun is ArrayRun) && existingRun.Start == abilityDescriptionsAddress) {
-                  var error = TryParse(this, "[description<>]abilitynames", existingRun.Start, existingRun.PointerSources, out var abilityDescriptions);
+                  var error = TryParse(this, "[description<\"\">]abilitynames", existingRun.Start, existingRun.PointerSources, out var abilityDescriptions);
                   if (!error.HasError) ObserveAnchorWritten(noChangeDelta, "abilitydescriptions", abilityDescriptions);
                }
             }

--- a/src/HexManiac.Core/Models/AutoSearchModel.cs
+++ b/src/HexManiac.Core/Models/AutoSearchModel.cs
@@ -87,7 +87,7 @@ namespace HavenSoft.HexManiac.Core.Models {
       }
 
       private void DecodeDataArrays() {
-         if (TrySearch(this, noChangeDelta, "[name\"\"14 index: price: holdeffect: description<> keyitemvalue. bagkeyitem. pocket. type. fieldeffect<> battleusage:: battleeffect<> battleextra::]", out var itemdata)) {
+         if (TrySearch(this, noChangeDelta, $"[name\"\"14 index: price: holdeffect: description<> keyitemvalue. bagkeyitem. pocket. type. fieldeffect<> battleusage:: battleeffect<> battleextra::]", out var itemdata)) {
             ObserveAnchorWritten(noChangeDelta, "items", itemdata);
          }
 
@@ -120,8 +120,12 @@ namespace HavenSoft.HexManiac.Core.Models {
             }
          }
 
-         if (TrySearch(this, noChangeDelta, "[effect. power. type.types accuracy. pp. effectAccuracy. target. priority. more::]movenames", out var movedata, run => run.PointerSources.Count > 100)) {
+         if (TrySearch(this, noChangeDelta, "[effect. power. type.types accuracy. pp. effectAccuracy. target. priority. more::]" + EggMoveRun.MoveNamesTable, out var movedata, run => run.PointerSources.Count > 100)) {
             ObserveAnchorWritten(noChangeDelta, "movedata", movedata);
+         }
+
+         if (TrySearch(this, noChangeDelta, $"[moves<{PLMRun.SharedFormatString}>]" + EggMoveRun.PokemonNameTable, out var lvlMoveData)) {
+            ObserveAnchorWritten(noChangeDelta, "lvlmoves", lvlMoveData);
          }
 
          // @3D4294 ^itemicons[image<> palette<>]items

--- a/src/HexManiac.Core/Models/AutoSearchModel.cs
+++ b/src/HexManiac.Core/Models/AutoSearchModel.cs
@@ -40,6 +40,8 @@ namespace HavenSoft.HexManiac.Core.Models {
             DecodeDataArrays();
             DecodeStreams();
          }
+
+         ResolveConflicts();
       }
 
       private void DecodeHeader() {

--- a/src/HexManiac.Core/Models/IDataModel.cs
+++ b/src/HexManiac.Core/Models/IDataModel.cs
@@ -198,7 +198,7 @@ namespace HavenSoft.HexManiac.Core.Models {
          while (length > 0) {
             startPlaces.Add(left);
             var run = model.GetNextRun(left);
-            if (run is NoInfoRun) startPlaces.Add(run.Start);
+            if (run is NoInfoRun && run.Start < left + length) startPlaces.Add(run.Start);
             if (!(run is NoInfoRun)) break;
             while (model[left] != 0xFF) { left++; length--; }
             left++; length--;

--- a/src/HexManiac.Core/Models/IDataModel.cs
+++ b/src/HexManiac.Core/Models/IDataModel.cs
@@ -53,7 +53,7 @@ namespace HavenSoft.HexManiac.Core.Models {
       string GetAnchorFromAddress(int requestSource, int destination);
       IReadOnlyList<string> GetAutoCompleteAnchorNameOptions(string partial);
       StoredMetadata ExportMetadata();
-      void UpdateArrayPointer(ModelDelta changeToken, int address, int destination);
+      void UpdateArrayPointer(ModelDelta changeToken, ArrayRunElementSegment segment, int address, int destination);
       int ConsiderResultsAsTextRuns(ModelDelta changeToken, IReadOnlyList<int> startLocations);
    }
 
@@ -113,7 +113,7 @@ namespace HavenSoft.HexManiac.Core.Models {
 
       public abstract IReadOnlyList<int> SearchForPointersToAnchor(ModelDelta changeToken, params int[] addresses);
 
-      public abstract void UpdateArrayPointer(ModelDelta currentChange, int index, int fullValue);
+      public abstract void UpdateArrayPointer(ModelDelta currentChange, ArrayRunElementSegment segment, int index, int fullValue);
 
       public int ReadValue(int index) => BitConverter.ToInt32(RawData, index);
 
@@ -305,7 +305,7 @@ namespace HavenSoft.HexManiac.Core.Models {
 
       public override IReadOnlyList<int> SearchForPointersToAnchor(ModelDelta changeToken, params int[] addresses) => throw new NotImplementedException();
 
-      public override void UpdateArrayPointer(ModelDelta changeToken, int address, int destination) {
+      public override void UpdateArrayPointer(ModelDelta changeToken, ArrayRunElementSegment segment, int address, int destination) {
          WritePointer(changeToken, address, destination);
       }
 

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -804,7 +804,10 @@ namespace HavenSoft.HexManiac.Core.Models {
          var anchorRun = runs[index];
          var newAnchorRun = anchorRun.RemoveSource(start);
          changeToken.RemoveRun(anchorRun);
-         if (newAnchorRun.PointerSources.Count == 0 && !anchorForAddress.ContainsKey(newAnchorRun.Start)) {
+
+         // the only run that is allowed to exist with nothing pointing to it and no name is a pointer run.
+         // if it's any other kind of run with no name and no pointers to it, remove it.
+         if (newAnchorRun.PointerSources.Count == 0 && !anchorForAddress.ContainsKey(newAnchorRun.Start) && !(newAnchorRun is PointerRun)) {
             runs.RemoveAt(index);
          } else {
             runs[index] = newAnchorRun;

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -477,11 +477,10 @@ namespace HavenSoft.HexManiac.Core.Models {
             runs[index] = array.AddSourcePointingWithinArray(start);
             changeToken.AddRun(runs[index]);
          } else if (index < 0) {
-            // the pointer is brand new
-            index = ~index;
             IFormattedRun newRun = new NoInfoRun(destination, new[] { start });
             UpdateNewRunFromPointerFormat(ref newRun, segment as ArrayRunPointerSegment, changeToken);
-            runs.Insert(index, newRun);
+            index = BinarySearch(destination); // runs could've been removed/added during UpdateNewRunFromPointerFormat: search for the index again.
+            runs.Insert(~index, newRun);
             changeToken.AddRun(newRun);
          } else {
             // the pointer points to a known normal anchor
@@ -493,6 +492,10 @@ namespace HavenSoft.HexManiac.Core.Models {
          }
       }
 
+      /// <summary>
+      /// If this new FormattedRun is a pointer to a known stream format,
+      /// Update the model so the data we're pointing to is actually that format.
+      /// </summary>
       private void UpdateNewRunFromPointerFormat(ref IFormattedRun run, ArrayRunPointerSegment segment, ModelDelta token) {
          if (segment == null) return;
          if (segment.InnerFormat == PCSRun.SharedFormatString) {

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -29,7 +29,7 @@ namespace HavenSoft.HexManiac.Core.Models {
       public virtual int EarliestAllowedAnchor => 0;
 
       public override IReadOnlyList<ArrayRun> Arrays => runs.OfType<ArrayRun>().ToList();
-      public override IReadOnlyList<IFormattedRun> Streams => runs.Where(run => run is EggMoveRun || run is PLMRun).ToList();
+      public override IReadOnlyList<IFormattedRun> Streams => runs.Where(run => run is IStreamRun).ToList();
 
       #region Constructor
 

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -504,6 +504,7 @@ namespace HavenSoft.HexManiac.Core.Models {
       }
 
       public override void ObserveAnchorWritten(ModelDelta changeToken, string anchorName, IFormattedRun run) {
+         Debug.Assert(run.Length > 0); // writing an anchor of length zero is stupid.
          int location = run.Start;
          int index = BinarySearch(location);
 

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -508,7 +508,7 @@ namespace HavenSoft.HexManiac.Core.Models {
             var length = PCSString.ReadString(this, run.Start, true);
             if (length > 0) {
                var newRun = new PCSRun(this, run.Start, length, run.PointerSources);
-               if (!newRun.Equals(run)) ClearFormat(token, run.Start, run.Length);
+               if (!newRun.Equals(run)) ClearFormat(token, newRun.Start, newRun.Length);
                run = newRun;
             }
          } else if (segment.InnerFormat == PLMRun.SharedFormatString) {

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -29,7 +29,7 @@ namespace HavenSoft.HexManiac.Core.Models {
       public virtual int EarliestAllowedAnchor => 0;
 
       public override IReadOnlyList<ArrayRun> Arrays => runs.OfType<ArrayRun>().ToList();
-      public override IReadOnlyList<IFormattedRun> Streams => runs.OfType<EggMoveRun>().ToList();
+      public override IReadOnlyList<IFormattedRun> Streams => runs.Where(run => run is EggMoveRun || run is PLMRun).ToList();
 
       #region Constructor
 
@@ -683,7 +683,7 @@ namespace HavenSoft.HexManiac.Core.Models {
          if (nextRun.Start < address) return false;
          if (nextRun.Start == address && !(nextRun is NoInfoRun)) return false;
          var run = new PLMRun(model, address);
-         if (run.Length < 6) return false;
+         if (run.Length < 2) return false;
          if (address + run.Length > nextRun.Start && nextRun.Start != address) return false;
          var pointers = model.SearchForPointersToAnchor(currentChange, address);  // this is slow and change the metadata. Only do it if we're sure we want the new PLMRun
          if (pointers.Count == 0) return false;
@@ -1188,6 +1188,8 @@ namespace HavenSoft.HexManiac.Core.Models {
             newRun = array.Move(newStart);
          } else if (run is EggMoveRun egg) {
             newRun = new EggMoveRun(this, newStart);
+         } else if (run is PLMRun plm) {
+            newRun = new PLMRun(this, newStart);
          } else {
             throw new NotImplementedException();
          }

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -138,7 +138,7 @@ namespace HavenSoft.HexManiac.Core.Models {
 
       [Conditional("DEBUG")]
       protected void ResolveConflicts() {
-         for (int i = 0; i < runs.Count - 1; i++) {
+         for (int i = 0; i < runs.Count; i++) {
             // for every pointer run, make sure that the thing it points to knows about it
             if (runs[i] is PointerRun pointerRun) {
                var destination = ReadPointer(pointerRun.Start);
@@ -168,7 +168,7 @@ namespace HavenSoft.HexManiac.Core.Models {
                }
             }
 
-            if (runs[i].Start + runs[i].Length <= runs[i + 1].Start) continue;
+            if (i == runs.Count - 1 || runs[i].Start + runs[i].Length <= runs[i + 1].Start) continue;
             var debugRunStart1 = runs[i].Start.ToString("X6");
             var debugRunStart2 = runs[i + 1].Start.ToString("X6");
             Debug.Fail("Conflict: there's a run that ends before the next run starts!");
@@ -410,6 +410,7 @@ namespace HavenSoft.HexManiac.Core.Models {
             var existingRun = runs[index];
             changeToken.RemoveRun(existingRun);
             run = run.MergeAnchor(existingRun.PointerSources);
+            if (run is NoInfoRun) run = existingRun.MergeAnchor(run.PointerSources); // when writing an anchor with no format, keep the existing format.
             runs[index] = run;
             changeToken.AddRun(run);
          }

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -472,7 +472,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
                var pointerSegment = new ArrayRunPointerSegment(name, segments.Substring(1, formatLength - 2));
                if (!pointerSegment.IsInnerFormatValid) throw new ArrayRunParseException($"pointer format '{pointerSegment.InnerFormat}' was not understood.");
                list.Add(pointerSegment);
-               segments = segments.Substring(formatLength);
+               segments = segments.Substring(formatLength).Trim();
             } else {
                segments = segments.Substring(formatLength).Trim();
                if (format == ElementContentType.Unknown) {

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -622,7 +622,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
                throw new NotImplementedException();
          }
       }
-      
+
       [Flags]
       public enum FormatMatchFlags {
          IsSingleSegment = 0x01,

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -275,6 +275,8 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
 
 
             if (!earlyExit) {
+               var dataEmpty = Enumerable.Range(targetRun.Start, currentLength * elementLength).Select(i => data[i]).All(d => d == 0xFF || d == 0x00);
+               if (dataEmpty) continue; // don't accept the run if it contains no data
                bestLength = currentLength;
                return targetRun.Start;
             }

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -116,14 +116,14 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
                elementCount++;
             }
             LengthFromAnchor = string.Empty;
-            ElementCount = elementCount;
+            ElementCount = Math.Max(1, elementCount); // if the user said there's a format here, then there is, even if the format it wrong.
          } else if (int.TryParse(length, out int result)) {
             // fixed length is easy
             LengthFromAnchor = string.Empty;
-            ElementCount = result;
+            ElementCount = Math.Max(1, result);
          } else {
             LengthFromAnchor = length;
-            ElementCount = ParseLengthFromAnchor();
+            ElementCount = Math.Max(1, ParseLengthFromAnchor());
          }
 
          Length = ElementLength * ElementCount;

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -445,6 +445,25 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          return new ArrayRun(owner, FormatString, LengthFromAnchor, Start, ElementCount, ElementContent, newPointerSources, newInnerPointerSources);
       }
 
+      public bool HasSameSegments(ArrayRun other) {
+         if (other == null) return false;
+         if (other.ElementContent.Count != ElementContent.Count) return false;
+         for (int i = 0; i < ElementContent.Count; i++) {
+            var mine = ElementContent[i];
+            var theirs = other.ElementContent[i];
+            if (mine.Type != theirs.Type || mine.Length != theirs.Length) return false;
+            if (mine is ArrayRunEnumSegment enumSegment) {
+               if (!(theirs is ArrayRunEnumSegment enumSegment2)) return false;
+               if (enumSegment.EnumName != enumSegment2.EnumName) return false;
+            }
+            if (mine is ArrayRunPointerSegment pointerSegment) {
+               if (!(theirs is ArrayRunPointerSegment pointerSegment2)) return false;
+               if (pointerSegment.InnerFormat != pointerSegment2.InnerFormat) return false;
+            }
+         }
+         return true;
+      }
+
       protected override IFormattedRun Clone(IReadOnlyList<int> newPointerSources) {
          // since the inner pointer sources includes the first row, update the first row
          List<IReadOnlyList<int>> newInnerPointerSources = null;

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -468,6 +468,11 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
                   segments = segments.Substring(endOfToken).Trim();
                   list.Add(new ArrayRunEnumSegment(name, segmentLength, enumName));
                }
+            } else if (format == ElementContentType.Pointer && formatLength > 2) {
+               var pointerSegment = new ArrayRunPointerSegment(name, segments.Substring(1, formatLength - 2));
+               if (!pointerSegment.IsInnerFormatValid) throw new ArrayRunParseException($"pointer format '{pointerSegment.InnerFormat}' was not understood.");
+               list.Add(pointerSegment);
+               segments = segments.Substring(formatLength);
             } else {
                segments = segments.Substring(formatLength).Trim();
                if (format == ElementContentType.Unknown) {
@@ -483,7 +488,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       }
 
       private static (ElementContentType format, int formatLength, int segmentLength) ExtractSingleFormat(string segments) {
-         if (segments.Length >= 2 && segments.Substring(0, 2) == "\"\"") {
+         if (segments.Length >= 2 && segments.Substring(0, 2) == PCSRun.StringDelimeter + string.Empty + PCSRun.StringDelimeter) {
             var format = ElementContentType.PCS;
             var formatLength = 2;
             while (formatLength < segments.Length && char.IsDigit(segments[formatLength])) formatLength++;
@@ -498,8 +503,16 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
             return (ElementContentType.Integer, 1, 2);
          } else if (segments.StartsWith(SingleByteIntegerFormat.ToString())) {
             return (ElementContentType.Integer, 1, 1);
-         } else if (segments.StartsWith(PointerRun.PointerStart + string.Empty + PointerRun.PointerEnd)) {
-            return (ElementContentType.Pointer, 2, 4);
+         } else if (segments.Length > 0 && segments[0] == PointerRun.PointerStart) {
+            var openCount = 1;
+            var endIndex = 1;
+            while (openCount > 0 && endIndex < segments.Length) {
+               if (segments[endIndex] == PointerRun.PointerStart) openCount += 1;
+               else if (segments[endIndex] == PointerRun.PointerEnd) openCount -= 1;
+               endIndex += 1;
+            }
+            if (openCount > 0) return (ElementContentType.Unknown, 0, 0);
+            return (ElementContentType.Pointer, endIndex, 4);
          }
 
          return (ElementContentType.Unknown, 0, 0);
@@ -569,7 +582,11 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
             case ElementContentType.Pointer:
                var destination = owner.ReadPointer(start);
                if (destination == Pointer.NULL) return true;
-               return 0 <= destination && destination <= owner.Count;
+               if (0 > destination || destination > owner.Count) return false;
+               if (segment is ArrayRunPointerSegment pointerSegment) {
+                  if (!pointerSegment.DestinationDataMatchesPointerFormat(owner, new NoDataChangeDeltaModel(), destination)) return false;
+               }
+               return true;
             default:
                throw new NotImplementedException();
          }

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -194,7 +194,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
             } else if (InnerFormat == PLMRun.SharedFormatString) {
                var plmRun = PlmFactory(owner)(destination);
                var length = plmRun.Length;
-               if (length > 2) {
+               if (length >= 2) {
                   if (!(token is NoDataChangeDeltaModel)) owner.ObserveRunWritten(token, plmRun);
                   return true;
                }

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -180,7 +180,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          if (destination == Pointer.NULL) return true;
          var run = owner.GetNextAnchor(destination);
          if (run.Start < destination) return false;
-         if (run.Start > destination || (run.Start == destination && run is NoInfoRun)) {
+         if (run.Start > destination || (run.Start == destination && (run is NoInfoRun || run is PointerRun))) {
             // hard case: no format found, so check the data
             if (InnerFormat == PCSRun.SharedFormatString) {
                var length = PCSString.ReadString(owner, destination, true);

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -182,7 +182,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
                if (length > 2) {
                   // our token will be a no-change token if we're in the middle of exploring the data.
                   // If so, don't actually add the run. It's enough to know that we _can_ add the run.
-                  if (!(token is NoDataChangeDeltaModel)) owner.ObserveRunWritten(token, new PCSRun(destination, length));
+                  if (!(token is NoDataChangeDeltaModel)) owner.ObserveRunWritten(token, new PCSRun(owner, destination, length));
                   return true;
                }
             }

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -178,11 +178,11 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
 
       public bool DestinationDataMatchesPointerFormat(IDataModel owner, ModelDelta token, int destination) {
          if (destination == Pointer.NULL) return true;
-         var run = owner.GetNextRun(destination);
+         var run = owner.GetNextAnchor(destination);
          if (run.Start < destination) return false;
          if (run.Start > destination || (run.Start == destination && run is NoInfoRun)) {
             // hard case: no format found, so check the data
-            var maxLength = run.Start > destination ? run.Start - destination : owner.GetNextRun(destination + 1).Start - destination;
+            var maxLength = run.Start > destination ? run.Start - destination : owner.GetNextAnchor(destination + 1).Start - destination;
             if (InnerFormat == PCSRun.SharedFormatString) {
                var length = PCSString.ReadString(owner, destination, false, maxLength);
 

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -182,11 +182,10 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          if (run.Start < destination) return false;
          if (run.Start > destination || (run.Start == destination && run is NoInfoRun)) {
             // hard case: no format found, so check the data
-            var maxLength = run.Start > destination ? run.Start - destination : owner.GetNextAnchor(destination + 1).Start - destination;
             if (InnerFormat == PCSRun.SharedFormatString) {
-               var length = PCSString.ReadString(owner, destination, false, maxLength);
+               var length = PCSString.ReadString(owner, destination, true);
 
-               if (length > 2) {
+               if (length > 0) {
                   // our token will be a no-change token if we're in the middle of exploring the data.
                   // If so, don't actually add the run. It's enough to know that we _can_ add the run.
                   if (!(token is NoDataChangeDeltaModel)) owner.ObserveRunWritten(token, new PCSRun(owner, destination, length));
@@ -195,7 +194,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
             } else if (InnerFormat == PLMRun.SharedFormatString) {
                var plmRun = PlmFactory(owner)(destination);
                var length = plmRun.Length;
-               if (length > 2 && length <= maxLength) {
+               if (length > 2) {
                   if (!(token is NoDataChangeDeltaModel)) owner.ObserveRunWritten(token, plmRun);
                   return true;
                }

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -169,6 +169,13 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          InnerFormat = innerFormat;
       }
 
+      private Func<int, PLMRun> plmFactory;
+      private Func<int, PLMRun> PlmFactory(IDataModel owner) {
+         if (plmFactory != null) return plmFactory;
+         plmFactory = PLMRun.CreateFactory(owner);
+         return plmFactory;
+      }
+
       public bool DestinationDataMatchesPointerFormat(IDataModel owner, ModelDelta token, int destination) {
          if (destination == Pointer.NULL) return true;
          var run = owner.GetNextRun(destination);
@@ -186,7 +193,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
                   return true;
                }
             } else if (InnerFormat == PLMRun.SharedFormatString) {
-               var plmRun = new PLMRun(owner, destination);
+               var plmRun = PlmFactory(owner)(destination);
                var length = plmRun.Length;
                if (length > 2 && length <= maxLength) {
                   if (!(token is NoDataChangeDeltaModel)) owner.ObserveRunWritten(token, plmRun);

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -159,8 +159,8 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
 
       public bool IsInnerFormatValid {
          get {
-            if (InnerFormat == PCSRun.StringDelimeter + string.Empty + PCSRun.StringDelimeter) return true;
-            if (InnerFormat == "`plm`") return true;
+            if (InnerFormat == PCSRun.SharedFormatString) return true;
+            if (InnerFormat == PLMRun.SharedFormatString) return true;
             return false;
          }
       }
@@ -175,8 +175,8 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          if (run.Start < destination) return false;
          if (run.Start > destination || (run.Start == destination && run is NoInfoRun)) {
             // hard case: no format found, so check the data
-            if (InnerFormat == PCSRun.StringDelimeter + string.Empty + PCSRun.StringDelimeter) {
-               var maxLength = run.Start > destination ? run.Start - destination : owner.GetNextRun(destination + 1).Start - destination;
+            var maxLength = run.Start > destination ? run.Start - destination : owner.GetNextRun(destination + 1).Start - destination;
+            if (InnerFormat == PCSRun.SharedFormatString) {
                var length = PCSString.ReadString(owner, destination, false, maxLength);
 
                if (length > 2) {
@@ -185,11 +185,18 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
                   if (!(token is NoDataChangeDeltaModel)) owner.ObserveRunWritten(token, new PCSRun(owner, destination, length));
                   return true;
                }
+            } else if (InnerFormat == PLMRun.SharedFormatString) {
+               var plmRun = new PLMRun(owner, destination);
+               var length = plmRun.Length;
+               if (length > 2 && length <= maxLength) {
+                  if (!(token is NoDataChangeDeltaModel)) owner.ObserveRunWritten(token, plmRun);
+                  return true;
+               }
             }
          } else {
             // easy case: already have a useful format, just see if it matches
-            if (InnerFormat == PCSRun.StringDelimeter + string.Empty + PCSRun.StringDelimeter) return run is PCSRun;
-            //if (InnerFormat == "`plm`") return run is PokemonLearnableMovesRun;
+            if (InnerFormat == PCSRun.SharedFormatString) return run is PCSRun;
+            if (InnerFormat == PLMRun.SharedFormatString) return run is PLMRun;
          }
          return false;
       }

--- a/src/HexManiac.Core/Models/Runs/AsciiRun.cs
+++ b/src/HexManiac.Core/Models/Runs/AsciiRun.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 namespace HavenSoft.HexManiac.Core.Models.Runs {
    public class AsciiRun : BaseRun {
       public const char StreamDelimeter = '`';
+      public static readonly string SharedFormatString = AsciiRun.StreamDelimeter + "asc" + AsciiRun.StreamDelimeter;
 
       public override int Length { get; }
 

--- a/src/HexManiac.Core/Models/Runs/EggMoveRun.cs
+++ b/src/HexManiac.Core/Models/Runs/EggMoveRun.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 
 namespace HavenSoft.HexManiac.Core.Models.Runs {
-   public class EggMoveRun : IFormattedRun {
+   public class EggMoveRun : IStreamRun {
       public const int MagicNumber = 0x4E20; // anything above this number is a pokemon, anything below it is a move
       public const int EndStream = 0xFFFF;
       public const string PokemonNameTable = "pokenames";
@@ -136,7 +136,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          return names.IndexOfPartial(input);
       }
 
-      public string SerializeForTool() {
+      public string SerializeRun() {
          var builder = new StringBuilder();
          for (int i = 0; i < Length - 2; i += 2) {
             var address = Start + i;
@@ -152,7 +152,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          return builder.ToString();
       }
 
-      public int DeserializeFromTool(string content, ModelDelta token) {
+      public IStreamRun DeserializeRun(string content, ModelDelta token) {
          var data = new List<int>();
          var pokemonNames = cachedPokenames.Select(name => $"{GroupStart}{name.Trim('"').ToLower()}{GroupEnd}").ToList();
          var moveNames = cachedMovenames.Select(name => name.Trim('"').ToLower()).ToList();
@@ -179,7 +179,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          for (int i = 0; i < data.Count; i++) model.WriteMultiByteValue(run.Start + i * 2, 2, token, data[i]);
          model.WriteMultiByteValue(run.Start + data.Count * 2, 2, token, EndStream); // write the new end token
          for (int i = data.Count + 2; i < Length / 2; i++) model.WriteMultiByteValue(run.Start + i * 2, 2, token, EndStream); // fill any remaining old space with FF
-         return run.Start;
+         return new EggMoveRun(model, run.Start);
       }
 
       public IEnumerable<string> GetAutoCompleteOptions() {

--- a/src/HexManiac.Core/Models/Runs/EggMoveRun.cs
+++ b/src/HexManiac.Core/Models/Runs/EggMoveRun.cs
@@ -13,12 +13,13 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       public const string MoveNamesTable = "movenames";
       public const string GroupStart = "[";
       public const string GroupEnd = "]";
+      public static readonly string SharedFormatString = AsciiRun.StreamDelimeter + "egg" + AsciiRun.StreamDelimeter;
       private readonly IDataModel model;
 
       public int Start { get; }
       public int Length { get; }
       public IReadOnlyList<int> PointerSources { get; private set; }
-      public string FormatString => AsciiRun.StreamDelimeter + "egg" + AsciiRun.StreamDelimeter;
+      public string FormatString => SharedFormatString;
 
       public EggMoveRun(IDataModel dataModel, int dataIndex) {
          model = dataModel;
@@ -124,14 +125,15 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
 
       public int GetPokemonNumber(string input) {
          if (input.StartsWith(GroupStart)) input = input.Substring(1, input.Length - 2);
+         input = input.ToLower();
          var names = cachedPokenames.Select(name => name.Trim('"').ToLower()).ToList();
-         return GetNumber(input.ToLower(), names);
+         return names.IndexOfPartial(input);
       }
 
       public int GetMoveNumber(string input) {
          input = input.Trim('"').ToLower();
          var names = cachedMovenames.Select(name => name.Trim('"').ToLower()).ToList();
-         return GetNumber(input, names);
+         return names.IndexOfPartial(input);
       }
 
       public string SerializeForTool() {
@@ -184,14 +186,6 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          var pokenames = cachedPokenames.Select(name => $"{GroupStart}{name}{GroupEnd}");
          var movenames = cachedMovenames.Select(name => name + " ");
          return pokenames.Concat(movenames);
-      }
-
-      private static int GetNumber(string input, IList<string> names) {
-         var matchIndex = names.IndexOf(input);
-         if (matchIndex != -1) return matchIndex;
-         var match = names.FirstOrDefault(name => name.Contains(input));
-         if (match == null) return -1;
-         return names.IndexOf(match);
       }
 
       public void AppendTo(StringBuilder text, int start, int length) {

--- a/src/HexManiac.Core/Models/Runs/EggMoveRun.cs
+++ b/src/HexManiac.Core/Models/Runs/EggMoveRun.cs
@@ -183,8 +183,8 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       }
 
       public IEnumerable<string> GetAutoCompleteOptions() {
-         var pokenames = cachedPokenames.Select(name => $"{GroupStart}{name}{GroupEnd}");
-         var movenames = cachedMovenames.Select(name => name + " ");
+         var pokenames = cachedPokenames.Select(name => $"{GroupStart}{name}{GroupEnd}"); // closing brace, so no space needed
+         var movenames = cachedMovenames.Select(name => name + " "); // autocomplete needs to complete after selection, so add a space
          return pokenames.Concat(movenames);
       }
 

--- a/src/HexManiac.Core/Models/Runs/IFormattedRun.cs
+++ b/src/HexManiac.Core/Models/Runs/IFormattedRun.cs
@@ -14,6 +14,25 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       IFormattedRun RemoveSource(int source);
    }
 
+   /// <summary>
+   /// A run representing a stream.
+   /// Streams usually are variable length, and end with some sort of 'end' token.
+   /// We want to be able to stringify streams, so we can use them with the tools.
+   /// </summary>
+   public interface IStreamRun : IFormattedRun {
+      /// <summary>
+      /// Should not change the data, only creates a string representation of that data.
+      /// </summary>
+      string SerializeRun();
+
+      /// <summary>
+      /// Updates data based on converting content back into the stream.
+      /// Returns the run where the data was placed.
+      /// The run usually starts at the same spot as before, but in the case of repointing it can be different.
+      /// </summary>
+      IStreamRun DeserializeRun(string content, ModelDelta token);
+   }
+
    public class FormattedRunComparer : IComparer<IFormattedRun> {
       public static FormattedRunComparer Instance { get; } = new FormattedRunComparer();
       public int Compare(IFormattedRun a, IFormattedRun b) => a.Start.CompareTo(b.Start);

--- a/src/HexManiac.Core/Models/Runs/PCSRun.cs
+++ b/src/HexManiac.Core/Models/Runs/PCSRun.cs
@@ -4,12 +4,13 @@ using System.Collections.Generic;
 namespace HavenSoft.HexManiac.Core.Models.Runs {
    public class PCSRun : BaseRun {
       public const char StringDelimeter = '"';
+      public static readonly string SharedFormatString = StringDelimeter + string.Empty + StringDelimeter;
 
       private int cachedIndex = int.MaxValue;
       private string cachedFullString;
 
       public override int Length { get; }
-      public override string FormatString => StringDelimeter.ToString() + StringDelimeter;
+      public override string FormatString => SharedFormatString;
 
       public PCSRun(int start, int length, IReadOnlyList<int> sources = null) : base(start, sources) => Length = length;
 

--- a/src/HexManiac.Core/Models/Runs/PCSRun.cs
+++ b/src/HexManiac.Core/Models/Runs/PCSRun.cs
@@ -1,9 +1,10 @@
 ﻿using HavenSoft.HexManiac.Core.ViewModels.DataFormats;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace HavenSoft.HexManiac.Core.Models.Runs {
-   public class PCSRun : BaseRun, IStreamRun {
+   public class PCSRun : BaseRun, IStreamRun, IEquatable<IFormattedRun> {
       public const char StringDelimeter = '"';
       public static readonly string SharedFormatString = StringDelimeter + string.Empty + StringDelimeter;
 
@@ -15,6 +16,11 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       public override string FormatString => SharedFormatString;
 
       public PCSRun(IDataModel model, int start, int length, IReadOnlyList<int> sources = null) : base(start, sources) => (this.model, Length) = (model, length);
+
+      public bool Equals(IFormattedRun run) {
+         if (!(run is PCSRun other)) return false;
+         return Start == other.Start && Length == other.Length && model == other.model;
+      }
 
       public override IDataFormat CreateDataFormat(IDataModel data, int index) {
          Debug.Assert(data == model);

--- a/src/HexManiac.Core/Models/Runs/PCSRun.cs
+++ b/src/HexManiac.Core/Models/Runs/PCSRun.cs
@@ -1,20 +1,24 @@
 ﻿using HavenSoft.HexManiac.Core.ViewModels.DataFormats;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace HavenSoft.HexManiac.Core.Models.Runs {
-   public class PCSRun : BaseRun {
+   public class PCSRun : BaseRun, IStreamRun {
       public const char StringDelimeter = '"';
       public static readonly string SharedFormatString = StringDelimeter + string.Empty + StringDelimeter;
 
+      private readonly IDataModel model;
       private int cachedIndex = int.MaxValue;
       private string cachedFullString;
 
       public override int Length { get; }
       public override string FormatString => SharedFormatString;
 
-      public PCSRun(int start, int length, IReadOnlyList<int> sources = null) : base(start, sources) => Length = length;
+      public PCSRun(IDataModel model, int start, int length, IReadOnlyList<int> sources = null) : base(start, sources) => (this.model, Length) = (model, length);
 
       public override IDataFormat CreateDataFormat(IDataModel data, int index) {
+         Debug.Assert(data == model);
+
          // only read the full string from the data once per pass.
          // This assumes that we read data starting at the lowest index and working our way up.
          if (index < cachedIndex) cachedFullString = PCSString.Convert(data, Start, Length);
@@ -39,8 +43,27 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          }
       }
 
+      public string SerializeRun() {
+         var newContent = PCSString.Convert(model, Start, Length);
+         newContent = newContent.Substring(1, newContent.Length - 2); // remove quotes
+         return newContent;
+      }
+
+      public IStreamRun DeserializeRun(string content, ModelDelta token) {
+         var bytes = PCSString.Convert(content);
+         var newRun = model.RelocateForExpansion(token, this, bytes.Count);
+
+         // clear out excess bytes that are no longer in use
+         if (Start == newRun.Start) {
+            for (int i = bytes.Count; i < Length; i++) token.ChangeData(model, Start + i, 0xFF);
+         }
+
+         for (int i = 0; i < bytes.Count; i++) token.ChangeData(model, newRun.Start + i, bytes[i]);
+         return new PCSRun(model, newRun.Start, bytes.Count, newRun.PointerSources);
+      }
+
       protected override IFormattedRun Clone(IReadOnlyList<int> newPointerSources) {
-         return new PCSRun(Start, Length, newPointerSources);
+         return new PCSRun(model, Start, Length, newPointerSources);
       }
    }
 }

--- a/src/HexManiac.Core/Models/Runs/PLMRun.cs
+++ b/src/HexManiac.Core/Models/Runs/PLMRun.cs
@@ -74,5 +74,9 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          move = names.IndexOfPartial(moveName);
          return move != -1;
       }
+
+      public IEnumerable<string> GetAutoCompleteOptions(string header) {
+         return cachedMovenames.Select(name => $"{header} {name} "); // autocomplete needs to complete after selection, so add a space
+      }
    }
 }

--- a/src/HexManiac.Core/Models/Runs/PLMRun.cs
+++ b/src/HexManiac.Core/Models/Runs/PLMRun.cs
@@ -39,7 +39,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
             }
             // validate value
             var (level, move) = SplitToken(value);
-            if (level > 100 || level < 1) break;
+            if (level > 101 || level < 1) break;
             if (move > this.cachedMovenames.Count) break;
          }
       }

--- a/src/HexManiac.Core/Models/Runs/PLMRun.cs
+++ b/src/HexManiac.Core/Models/Runs/PLMRun.cs
@@ -1,0 +1,78 @@
+﻿using HavenSoft.HexManiac.Core.ViewModels.DataFormats;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace HavenSoft.HexManiac.Core.Models.Runs {
+   public class PLMRun : IFormattedRun {
+      public const int MaxLearningLevel = 100;
+      public static readonly string SharedFormatString = AsciiRun.StreamDelimeter + "plm" + AsciiRun.StreamDelimeter;
+      private readonly IDataModel model;
+      public int Start { get; }
+      public int Length { get; }
+      public IReadOnlyList<int> PointerSources { get; private set; }
+      public string FormatString => SharedFormatString;
+
+      public PLMRun(IDataModel dataModel, int start) {
+         model = dataModel;
+         cachedMovenames = ArrayRunEnumSegment.GetOptions(model, EggMoveRun.MoveNamesTable) ?? new List<string>();
+         Start = start;
+         for (int i = Start; i < model.Count; i += 2) {
+            var value = model.ReadMultiByteValue(i, 2);
+            if (value == 0xFFFF) {
+               Length = i - Start + 2;
+               break;
+            }
+            // validate value
+            var (level, move) = SplitToken(value);
+            if (level > 100) break;
+            if (move > cachedMovenames.Count) break;
+         }
+      }
+
+      public static (int level, int move) SplitToken(int value) {
+         var level = (value & 0xFE00) >> 9;
+         var move = (value & 0x1FF);
+         return (level, move);
+      }
+
+      private IReadOnlyList<string> cachedMovenames;
+      private int lastFormatRequest = int.MinValue;
+      public IDataFormat CreateDataFormat(IDataModel data, int index) {
+         Debug.Assert(data == model);
+         if (index != lastFormatRequest + 1) {
+            cachedMovenames = ArrayRunEnumSegment.GetOptions(model, EggMoveRun.MoveNamesTable) ?? new List<string>();
+         }
+         lastFormatRequest = index;
+
+         var position = index - Start;
+         var groupStart = position % 2 == 1 ? position - 1 : position;
+         position -= groupStart;
+         var value = data.ReadMultiByteValue(Start + groupStart, 2);
+         var (level, move) = SplitToken(value);
+         var moveName = cachedMovenames.Count > move ? cachedMovenames[move] : move.ToString();
+         return new PlmItem(groupStart + Start, position, level, move, moveName);
+      }
+
+      public IFormattedRun MergeAnchor(IReadOnlyList<int> sources) {
+         var newSources = new HashSet<int>();
+         if (sources != null) newSources.AddRange(sources);
+         if (PointerSources != null) newSources.AddRange(PointerSources);
+         return new PLMRun(model, Start) { PointerSources = newSources.ToList() };
+      }
+
+      public IFormattedRun RemoveSource(int source) {
+         var sources = PointerSources.ToList();
+         sources.Remove(source);
+         return new PLMRun(model, Start) { PointerSources = sources };
+      }
+
+      public bool TryGetMoveNumber(string moveName, out int move) {
+         moveName = moveName.Trim('"').ToLower();
+         var names = cachedMovenames.Select(name => name.Trim('"').ToLower()).ToList();
+         move = names.IndexOfPartial(moveName);
+         return move != -1;
+      }
+   }
+}

--- a/src/HexManiac.Core/Models/Runs/PLMRun.cs
+++ b/src/HexManiac.Core/Models/Runs/PLMRun.cs
@@ -20,7 +20,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       /// We can do it using the factory returned by this method instead of the constructor.
       /// This lets us reuse the same cache for each new run.
       /// </summary>
-      public static Func<int, PLMRun>CreateFactory(IDataModel model) {
+      public static Func<int, PLMRun> CreateFactory(IDataModel model) {
          var cachedMoveNames = ArrayRunEnumSegment.GetOptions(model, EggMoveRun.MoveNamesTable) ?? new List<string>();
          return start => new PLMRun(model, start, cachedMoveNames);
       }

--- a/src/HexManiac.Core/Models/Runs/PLMRun.cs
+++ b/src/HexManiac.Core/Models/Runs/PLMRun.cs
@@ -95,7 +95,8 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          for (int i = 0; i < Length - 2; i += 2) {
             var address = Start + i;
             var (level, move) = SplitToken(model.ReadMultiByteValue(address, 2));
-            builder.Append($"{level} {move}");
+            var moveName = cachedMovenames.Count > move ? cachedMovenames[move] : move.ToString();
+            builder.Append($"{level} {moveName}");
             if (i < Length - 4) builder.AppendLine();
          }
          return builder.ToString();

--- a/src/HexManiac.Core/Models/StoredMetadata.cs
+++ b/src/HexManiac.Core/Models/StoredMetadata.cs
@@ -34,11 +34,11 @@ namespace HavenSoft.HexManiac.Core.Models {
             }
 
             if (cleanLine.StartsWith("Name = '''")) {
-               currentItemName = cleanLine.Split(new[] { "'''" }, StringSplitOptions.None)[1];
+               currentItemName = cleanLine.Split("'''")[1];
             }
 
             if (cleanLine.StartsWith("Format = '''")) {
-               currentItemFormat = cleanLine.Split(new[] { "'''" }, StringSplitOptions.None)[1];
+               currentItemFormat = cleanLine.Split("'''")[1];
             }
          }
 

--- a/src/HexManiac.Core/SystemExtensions.cs
+++ b/src/HexManiac.Core/SystemExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace HavenSoft.HexManiac.Core {
    public static class SystemExtensions {
@@ -21,8 +22,19 @@ namespace HavenSoft.HexManiac.Core {
 
          return true;
       }
+      public static int IndexOfPartial(this IList<string> names, string input) {
+         // perfect match first
+         var matchIndex = names.IndexOf(input);
+         if (matchIndex != -1) return matchIndex;
+
+         // no perfect match found. How about a partial match?
+         var match = names.FirstOrDefault(name => name.Contains(input));
+         if (match == null) return -1;
+         return names.IndexOf(match);
+      }
       public static void AddRange<T>(this HashSet<T> set, IEnumerable<T> items) {
          foreach (var item in items) set.Add(item);
       }
+      public static int Count<T>(this IEnumerable<T> list, T c) where T : struct => list.Count(ch => ch.Equals(c));
    }
 }

--- a/src/HexManiac.Core/SystemExtensions.cs
+++ b/src/HexManiac.Core/SystemExtensions.cs
@@ -4,15 +4,37 @@ using System.Linq;
 
 namespace HavenSoft.HexManiac.Core {
    public static class SystemExtensions {
+
+      ////// Random utility functions on basic types, mostly added to make code easier to read. //////
+
       public static T LimitToRange<T>(this T value, T lower, T upper) where T : IComparable<T> {
          if (upper.CompareTo(lower) < 0) throw new ArgumentException($"upper value {upper} is less than lower value {lower}");
          if (value.CompareTo(lower) < 0) return lower;
          if (upper.CompareTo(value) < 0) return upper;
          return value;
       }
+
       public static void Sort<T>(this List<T> list, Func<T, T, int> compare) {
          list.Sort(new StubComparer<T> { Compare = compare });
       }
+
+      public static void AddRange<T>(this HashSet<T> set, IEnumerable<T> items) {
+         foreach (var item in items) set.Add(item);
+      }
+
+      public static int Count<T>(this IEnumerable<T> list, T c) where T : struct => list.Count(ch => ch.Equals(c));
+
+      public static int IndexOf<T>(this IReadOnlyList<T> list, T element) where T : class {
+         for (int i = 0; i < list.Count; i++) {
+            if (list[i] == element) return i;
+         }
+         return -1;
+      }
+
+      public static string[] Split(this string self, string token) => self.Split(new[] { token }, StringSplitOptions.None);
+
+      ////// these are some specific string extensions to deal with smart auto-complete //////
+
       public static bool MatchesPartial(this string full, string partial) {
          foreach (var character in partial) {
             var index = full.IndexOf(character.ToString(), StringComparison.CurrentCultureIgnoreCase);
@@ -32,9 +54,5 @@ namespace HavenSoft.HexManiac.Core {
          if (match == null) return -1;
          return names.IndexOf(match);
       }
-      public static void AddRange<T>(this HashSet<T> set, IEnumerable<T> items) {
-         foreach (var item in items) set.Add(item);
-      }
-      public static int Count<T>(this IEnumerable<T> list, T c) where T : struct => list.Count(ch => ch.Equals(c));
    }
 }

--- a/src/HexManiac.Core/ViewModels/ConvertCellToText.cs
+++ b/src/HexManiac.Core/ViewModels/ConvertCellToText.cs
@@ -50,5 +50,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       public void Visit(EggSection section, byte data) => Result = section.SectionName;
 
       public void Visit(EggItem item, byte data) => Result = item.ItemName;
+
+      public void Visit(PlmItem item, byte data) => Result = item.ToString();
    }
 }

--- a/src/HexManiac.Core/ViewModels/DataFormats.cs
+++ b/src/HexManiac.Core/ViewModels/DataFormats.cs
@@ -30,6 +30,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.DataFormats {
       void Visit(IntegerEnum integer, byte data);
       void Visit(EggSection section, byte data);
       void Visit(EggItem item, byte data);
+      void Visit(PlmItem item, byte data);
    }
 
    /// <summary>
@@ -258,19 +259,34 @@ namespace HavenSoft.HexManiac.Core.ViewModels.DataFormats {
    public class EggItem : IDataFormatInstance {
       public int Source { get; }
       public int Position { get; }
-      public int Length { get; }
       public string ItemName { get; }
 
       public EggItem(int source, int position, string name) => (Source, Position, ItemName) = (source, position, name);
 
       public bool Equals(IDataFormat other) {
          if (other is EggItem that) {
-            return that.ItemName == ItemName &&
-               that.Source == Source &&
-               that.Length == Length;
+            return that.ItemName == ItemName && that.Source == Source;
          }
          return false;
       }
+
+      public void Visit(IDataFormatVisitor visitor, byte data) => visitor.Visit(this, data);
+   }
+
+   public class PlmItem : IDataFormatInstance {
+      public int Source { get; }
+      public int Position { get; }
+      public int Level { get; }
+      public int Move { get; }
+      public string MoveName { get; }
+      public override string ToString() => $"{Level} {Move}";
+
+      public PlmItem(int source, int position, int level, int move, string moveName) {
+         (Source, Position) = (source, position);
+         (Level, Move, MoveName) = (level, move, moveName);
+      }
+
+      public bool Equals(IDataFormat other) => ToString() == other.ToString();
 
       public void Visit(IDataFormatVisitor visitor, byte data) => visitor.Visit(this, data);
    }

--- a/src/HexManiac.Core/ViewModels/DataFormats.cs
+++ b/src/HexManiac.Core/ViewModels/DataFormats.cs
@@ -279,7 +279,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.DataFormats {
       public int Level { get; }
       public int Move { get; }
       public string MoveName { get; }
-      public override string ToString() => $"{Level} {Move}";
+      public override string ToString() => $"{Level} {MoveName}";
 
       public PlmItem(int source, int position, int level, int move, string moveName) {
          (Source, Position) = (source, position);

--- a/src/HexManiac.Core/ViewModels/DataFormats.cs
+++ b/src/HexManiac.Core/ViewModels/DataFormats.cs
@@ -279,7 +279,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.DataFormats {
       public int Level { get; }
       public int Move { get; }
       public string MoveName { get; }
-      public override string ToString() => $"{Level} {MoveName}";
+      public override string ToString() => (Level == 0x7F && Move == 0x1FF) ? EggMoveRun.GroupStart + string.Empty + EggMoveRun.GroupEnd : $"{Level} {MoveName}";
 
       public PlmItem(int source, int position, int level, int move, string moveName) {
          (Source, Position) = (source, position);

--- a/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
@@ -220,7 +220,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
       }
    }
 
-   public class TextStreamArrayElementViewModel : ViewModelCore, IArrayElementViewModel {
+   public class StreamArrayElementViewModel : ViewModelCore, IArrayElementViewModel {
       private readonly ChangeHistory<ModelDelta> history;
       private readonly FieldArrayElementViewModel matchingField;
       private readonly IDataModel model;
@@ -238,23 +238,19 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
          set {
             if (TryUpdate(ref content, value)) {
                var destination = model.ReadPointer(start);
-               var run = model.GetNextRun(destination);
-               var data = PCSString.Convert(content);
-               var newRun = model.RelocateForExpansion(history.CurrentChange, run, data.Count);
+               var run = (IStreamRun)model.GetNextRun(destination);
+               var newRun = run.DeserializeRun(content, history.CurrentChange);
                if (run.Start != newRun.Start) {
                   DataMoved?.Invoke(this, (run.Start, newRun.Start));
                   matchingField.RefreshControlFromModelChange();
                }
                run = newRun;
-               for (int i = 0; i < data.Count; i++) history.CurrentChange.ChangeData(model, run.Start + i, data[i]);
-               for (int i = data.Count; i < run.Length; i++) history.CurrentChange.ChangeData(model, run.Start + i, 0xFF);
                DataChanged?.Invoke(this, EventArgs.Empty);
-               model.ObserveRunWritten(history.CurrentChange, new PCSRun(model, run.Start, data.Count));
             }
          }
       }
 
-      public TextStreamArrayElementViewModel(ChangeHistory<ModelDelta> history, FieldArrayElementViewModel matchingField, IDataModel model, string name, int start) {
+      public StreamArrayElementViewModel(ChangeHistory<ModelDelta> history, FieldArrayElementViewModel matchingField, IDataModel model, string name, int start) {
          this.history = history;
          this.matchingField = matchingField;
          this.model = model;
@@ -265,8 +261,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
 
          // by the time we get this far, we're guaranteed that this will be a PCSRun.
          // if it's not a PCSRun, we shouldn't have asked to construct this object.
-         var run = (PCSRun)model.GetNextRun(destination);
-         content = PCSString.Convert(model, run.Start, run.Length);
+         var run = (IStreamRun)model.GetNextRun(destination);
+         content = run.SerializeRun();
       }
    }
 }

--- a/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
@@ -249,7 +249,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
                for (int i = 0; i < data.Count; i++) history.CurrentChange.ChangeData(model, run.Start + i, data[i]);
                for (int i = data.Count; i < run.Length; i++) history.CurrentChange.ChangeData(model, run.Start + i, 0xFF);
                DataChanged?.Invoke(this, EventArgs.Empty);
-               model.ObserveRunWritten(history.CurrentChange, new PCSRun(run.Start, data.Count));
+               model.ObserveRunWritten(history.CurrentChange, new PCSRun(model, run.Start, data.Count));
             }
          }
       }

--- a/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
@@ -226,7 +226,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
       private readonly IDataModel model;
       private readonly string name;
       private readonly int start;
-      
+
       public bool IsInError => !string.IsNullOrEmpty(ErrorText);
       public string ErrorText { get; private set; }
       public event EventHandler DataChanged;

--- a/src/HexManiac.Core/ViewModels/Tools/PCSTool.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/PCSTool.cs
@@ -195,7 +195,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
       private void UpdateSelectionFromTool() {
          if (ignoreSelectionUpdates) return;
          var run = model.GetNextRun(Address);
-         if (!(run is ArrayRun) && !(run is PCSRun) && !(run is EggMoveRun)) return;
+         if (!(run is ArrayRun) && !(run is PCSRun) && !(run is EggMoveRun) && !(run is PLMRun)) return;
 
          // for arrays, the address must be at the start of a string segment within the first element of the array
          if (run is ArrayRun arrayRun) {
@@ -221,14 +221,14 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
             var afterLines = content.Substring(0, contentIndex + selectionLength).Split(Environment.NewLine);
             var selectionEnd = textStart + (afterLines.Length - 1) * array.ElementLength + afterLines[afterLines.Length - 1].Length;
             selectionLength = selectionEnd - selectionStart;
-         } else if (run is EggMoveRun egg) {
+         } else if (run is EggMoveRun || run is PLMRun) { // both of these streams format by putting 2 bytes per line.
             var beforeSelection = content.Substring(0, selectionStart);
             var beforeLineCount = (beforeSelection.Split(Environment.NewLine).Length - 1).LimitToRange(0, int.MaxValue);
             var withSelection = content.Substring(0, selectionStart + selectionLength);
             var withSelectionLineCount = (withSelection.Split(Environment.NewLine).Length - 1).LimitToRange(0, int.MaxValue);
 
-            selectionStart = egg.Start + beforeLineCount * 2;
-            var selectionEnd = egg.Start + withSelectionLineCount * 2;
+            selectionStart = run.Start + beforeLineCount * 2;
+            var selectionEnd = run.Start + withSelectionLineCount * 2;
             selectionLength = selectionEnd - selectionStart;
          }
 

--- a/src/HexManiac.Core/ViewModels/Tools/TableTool.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/TableTool.cs
@@ -161,10 +161,23 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
             }
             Children.Add(viewModel);
             viewModel.DataChanged += ForwardModelChanged;
+            if (item is ArrayRunPointerSegment pointerSegment) {
+               if (pointerSegment.DestinationDataMatchesPointerFormat(model, history.CurrentChange, model.ReadPointer(itemAddress))) {
+                  if (pointerSegment.InnerFormat == $"{PCSRun.StringDelimeter}{PCSRun.StringDelimeter}") {
+                     var streamElement = new TextStreamArrayElementViewModel(history, model, item.Name, itemAddress);
+                     streamElement.DataChanged += ForwardModelChanged;
+                     streamElement.DataMoved += ForwardModelDataMoved;
+                     Children.Add(streamElement);
+                  } else {
+                     throw new NotImplementedException();
+                  }
+               }
+            }
             itemAddress += item.Length;
          }
       }
 
       private void ForwardModelChanged(object sender, EventArgs e) => ModelDataChanged?.Invoke(this, model.GetNextRun(Address));
+      private void ForwardModelDataMoved(object sender, (int originalStart, int newStart) e) => ModelDataMoved?.Invoke(this, e);
    }
 }

--- a/src/HexManiac.Core/ViewModels/Tools/TableTool.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/TableTool.cs
@@ -163,7 +163,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
             viewModel.DataChanged += ForwardModelChanged;
             if (item is ArrayRunPointerSegment pointerSegment) {
                var destination = model.ReadPointer(itemAddress);
-               if (destination != Pointer.NULL && pointerSegment.DestinationDataMatchesPointerFormat(model, history.CurrentChange, destination)) {
+               if (destination != Pointer.NULL && pointerSegment.DestinationDataMatchesPointerFormat(model, new NoDataChangeDeltaModel(), destination)) {
                   if (pointerSegment.InnerFormat == PCSRun.SharedFormatString || pointerSegment.InnerFormat == PLMRun.SharedFormatString) {
                      var streamElement = new StreamArrayElementViewModel(history, (FieldArrayElementViewModel)viewModel, model, item.Name, itemAddress);
                      streamElement.DataChanged += ForwardModelChanged;

--- a/src/HexManiac.Core/ViewModels/Tools/TableTool.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/TableTool.cs
@@ -164,8 +164,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
             if (item is ArrayRunPointerSegment pointerSegment) {
                var destination = model.ReadPointer(itemAddress);
                if (destination != Pointer.NULL && pointerSegment.DestinationDataMatchesPointerFormat(model, history.CurrentChange, destination)) {
-                  if (pointerSegment.InnerFormat == $"{PCSRun.StringDelimeter}{PCSRun.StringDelimeter}") {
-                     var streamElement = new TextStreamArrayElementViewModel(history, (FieldArrayElementViewModel)viewModel, model, item.Name, itemAddress);
+                  if (pointerSegment.InnerFormat == PCSRun.SharedFormatString || pointerSegment.InnerFormat == PLMRun.SharedFormatString) {
+                     var streamElement = new StreamArrayElementViewModel(history, (FieldArrayElementViewModel)viewModel, model, item.Name, itemAddress);
                      streamElement.DataChanged += ForwardModelChanged;
                      streamElement.DataMoved += ForwardModelDataMoved;
                      Children.Add(streamElement);

--- a/src/HexManiac.Core/ViewModels/Tools/TableTool.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/TableTool.cs
@@ -162,9 +162,10 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
             Children.Add(viewModel);
             viewModel.DataChanged += ForwardModelChanged;
             if (item is ArrayRunPointerSegment pointerSegment) {
-               if (pointerSegment.DestinationDataMatchesPointerFormat(model, history.CurrentChange, model.ReadPointer(itemAddress))) {
+               var destination = model.ReadPointer(itemAddress);
+               if (destination != Pointer.NULL && pointerSegment.DestinationDataMatchesPointerFormat(model, history.CurrentChange, destination)) {
                   if (pointerSegment.InnerFormat == $"{PCSRun.StringDelimeter}{PCSRun.StringDelimeter}") {
-                     var streamElement = new TextStreamArrayElementViewModel(history, model, item.Name, itemAddress);
+                     var streamElement = new TextStreamArrayElementViewModel(history, (FieldArrayElementViewModel)viewModel, model, item.Name, itemAddress);
                      streamElement.DataChanged += ForwardModelChanged;
                      streamElement.DataMoved += ForwardModelDataMoved;
                      Children.Add(streamElement);

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -613,17 +613,18 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          }
 
          run = Model.GetNextRun(index);
-         var cellToText = new ConvertCellToText(Model, run.Start);
-         var cell = currentView[point.X, point.Y];
 
-         if (run is PCSRun pcs) {
+         if (run is PCSRun || run is AsciiRun) {
             for (int i = index; i < run.Start + run.Length; i++) history.CurrentChange.ChangeData(Model, i, 0xFF);
             var length = PCSString.ReadString(Model, run.Start, true);
-            Model.ObserveRunWritten(history.CurrentChange, new PCSRun(Model, run.Start, length, run.PointerSources));
+            if (run is PCSRun) Model.ObserveRunWritten(history.CurrentChange, new PCSRun(Model, run.Start, length, run.PointerSources));
             RefreshBackingData();
             SelectionStart = scroll.DataIndexToViewPoint(index - 1);
             return;
          }
+
+         var cellToText = new ConvertCellToText(Model, run.Start);
+         var cell = currentView[point.X, point.Y];
 
          if (run is ArrayRun array) {
             var offsets = array.ConvertByteOffsetToArrayOffset(index);

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -1097,7 +1097,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          (Point, Point) pair(int start, int end) => (scroll.DataIndexToViewPoint(start), scroll.DataIndexToViewPoint(end));
 
          if (run is PointerRun) return pair(run.Start, run.Start + run.Length - 1);
-         if (run is EggMoveRun) {
+         if (run is EggMoveRun || run is PLMRun) {
             var even = (index - run.Start) % 2 == 0;
             if (even) return pair(index, index + 1);
             return pair(index - 1, index);

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -795,6 +795,15 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                   }
                }
             }
+            // option 2: the value is used by learnable moves
+            if (child is PLMRun plmRun && parentArrayName == EggMoveRun.MoveNamesTable) {
+               for (int i = 0; i < plmRun.Length - 2; i += 2) {
+                  var fullValue = Model.ReadMultiByteValue(plmRun.Start + i, 2);
+                  if (PLMRun.SplitToken(fullValue).move == offsets.ElementIndex) {
+                     yield return (plmRun.Start + i, plmRun.Start + i + 1);
+                  }
+               }
+            }
          }
       }
 

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -1274,7 +1274,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                errorInfo = ErrorInfo.NoError;
             }
          } else if (underEdit.CurrentText == AnchorStart + PLMRun.SharedFormatString) {
-            if (!PokemonModel.ConsiderAsPlmStream(Model, history.CurrentChange, index)) {
+            if (!PokemonModel.ConsiderAsPlmStream(Model, index, history.CurrentChange)) {
                errorInfo = new ErrorInfo("An anchor with nothing pointing to it must have a name.");
             } else {
                errorInfo = ErrorInfo.NoError;

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -310,11 +310,14 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                   var errorInfo = PokemonModel.ApplyAnchor(Model, history.CurrentChange, index, AnchorText);
                   if (errorInfo == ErrorInfo.NoError) {
                      OnError?.Invoke(this, string.Empty);
-                     if (run is ArrayRun array) {
-                        // to keep from double-updating the AnchorText
-                        selection.PropertyChanged -= SelectionPropertyChanged;
-                        Goto.Execute(index.ToString("X2"));
-                        selection.PropertyChanged += SelectionPropertyChanged;
+                     var newRun = Model.GetNextRun(index);
+                     if (newRun is ArrayRun array) {
+                        // if the format changed (ignoring length), run a goto to update the display width
+                        if (run is ArrayRun array2 && !array.HasSameSegments(array2)) {
+                           selection.PropertyChanged -= SelectionPropertyChanged; // to keep from double-updating the AnchorText
+                           Goto.Execute(index.ToString("X2"));
+                           selection.PropertyChanged += SelectionPropertyChanged;
+                        }
                         UpdateColumnHeaders();
                         Tools.RefreshContent();
                      }

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -194,13 +194,28 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          var left = Math.Min(dataIndex1, dataIndex2);
          var result = "Address: " + left.ToString("X6");
 
-         if (Model.GetNextRun(left) is ArrayRun array && array.Start <= left) {
-            var index = array.ConvertByteOffsetToArrayOffset(left).ElementIndex;
-            var basename = Model.GetAnchorFromAddress(-1, array.Start);
-            if (array.ElementNames.Count > index) {
-               result += $" | {basename}/{array.ElementNames[index]}";
+         var run = Model.GetNextRun(left);
+         if (run is ArrayRun array1 && array1.Start <= left) {
+            var index = array1.ConvertByteOffsetToArrayOffset(left).ElementIndex;
+            var basename = Model.GetAnchorFromAddress(-1, array1.Start);
+            if (array1.ElementNames.Count > index) {
+               result += $" | {basename}/{array1.ElementNames[index]}";
             } else {
                result += $" | {basename}/{index}";
+            }
+         } else if (run.PointerSources != null && run.PointerSources.Count > 0 && string.IsNullOrEmpty(Model.GetAnchorFromAddress(-1, run.Start))) {
+            var sourceRun = Model.GetNextRun(run.PointerSources[0]);
+            if (sourceRun is ArrayRun array2) {
+               // we are an anchor that's pointed to from an array
+               var offset = array2.ConvertByteOffsetToArrayOffset(run.PointerSources[0]);
+               var index = offset.ElementIndex;
+               var segment = array2.ElementContent[offset.SegmentIndex];
+               var basename = Model.GetAnchorFromAddress(-1, array2.Start);
+               if (array2.ElementNames.Count > index) {
+                  result += $" | {basename}/{array2.ElementNames[index]}/{segment.Name}";
+               } else {
+                  result += $" | {basename}/{index}/{segment.Name}";
+               }
             }
          }
 

--- a/src/HexManiac.Core/ViewModels/Visitors/CompleteEditOperation.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/CompleteEditOperation.cs
@@ -281,7 +281,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
                memoryLocation++;
                NewDataIndex = memoryLocation;
                var newRunLength = PCSString.ReadString(Model, run.Start, true);
-               Model.ObserveRunWritten(CurrentChange, new PCSRun(run.Start, newRunLength, run.PointerSources));
+               Model.ObserveRunWritten(CurrentChange, new PCSRun(Model, run.Start, newRunLength, run.PointerSources));
             }
          } else if (run is ArrayRun arrayRun) {
             var offsets = arrayRun.ConvertByteOffsetToArrayOffset(memoryLocation);
@@ -327,7 +327,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
 
                CurrentChange.ChangeData(Model, memoryLocation + 1, 0xFF);
                if (editText == "\\\\") CurrentChange.ChangeData(Model, memoryLocation + 2, 0xFF);
-               run = new PCSRun(run.Start, run.Length + extraBytesNeeded, run.PointerSources);
+               run = new PCSRun(Model, run.Start, run.Length + extraBytesNeeded, run.PointerSources);
                Model.ObserveRunWritten(CurrentChange, run);
             }
          } else if (run is ArrayRun arrayRun) {

--- a/src/HexManiac.Core/ViewModels/Visitors/CompleteEditOperation.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/CompleteEditOperation.cs
@@ -132,7 +132,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          if (quoteCount % 2 != 0) return;
          if (!CurrentText.EndsWith(StringDelimeter.ToString()) && !CurrentText.EndsWith(" ")) return;
          ErrorText = ValidatePlmText(run, quoteCount, out var level, out var move);
-         if (ErrorText != null) return;
+         if (ErrorText != null || move == -1) return;
 
          // part 3: write to the model
          NewDataIndex = memoryLocation + 2;
@@ -164,7 +164,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          (level, move) = (default, default);
          if (quoteCount == 0) {
             var split = CurrentText.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            if (split.Length < 2) return null;
+            if (split.Length < 2) { move = -1; return null; } // user hasn't entered a move yet
+            if (!CurrentText.EndsWith(" ")) { move = -1; return null; } // user is still entering a move
             if (!int.TryParse(split[0], out level) || level < 1 || level > PLMRun.MaxLearningLevel) {
                return $"Could not parse '{split[0]}' as a pokemon level.";
             } else if (!run.TryGetMoveNumber(split[1], out move)) {

--- a/src/HexManiac.Core/ViewModels/Visitors/CompleteEditOperation.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/CompleteEditOperation.cs
@@ -189,8 +189,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
 
          if (fullValue == Pointer.NULL || (0 <= fullValue && fullValue < Model.Count)) {
             if (inArray) {
-               Model.UpdateArrayPointer(CurrentChange, memoryLocation, fullValue);
-               // Tools.Schedule(Tools.TableTool.DataForCurrentRunChanged);
+               UpdateArrayPointer((ArrayRun)currentRun, fullValue);
             } else {
                Model.WritePointer(CurrentChange, memoryLocation, fullValue);
                Model.ObserveRunWritten(CurrentChange, new PointerRun(memoryLocation, sources));
@@ -352,6 +351,19 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
             eggRun = (EggMoveRun)Model.GetNextRun(eggRun.Start);
             eggRun.UpdateLimiter(CurrentChange);
          }
+      }
+
+      private void UpdateArrayPointer(ArrayRun run, int pointerDestination) {
+         var offsets = run.ConvertByteOffsetToArrayOffset(memoryLocation);
+         var segment = run.ElementContent[offsets.SegmentIndex];
+         if (segment is ArrayRunPointerSegment pointerSegment) {
+            if (!pointerSegment.DestinationDataMatchesPointerFormat(Model, CurrentChange, pointerDestination)) {
+               ErrorText = $"This pointer must point to {pointerSegment.InnerFormat} data.";
+               return;
+            }
+         }
+
+         Model.UpdateArrayPointer(CurrentChange, segment, memoryLocation, pointerDestination);
       }
    }
 }

--- a/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
@@ -105,7 +105,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
 
       public void Visit(ErrorPCS pcs, byte data) => Visit((PCS)null, data);
 
-      public void Visit(Ascii ascii, byte data) { }
+      public void Visit(Ascii ascii, byte data) => Results.AddRange(GetFormattedChildren());
 
       public void Visit(Integer integer, byte data) {
          var arrayRun = (ArrayRun)ViewPort.Model.GetNextRun(ViewPort.Tools.TableTool.Address);

--- a/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
@@ -125,6 +125,12 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          Results.AddRange(GetFormattedChildren());
       }
 
+      public void Visit(PlmItem item, byte data) {
+         var point = ViewPort.SelectionStart;
+         Results.Add(new ContextItem("Open In Text Tool", arg => ViewPort.FollowLink(point.X, point.Y)) { ShortcutText = "Ctrl+Click" });
+         Results.AddRange(GetFormattedChildren());
+      }
+
       private IEnumerable<IContextItem> GetTableChildren(ArrayRun array) {
          if (ViewPort.Tools.TableTool.Append.CanExecute(null)) {
             yield return new ContextItem("Extend Table", ViewPort.Tools.TableTool.Append.Execute);

--- a/src/HexManiac.Core/ViewModels/Visitors/ContinueCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/ContinueCellEdit.cs
@@ -84,5 +84,23 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
             specialCharacters.Contains(Input) ||
             char.IsWhiteSpace(Input);
       }
+
+      public void Visit(PlmItem item, byte data) {
+         var specialCharacters = " -"; // double-edge, Vine Whip
+
+         if (!UnderEdit.CurrentText.Contains(" ")) {
+            // before the space, only numbers are allowed
+            Result = char.IsDigit(Input) || Input == ' ';
+         } else if (UnderEdit.CurrentText.EndsWith(" ") && !UnderEdit.CurrentText.Contains(StringDelimeter)) {
+            // directly after the space, can be a quote, a letter, or a digit.
+            Result = Input == StringDelimeter || char.IsLetterOrDigit(Input);
+         } else if (UnderEdit.CurrentText.Contains(StringDelimeter)) {
+            // if there is a quote, accept lots
+            Result = Input == StringDelimeter || char.IsLetterOrDigit(Input) || specialCharacters.Contains(Input);
+         } else {
+            // if there is no quote, accept lots, but not a quote
+            Result = Input == StringDelimeter || char.IsLetterOrDigit(Input) || specialCharacters.Contains(Input);
+         }
+      }
    }
 }

--- a/src/HexManiac.Core/ViewModels/Visitors/DataClear.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/DataClear.cs
@@ -48,5 +48,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
       public void Visit(EggSection section, byte data) => buffer.WriteMultiByteValue(index, 2, currentChange, EggMoveRun.MagicNumber);
 
       public void Visit(EggItem item, byte data) => buffer.WriteMultiByteValue(index, 2, currentChange, 0x0000);
+
+      public void Visit(PlmItem item, byte data) => buffer.WriteMultiByteValue(index, 2, currentChange, 0x0200);
    }
 }

--- a/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
@@ -84,11 +84,13 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
       }
 
       public void Visit(PCS pcs, byte data) {
-         if (Model.GetNextRun(MemoryLocation) is ArrayRun array) {
+         // don't let it start with a space unless it's in quotes (for copy/paste)
+         var run = Model.GetNextRun(MemoryLocation);
+         if (run is ArrayRun array) {
             var offsets = array.ConvertByteOffsetToArrayOffset(MemoryLocation);
-            // don't let it start with a space unless it's in quotes (for copy/paste)
             if (offsets.SegmentStart == MemoryLocation && Input == ' ') return;
          }
+         if (run is PCSRun && run.Start == MemoryLocation && Input == ' ') return;
 
          Result = Input == StringDelimeter || PCSString.PCS.Any(str => str != null && str.StartsWith(Input.ToString()));
       }

--- a/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
@@ -131,5 +131,6 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          NewFormat = new UnderEdit(eggFormat, Input.ToString(), 2, autocomplete);
          Result = true;
       }
+      public void Visit(PlmItem item, byte data) => Result = char.IsDigit(Input);
    }
 }

--- a/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
@@ -131,6 +131,12 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          NewFormat = new UnderEdit(eggFormat, Input.ToString(), 2, autocomplete);
          Result = true;
       }
-      public void Visit(PlmItem item, byte data) => Result = char.IsDigit(Input);
+      public void Visit(PlmItem item, byte data) {
+         Result = char.IsDigit(Input);
+         if (Result) {
+            var autocomplete = AutoCompleteSelectionItem.Generate(Enumerable.Empty<string>(), -1);
+            NewFormat = new UnderEdit(item, Input.ToString(), 2, autocomplete);
+         }
+      }
    }
 }

--- a/src/HexManiac.Tests/ArrayRunTests.cs
+++ b/src/HexManiac.Tests/ArrayRunTests.cs
@@ -190,7 +190,7 @@ namespace HavenSoft.HexManiac.Tests {
          viewPort.FollowLink(0, 0);
 
          Assert.Equal("^pokenames[name\"\"11]", viewPort.AnchorText);
-         Assert.Equal("BULBASAUR", viewPort.Tools.StringTool.Content.Split(new[] { Environment.NewLine }, StringSplitOptions.None).Last());
+         Assert.Equal("BULBASAUR", viewPort.Tools.StringTool.Content.Split(Environment.NewLine).Last());
       }
 
       [Fact]
@@ -212,7 +212,7 @@ namespace HavenSoft.HexManiac.Tests {
 
          Assert.Equal(0, viewPort.Tools.SelectedIndex); // string tool is selected
          Assert.Equal(100, viewPort.Tools.StringTool.Address);
-         var lineCount = viewPort.Tools.StringTool.Content.Split(new[] { Environment.NewLine }, StringSplitOptions.None).Length;
+         var lineCount = viewPort.Tools.StringTool.Content.Split(Environment.NewLine).Length;
          Assert.Equal(6, lineCount);
 
          viewPort.Tools.StringTool.ContentIndex = viewPort.Tools.StringTool.Content.IndexOf("pall");
@@ -283,7 +283,7 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.Equal(0x80, run.Start);
          Assert.Equal("testdata", model.GetAnchorFromAddress(-1, run.Start));
          Assert.Equal(5, ((ArrayRun)run).ElementCount);
-         var lines = viewPort.Tools.StringTool.Content.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+         var lines = viewPort.Tools.StringTool.Content.Split(Environment.NewLine);
          Assert.All(elements, element => Assert.Contains(element, lines));
 
          // assert -> nothing left behind

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -36,7 +36,7 @@ namespace HavenSoft.HexManiac.Tests {
 
          var address = model.GetAddressFromAnchor(noChange, -1, EggMoveRun.PokemonNameTable);
          var run = (ArrayRun)model.GetNextAnchor(address);
-         if (game.Contains("Gaia")) Assert.Equal(914, run.ElementCount);
+         if (game.Contains("Gaia")) Assert.Equal(925, run.ElementCount);
          else Assert.Equal(412, run.ElementCount);
       }
 

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -78,6 +78,14 @@ namespace HavenSoft.HexManiac.Tests {
          if (game.Contains("Clover")) Assert.Equal(156, run.ElementCount);
          else if (game.Contains("Gaia")) Assert.Equal(188, run.ElementCount);
          else Assert.Equal(78, run.ElementCount);
+
+         if (game.Contains("Gaia")) return; // don't validate description text in Gaia, it's actually invalid.
+
+         for (var i = 0; i < run.ElementCount; i++) {
+            address = model.ReadPointer(run.Start + i * 4);
+            var childRun = model.GetNextRun(address);
+            Assert.IsType<PCSRun>(childRun);
+         }
       }
 
       [SkippableTheory]

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -158,6 +158,17 @@ namespace HavenSoft.HexManiac.Tests {
 
       [SkippableTheory]
       [MemberData(nameof(PokemonGames))]
+      public void LvlUpMovesAreFound(string game) {
+         var model = LoadModel(game);
+         var noChange = new NoDataChangeDeltaModel();
+
+         var address = model.GetAddressFromAnchor(noChange, -1, "lvlmoves");
+         var run = (ArrayRun)model.GetNextAnchor(address);
+         Assert.NotNull(run);
+      }
+
+      [SkippableTheory]
+      [MemberData(nameof(PokemonGames))]
       public void MoveDataFound(string game) {
          var model = LoadModel(game);
          var noChange = new NoDataChangeDeltaModel();

--- a/src/HexManiac.Tests/ChangeHistoryTests.cs
+++ b/src/HexManiac.Tests/ChangeHistoryTests.cs
@@ -242,6 +242,8 @@ namespace HavenSoft.HexManiac.Tests {
          var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
 
          viewPort.Edit("^bob\"\" ");
+         var bobRun = model.GetNextRun(0);
+         Assert.Equal(1, bobRun.Length);
 
          // move the selection to force a break in the undo history
          viewPort.SelectionStart = new Point(3, 3);

--- a/src/HexManiac.Tests/HexManiac.Tests.csproj
+++ b/src/HexManiac.Tests/HexManiac.Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="..\..\artifacts\$(AssemblyName)\codegen\StubFileSystem.cs" />
     <Compile Include="..\..\artifacts\$(AssemblyName)\codegen\StubTabContent.cs" />
     <Compile Include="..\..\artifacts\$(AssemblyName)\codegen\StubViewPort.cs" />
+    <Compile Include="NestedTablesTests.cs" />
     <Compile Include="PointerModelTests.cs" />
     <Compile Include="NavigationTests.cs" />
     <Compile Include="StringModelTests.cs" />

--- a/src/HexManiac.Tests/NestedTablesTests.cs
+++ b/src/HexManiac.Tests/NestedTablesTests.cs
@@ -181,6 +181,9 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.Equal(1, format.Level);
          Assert.Equal(2, format.Move);
          Assert.Equal("Two", format.MoveName);
+
+         viewPort.SelectionStart = new Point(1, 0);
+         Assert.True(viewPort.IsSelected(new Point(0, 0)));
       }
 
       private void SetupMoveTable(int start) {

--- a/src/HexManiac.Tests/NestedTablesTests.cs
+++ b/src/HexManiac.Tests/NestedTablesTests.cs
@@ -190,8 +190,8 @@ namespace HavenSoft.HexManiac.Tests {
 
       [Fact]
       public void PlmStreamAutocomplete() {
-         SetupMoveTable(0x20);
-         viewPort.Goto.Execute("000040");
+         SetupMoveTable(0x20); // goes from 20 to 60
+         viewPort.Goto.Execute("000070");
 
          viewPort.Edit("FFFF");
          viewPort.SelectionStart = new Point(0, 0);

--- a/src/HexManiac.Tests/NestedTablesTests.cs
+++ b/src/HexManiac.Tests/NestedTablesTests.cs
@@ -2,6 +2,7 @@
 using HavenSoft.HexManiac.Core.Models.Runs;
 using HavenSoft.HexManiac.Core.ViewModels;
 using HavenSoft.HexManiac.Core.ViewModels.DataFormats;
+using HavenSoft.HexManiac.Core.ViewModels.Tools;
 using System.Collections.Generic;
 using Xunit;
 
@@ -121,6 +122,20 @@ namespace HavenSoft.HexManiac.Tests {
          viewPort.Edit("^table[description<\"\">]4 "); // adding this tries to add a format at the second line, but realizes that it's the wrong format, so it doesn't.
 
          Assert.IsType<None>(viewPort[1, 1].Format); // no PCS format was added
+      }
+
+      [Fact]
+      public void TableToolAllowsEditingTextContent() {
+         viewPort.Edit("FF"); // have to put the FF first, or trying to create a text run will fail
+         viewPort.MoveSelectionStart.Execute(Direction.Left);
+         viewPort.Edit("^text\"\" Some Text\"");
+
+         viewPort.SelectionStart = new Point(0, 4);
+         viewPort.Edit("^table[description<\"\">]4 <000000>"); // note that this auto-scrolls, since a table was created
+         viewPort.FollowLink(0, 0);
+
+         Assert.Equal(2, viewPort.Tools.TableTool.Children.Count);
+         Assert.IsType<TextStreamArrayElementViewModel>(viewPort.Tools.TableTool.Children[1]);
       }
    }
 }

--- a/src/HexManiac.Tests/NestedTablesTests.cs
+++ b/src/HexManiac.Tests/NestedTablesTests.cs
@@ -246,7 +246,7 @@ namespace HavenSoft.HexManiac.Tests {
          viewPort.Edit("<000100><000110><000120><000130><000140><000150><000160><000170>");
 
          // setup data that lvlmoves pointers will point to
-         for (int i = 0x100; i < 0x180; i += 0x10) SetupPlmStream(i, 8, withName: false);
+         for (int i = 0x100; i < 0x180; i += 0x10) SetupPlmStream(i, 6, withName: false);
 
          // add lvlmoves table
          viewPort.Goto.Execute("000000");
@@ -254,6 +254,27 @@ namespace HavenSoft.HexManiac.Tests {
 
          viewPort.Goto.Execute("000110"); // jump to the anchor for Bob's moves
          Assert.EndsWith("| lvlmoves/Bob/data", viewPort.SelectedAddress);
+      }
+
+      [Fact]
+      public void CanSearchForTextWithinPlmStream() {
+         // setup text tables
+         SetupNameTable(0x40);
+         SetupMoveTable(0x80);
+
+         // setup pointers that will eventually be in the lvlmoves table
+         viewPort.Goto.Execute("000000");
+         viewPort.Edit("<000100><000110><000120><000130><000140><000150><000160><000170>");
+
+         // setup data that lvlmoves pointers will point to
+         for (int i = 0x100; i < 0x180; i += 0x10) SetupPlmStream(i, 6, withName: false);
+
+         // add lvlmoves table
+         viewPort.Goto.Execute("000000");
+         viewPort.Edit("^lvlmoves[data<`plm`>]" + EggMoveRun.PokemonNameTable + " ");
+
+         var results = viewPort.Find("Three");
+         Assert.Equal(9, results.Count); // the actual text + entries for the 8 pokemon
       }
 
       // creates a move table that is 0x40 bytes long

--- a/src/HexManiac.Tests/NestedTablesTests.cs
+++ b/src/HexManiac.Tests/NestedTablesTests.cs
@@ -1,0 +1,126 @@
+﻿using HavenSoft.HexManiac.Core.Models;
+using HavenSoft.HexManiac.Core.Models.Runs;
+using HavenSoft.HexManiac.Core.ViewModels;
+using HavenSoft.HexManiac.Core.ViewModels.DataFormats;
+using System.Collections.Generic;
+using Xunit;
+
+namespace HavenSoft.HexManiac.Tests {
+   public class NestedTablesTests {
+      private readonly ViewPort viewPort;
+      private readonly PokemonModel model;
+      private readonly ModelDelta token = new ModelDelta();
+      private readonly byte[] data = new byte[0x200];
+      private readonly List<string> errors = new List<string>();
+
+      public NestedTablesTests() {
+         model = new PokemonModel(data);
+         viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
+         viewPort.OnError += (sender, e) => errors.Add(e);
+      }
+
+      [Fact]
+      public void SupportNestedTextStreams() {
+         // can parse
+         var info = ArrayRun.TryParse(model, "[description<\"\">]4", 0, null, out var table);
+         Assert.False(info.HasError);
+
+         model.ObserveAnchorWritten(token, "table", table);
+
+         // displays pointers
+         viewPort.Goto.Execute("000100");
+         viewPort.Goto.Execute("000000");
+         Assert.IsType<Pointer>(viewPort[4, 0].Format);
+
+         // can't update to point to non-text
+         viewPort.SelectionStart = new Point(5, 0);
+         errors.Clear();
+         viewPort.Edit("000100 "); // expected failure point
+         Assert.Single(errors);
+
+         // can update to point to text
+         viewPort.SelectionStart = new Point(0, 4);
+         viewPort.Edit("FF"); // have to put the FF first, or trying to create a text run will fail
+         viewPort.SelectionStart = new Point(0, 4);
+         viewPort.Edit("^text\"\" Hello World!\"");
+         viewPort.SelectionStart = new Point(5, 0);
+         errors.Clear();
+         viewPort.Edit("000040 ");
+         Assert.Empty(errors);
+
+         // can update to point to null
+         viewPort.SelectionStart = new Point(5, 0);
+         errors.Clear();
+         viewPort.Edit("null ");
+         Assert.Empty(errors);
+      }
+
+      /// <summary>
+      /// The user may want to update a pointer to a location where they know there is text,
+      /// even if there's no text recognized there.
+      /// In this case, there could be a pointer to NoInfoRun, or there could be no pointer at all.
+      /// Either way, accept the change and automatically add the run based on what's pointed to.
+      /// </summary>
+      [Fact]
+      public void SupportChangingPointerToWhereAFormatCouldBe() {
+         viewPort.Edit("FF"); // have to put the FF first, or trying to create a text run will fail
+         viewPort.MoveSelectionStart.Execute(Direction.Left);
+         viewPort.Edit("^text1\"\" Hello World!\"");
+         viewPort.SelectionStart = new Point(0, 0);
+         viewPort.Edit("^ "); // remove the format. So we have text data, but no format for it.
+
+         viewPort.SelectionStart = new Point(0, 2);
+         viewPort.Edit("FF"); // have to put the FF first, or trying to create a text run will fail
+         viewPort.MoveSelectionStart.Execute(Direction.Left);
+         viewPort.Edit("^text2\"\" Other Text\"");
+         viewPort.SelectionStart = new Point(0, 2);
+         viewPort.Edit("^text2 "); // remove the format, but keep the anchor
+
+         viewPort.SelectionStart = new Point(0, 4);
+         viewPort.Edit("^table[description<\"\">]4 ");
+         viewPort.Goto.Execute("000000");  // scroll back: making a table auto-scrolled
+         viewPort.SelectionStart = new Point(0, 4);
+         errors.Clear();
+
+         // test 1: pointing to data that is the right format, but with no anchor, works
+         viewPort.Edit("000000 ");
+         Assert.Empty(errors);
+         Assert.IsType<PCS>(viewPort[1, 0].Format);
+
+         // test 2: pointing to data that is the right format, but with a NoInfo anchor, works
+         viewPort.Edit("text2 ");
+         Assert.Empty(errors);
+         Assert.IsType<PCS>(viewPort[1, 2].Format);
+      }
+
+      /// <summary>
+      /// When a run is added, automatically add children runs as needed.
+      /// Note that removing this run doesn't remove the children run.
+      /// </summary>
+      [Fact]
+      public void SupportAutomaticallyAddingFormatsBasedOnPointerFormat() {
+         viewPort.Edit("FF"); // have to put the FF first, or trying to create a text run will fail
+         viewPort.MoveSelectionStart.Execute(Direction.Left);
+         viewPort.Edit("^text\"\" Some Text\"");
+         viewPort.SelectionStart = new Point(0, 0);
+         viewPort.Edit("^ "); // remove the anchor. Keeps the data though.
+
+         viewPort.SelectionStart = new Point(0, 4);
+         viewPort.Edit("00 00 00 08");
+         viewPort.SelectionStart = new Point(0, 4);
+         viewPort.Edit("^table[description<\"\">]4 "); // adding this should automatically add a format at 000000, since a pointer points there.
+
+         viewPort.Goto.Execute("000000"); // scroll back to top
+         Assert.IsType<PCSRun>(model.GetNextRun(0));
+      }
+
+      [Fact]
+      public void AddTableSuchThatPointerLeadsToBadDataDoesNotAddFormat() {
+         viewPort.Edit("10 00 00 08"); // point to second line, which is all zeros
+         viewPort.SelectionStart = new Point(0, 0);
+         viewPort.Edit("^table[description<\"\">]4 "); // adding this tries to add a format at the second line, but realizes that it's the wrong format, so it doesn't.
+
+         Assert.IsType<None>(viewPort[1, 1].Format); // no PCS format was added
+      }
+   }
+}

--- a/src/HexManiac.Tests/NestedTablesTests.cs
+++ b/src/HexManiac.Tests/NestedTablesTests.cs
@@ -229,6 +229,10 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.Equal(viewPort.Tools.IndexOf(viewPort.Tools.StringTool), viewPort.Tools.SelectedIndex);
          var itemCount = viewPort.Tools.StringTool.Content.Split(Environment.NewLine).Length;
          Assert.Equal(4, itemCount);
+
+         viewPort.Tools.StringTool.ContentIndex = 17; // third line
+         Assert.True(viewPort.IsSelected(new Point(4, 7)));
+         Assert.True(viewPort.IsSelected(new Point(5, 7)));
       }
 
       // creates a move table that is 0x40 bytes long

--- a/src/HexManiac.Tests/NestedTablesTests.cs
+++ b/src/HexManiac.Tests/NestedTablesTests.cs
@@ -1,4 +1,5 @@
-﻿using HavenSoft.HexManiac.Core.Models;
+﻿using HavenSoft.HexManiac.Core;
+using HavenSoft.HexManiac.Core.Models;
 using HavenSoft.HexManiac.Core.Models.Runs;
 using HavenSoft.HexManiac.Core.ViewModels;
 using HavenSoft.HexManiac.Core.ViewModels.DataFormats;
@@ -216,9 +217,35 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.Equal("10 Fou", format.CurrentText);
       }
 
+      [Fact]
+      public void PlmStreamsAppearInTextTool() {
+         SetupMoveTable(0x20);
+         SetupPlmStream(0x70, 4);
+         viewPort.Goto.Execute("000000");
+
+         viewPort.SelectionStart = new Point(2, 7);
+         viewPort.FollowLink(2, 7);
+
+         Assert.Equal(viewPort.Tools.IndexOf(viewPort.Tools.StringTool), viewPort.Tools.SelectedIndex);
+         var itemCount = viewPort.Tools.StringTool.Content.Split(Environment.NewLine).Length;
+         Assert.Equal(4, itemCount);
+      }
+
+      // creates a move table that is 0x40 bytes long
       private void SetupMoveTable(int start) {
          viewPort.Goto.Execute(start.ToString("X6"));
          viewPort.Edit("^" + EggMoveRun.MoveNamesTable + "[name\"\"8]8 Zero\" One\" Two\" Three\" Four\" Five\" Six\" Seven\"");
+      }
+
+      // creates a plm stream named 'stream' that is <0x20 bytes long. Length should be <9.
+      private void SetupPlmStream(int start, int length) {
+         viewPort.Goto.Execute(start.ToString("X6"));
+         viewPort.Edit("FFFF"); // make sure we terminate first. This will move as needed, but it allows us to add the stream cleanly by just editing inline.
+         viewPort.Goto.Execute(start.ToString("X6"));
+         viewPort.Edit("^stream`plm`");
+         for (int i = 0; i < length; i++) {
+            viewPort.Edit($"{i + 1} {i} ");
+         }
       }
    }
 }

--- a/src/HexManiac.Tests/NestedTablesTests.cs
+++ b/src/HexManiac.Tests/NestedTablesTests.cs
@@ -139,7 +139,7 @@ namespace HavenSoft.HexManiac.Tests {
          viewPort.FollowLink(0, 0);
 
          Assert.Equal(2, viewPort.Tools.TableTool.Children.Count);
-         Assert.IsType<TextStreamArrayElementViewModel>(viewPort.Tools.TableTool.Children[1]);
+         Assert.IsType<StreamArrayElementViewModel>(viewPort.Tools.TableTool.Children[1]);
       }
 
       [Fact]
@@ -151,7 +151,7 @@ namespace HavenSoft.HexManiac.Tests {
          viewPort.SelectionStart = new Point(0, 4);
          viewPort.Edit("^table[description<\"\">]4 <000000>"); // note that this auto-scrolls, since a table was created
          viewPort.SelectionStart = new Point(0, 0);
-         var textViewModel = (TextStreamArrayElementViewModel)viewPort.Tools.TableTool.Children[1];
+         var textViewModel = (StreamArrayElementViewModel)viewPort.Tools.TableTool.Children[1];
 
          // act: use the tool to change the content, forcing a repoint
          messages.Clear();

--- a/src/HexManiac.Tests/PointerModelTests.cs
+++ b/src/HexManiac.Tests/PointerModelTests.cs
@@ -139,7 +139,7 @@ namespace HavenSoft.HexManiac.Tests {
          viewPort.SelectionStart = new Point(0, 2);
          viewPort.Edit("^bob ");
 
-         Assert.IsType<Core.ViewModels.DataFormats.Anchor>(viewPort[0, 2].Format);
+         Assert.IsType<Anchor>(viewPort[0, 2].Format);
          Assert.Equal(0x8, viewPort[0, 2].Value);
       }
 
@@ -725,6 +725,22 @@ namespace HavenSoft.HexManiac.Tests {
          viewPort.Edit("^test3 ");
          Assert.IsType<Pointer>(viewPort[0x2, 0x0].Format);
          Assert.Single(((Anchor)viewPort[0x2, 0xA].Format).Sources);
+      }
+
+      [Fact]
+      public void ReplacingAPointerWithAnAnchorKeepsKnowledgeOfThatPointer() {
+         StandardSetup(out var data, out var model, out var viewPort);
+         viewPort.Edit("<000040><000040><000040>");
+         viewPort.Goto.Execute("000004");
+         viewPort.Edit("^bob "); // adding the anchor will remove the pointer
+
+         Assert.Equal(3, model.GetNextRun(0x40).PointerSources.Count); // since the pointer was removed, the anchor should only have 2 things pointing to it.
+      }
+
+      private void StandardSetup(out byte[] data, out PokemonModel model, out ViewPort viewPort) {
+         data = new byte[0x200];
+         model = new PokemonModel(data);
+         viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
       }
    }
 }

--- a/src/HexManiac.Tests/StringModelTests.cs
+++ b/src/HexManiac.Tests/StringModelTests.cs
@@ -18,7 +18,7 @@ namespace HavenSoft.HexManiac.Tests {
 
          var data = PCSString.Convert("Hello World!").ToArray();
          Array.Copy(data, 0, buffer, 0x10, data.Length);
-         model.ObserveRunWritten(token, new PCSRun(0x10, data.Length));
+         model.ObserveRunWritten(token, new PCSRun(model, 0x10, data.Length));
 
          var run = (PCSRun)model.GetNextRun(0);
          Assert.Equal(data.Length, run.Length);

--- a/src/HexManiac.Tests/ToolTests.cs
+++ b/src/HexManiac.Tests/ToolTests.cs
@@ -178,7 +178,7 @@ namespace HavenSoft.HexManiac.Tests {
 
          // Assert: Text Tool is updated
          viewPort.Tools.SelectedIndex = Enumerable.Range(0, 10).First(i => viewPort.Tools[i] == viewPort.Tools.StringTool);
-         var textToolContent = viewPort.Tools.StringTool.Content.Split(new[] { Environment.NewLine }, StringSplitOptions.None)[1];
+         var textToolContent = viewPort.Tools.StringTool.Content.Split(Environment.NewLine)[1];
          Assert.Equal("Larry", textToolContent);
       }
 

--- a/src/HexManiac.WPF/Controls/TabView.xaml
+++ b/src/HexManiac.WPF/Controls/TabView.xaml
@@ -129,7 +129,7 @@
                            <ComboBox SelectedIndex="{Binding SelectedIndex}" ItemsSource="{Binding Options}" Grid.Column="1"/>
                         </Grid>
                      </DataTemplate>
-                     <DataTemplate DataType="{x:Type hsg3hvmtr:TextStreamArrayElementViewModel}">
+                     <DataTemplate DataType="{x:Type hsg3hvmtr:StreamArrayElementViewModel}">
                         <TextBox Text="{Binding Content, UpdateSourceTrigger=PropertyChanged}" Margin="20,2,2,2" AcceptsReturn="True"/>
                      </DataTemplate>
                   </ItemsControl.Resources>

--- a/src/HexManiac.WPF/Controls/TabView.xaml
+++ b/src/HexManiac.WPF/Controls/TabView.xaml
@@ -129,6 +129,9 @@
                            <ComboBox SelectedIndex="{Binding SelectedIndex}" ItemsSource="{Binding Options}" Grid.Column="1"/>
                         </Grid>
                      </DataTemplate>
+                     <DataTemplate DataType="{x:Type hsg3hvmtr:TextStreamArrayElementViewModel}">
+                        <TextBox Text="{Binding Content, UpdateSourceTrigger=PropertyChanged}" Margin="20,2,2,2" AcceptsReturn="True"/>
+                     </DataTemplate>
                   </ItemsControl.Resources>
                </ItemsControl>
             </StackPanel>

--- a/src/HexManiac.WPF/Implementations/FormatDrawer.cs
+++ b/src/HexManiac.WPF/Implementations/FormatDrawer.cs
@@ -165,6 +165,22 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
          context.Pop();
       }
 
+      public void Visit(PlmItem item, byte data) {
+         if (item.Position != 0) return;
+         var content = item.ToString();
+
+         var text = CreateText(content, FontSize * 3 / 4, Brush(nameof(Theme.Stream2)));
+
+         // center the text
+         var characterWidth = text.Width / content.Length;
+         var xOffset = HexContent.CellWidth - content.Length * characterWidth / 2;
+         if (xOffset < 0) xOffset = 0;
+
+         context.PushClip(new RectangleGeometry(new Rect(0, 0, HexContent.CellWidth * 2, HexContent.CellHeight)));
+         context.DrawText(text, new Point(xOffset, CellTextOffset.Y + 2));
+         context.Pop();
+      }
+
       private void Underline(Brush brush, bool isStart, bool isEnd) {
          int startPoint = isStart ? 5 : 0;
          int endPoint = (int)HexContent.CellWidth - (isEnd ? 5 : 0);

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -6,5 +6,5 @@
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.2.1.0")]
-[assembly: AssemblyFileVersion("0.2.1.0")]
+[assembly: AssemblyVersion("0.2.2.0")]
+[assembly: AssemblyFileVersion("0.2.2.0")]


### PR DESCRIPTION
Level-up moves are stored in streams, which I've labeled PLM (Pokemon Levelup Moves) as a shorthand. Each stream is made of a number of tokens. Each token is 2 bytes long. The token is either FFFF, representing the end of the stream, or a 7-bit 9-bit pair of level and move. The levels are generally between 1 and 100 (though some fan games use pokemon at higher levels or have extra spaces for moves learned at level 101) and the moves are entries in the `movenames` table.

Since each pokemon's level-up moves are stored in a separate stream, the game stores the list off all the streams as a pointer table, which I've named `lvlmoves`. This required the added feature for pointers in a table to point to a stream of a known type. Right now, the supported options are pcs (text) or plm (level-up moves). So this PR also adds support for tables pointing to text streams.

Also in this PR, I fixed a major bug in the Runs in the Model. The model assumes that runs are stored in order and are non-overlapping, and the model assumes that every pointer leads to an anchor, and the locations in an anchor's source list are only pointers. These assumptions were only validated once, after initial setup. Those assumptions are now checked far more frequently (in debug mode) and this allowed me to find some places where the assumption was being broken.