### PR TITLE
Support for Move Tutors

### DIFF
--- a/src/HexManiac.Core/HexManiac.Core.csproj
+++ b/src/HexManiac.Core/HexManiac.Core.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Models\Runs\HeaderRow.cs" />
     <Compile Include="Models\Runs\ModelCacheScope.cs" />
     <Compile Include="Models\Runs\PLMRun.cs" />
+    <Compile Include="Models\Runs\WordRun.cs" />
     <Compile Include="ViewModels\AutoCompleteSelectionItem.cs" />
     <Compile Include="ViewModels\Tools\CodeTool.cs" />
     <Compile Include="ViewModels\Visitors\CompleteEditOperation.cs" />

--- a/src/HexManiac.Core/HexManiac.Core.csproj
+++ b/src/HexManiac.Core/HexManiac.Core.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Models\Runs\PLMRun.cs" />
     <Compile Include="Models\Runs\WordRun.cs" />
     <Compile Include="ViewModels\AutoCompleteSelectionItem.cs" />
+    <Compile Include="ViewModels\IQuickEditItem.cs" />
     <Compile Include="ViewModels\Tools\CodeTool.cs" />
     <Compile Include="ViewModels\Visitors\CompleteEditOperation.cs" />
     <Compile Include="ViewModels\Visitors\ContextItemFactory.cs" />

--- a/src/HexManiac.Core/Models/AutoSearchModel.cs
+++ b/src/HexManiac.Core/Models/AutoSearchModel.cs
@@ -14,6 +14,10 @@ namespace HavenSoft.HexManiac.Core.Models {
          FireRed = "BPRE",
          LeafGreen = "BPGE";
 
+      public const string
+         MoveTutors = "tutormoves",
+         TutorCompatibility = "tutorcompatibility";
+
       private readonly string gameCode;
       private readonly ModelDelta noChangeDelta = new NoDataChangeDeltaModel();
 
@@ -158,10 +162,10 @@ namespace HavenSoft.HexManiac.Core.Models {
             tutorCompatibility = ReadPointer(list[0] + originalCode.Length);
             if (tutorMoves < 0 || tutorMoves > Count || tutorCompatibility < 0 || tutorCompatibility > Count) return;
             if (list.Count != 1) return;
-            if (!TryParse(this, "[move:movenames]15", tutorMoves, null, out var tutorMovesRun).HasError) {
-               ObserveAnchorWritten(noChangeDelta, "tutormoves", tutorMovesRun);
-               if (!TryParse(this, "[pokemon|b[]tutormoves]pokenames", tutorCompatibility, null, out var tutorCompatibilityRun).HasError) {
-                  ObserveAnchorWritten(noChangeDelta, "tutorcompatibility", tutorCompatibilityRun);
+            if (!TryParse(this, $"[move:{EggMoveRun.MoveNamesTable}]15", tutorMoves, null, out var tutorMovesRun).HasError) {
+               ObserveAnchorWritten(noChangeDelta, MoveTutors, tutorMovesRun);
+               if (!TryParse(this, $"[pokemon|b[]{MoveTutors}]{EggMoveRun.PokemonNameTable}", tutorCompatibility, null, out var tutorCompatibilityRun).HasError) {
+                  ObserveAnchorWritten(noChangeDelta, TutorCompatibility, tutorCompatibilityRun);
                }
             }
          } else if (gameCode == Emerald) {
@@ -169,10 +173,10 @@ namespace HavenSoft.HexManiac.Core.Models {
             tutorMoves = ReadPointer(0x1B236C);
             tutorCompatibility = ReadPointer(0x1B2390);
             if (tutorMoves < 0 || tutorMoves > Count || tutorCompatibility < 0 || tutorCompatibility > Count) return;
-            if (!TryParse(this, "[move:movenames]30", tutorMoves, null, out var tutorMovesRun).HasError) {
-               ObserveAnchorWritten(noChangeDelta, "tutormoves", tutorMovesRun);
-               if (!TryParse(this, "[pokemon|b[]tutormoves]pokenames", tutorCompatibility, null, out var tutorCompatibilityRun).HasError) {
-                  ObserveAnchorWritten(noChangeDelta, "tutorcompatibility", tutorCompatibilityRun);
+            if (!TryParse(this, $"[move:{EggMoveRun.MoveNamesTable}]30", tutorMoves, null, out var tutorMovesRun).HasError) {
+               ObserveAnchorWritten(noChangeDelta, MoveTutors, tutorMovesRun);
+               if (!TryParse(this, $"[pokemon|b[]{MoveTutors}]{EggMoveRun.PokemonNameTable}", tutorCompatibility, null, out var tutorCompatibilityRun).HasError) {
+                  ObserveAnchorWritten(noChangeDelta, TutorCompatibility, tutorCompatibilityRun);
                }
             }
          }

--- a/src/HexManiac.Core/Models/AutoSearchModel.cs
+++ b/src/HexManiac.Core/Models/AutoSearchModel.cs
@@ -1,5 +1,6 @@
 ﻿using HavenSoft.HexManiac.Core.Models.Runs;
 using HavenSoft.HexManiac.Core.ViewModels.DataFormats;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using static HavenSoft.HexManiac.Core.Models.Runs.ArrayRun;
@@ -130,8 +131,59 @@ namespace HavenSoft.HexManiac.Core.Models {
             ObserveAnchorWritten(noChangeDelta, "lvlmoves", lvlMoveData);
          }
 
+         FindTutorMoveAnchors();
+
          // @3D4294 ^itemicons[image<> palette<>]items
          // @4886E8 ^movedescriptions[description<>]354
+      }
+
+      private void FindTutorMoveAnchors() {
+         int tutorMoves, tutorCompatibility;
+         if (gameCode == FireRed || gameCode == LeafGreen) {
+            var originalCode = new byte[] {
+               0x00, 0xB5, 0x00, 0x04, 0x00, 0x0C, 0x09, 0x06,
+               0x0A, 0x0E, 0x10, 0x2A, 0x0A, 0xD0, 0x10, 0x2A,  // This is the thumb code for the tutor compatibility check.
+               0x02, 0xDC, 0x0F, 0x2A, 0x03, 0xD0, 0x0B, 0xE0,  // It's the exact same in both FireRed and LeafGreen, but in different places.
+               0x11, 0x2A, 0x06, 0xD0, 0x08, 0xE0, 0x03, 0x28,  // If I find this not tampered with, then it's probably the original.
+               0x14, 0xD0, 0x0E, 0xE0, 0x06, 0x28, 0x11, 0xD0,  // More so, it's bookended by two pointers.
+               0x0B, 0xE0, 0x09, 0x28, 0x0E, 0xD0, 0x08, 0xE0,  // Directly before this is tutormoves.
+               0x05, 0x49, 0x40, 0x00, 0x40, 0x18, 0x00, 0x88,  // Directly after this is tutorcompatibility.
+               0x10, 0x41, 0x01, 0x21, 0x08, 0x40, 0x00, 0x28,
+               0x04, 0xD1, 0x00, 0x20, 0x03, 0xE0, 0x00, 0x00,
+            };
+
+            var list = Find(originalCode, 0x120B00, 0x120C00);
+            tutorMoves = ReadPointer(list[0] - 4);
+            tutorCompatibility = ReadPointer(list[0] + originalCode.Length);
+            if (tutorMoves < 0 || tutorMoves > Count || tutorCompatibility < 0 || tutorCompatibility > Count) return;
+            if (list.Count != 1) return;
+            if (!TryParse(this, "[move:movenames]15", tutorMoves, null, out var tutorMovesRun).HasError) {
+               ObserveAnchorWritten(noChangeDelta, "tutormoves", tutorMovesRun);
+               if (!TryParse(this, "[pokemon|b[]tutormoves]pokenames", tutorCompatibility, null, out var tutorCompatibilityRun).HasError) {
+                  ObserveAnchorWritten(noChangeDelta, "tutorcompatibility", tutorCompatibilityRun);
+               }
+            }
+         } else if (gameCode == Emerald) {
+            // these two addresses are supposed to have pointers to tutormoves / tutorcompatibility
+            tutorMoves = ReadPointer(0x1B236C);
+            tutorCompatibility = ReadPointer(0x1B2390);
+            if (tutorMoves < 0 || tutorMoves > Count || tutorCompatibility < 0 || tutorCompatibility > Count) return;
+            if (!TryParse(this, "[move:movenames]30", tutorMoves, null, out var tutorMovesRun).HasError) {
+               ObserveAnchorWritten(noChangeDelta, "tutormoves", tutorMovesRun);
+               if (!TryParse(this, "[pokemon|b[]tutormoves]pokenames", tutorCompatibility, null, out var tutorCompatibilityRun).HasError) {
+                  ObserveAnchorWritten(noChangeDelta, "tutorcompatibility", tutorCompatibilityRun);
+               }
+            }
+         }
+      }
+
+      private IList<int> Find(byte[] subset, int start, int end) {
+         var results = new List<int>();
+         for (int i = start; i < end; i++) {
+            bool match = Enumerable.Range(0, subset.Length).All(j => this[i + j] == subset[j]);
+            if (match) results.Add(i);
+         }
+         return results;
       }
 
       private void DecodeStreams() {

--- a/src/HexManiac.Core/Models/AutoSearchModel.cs
+++ b/src/HexManiac.Core/Models/AutoSearchModel.cs
@@ -153,6 +153,7 @@ namespace HavenSoft.HexManiac.Core.Models {
             };
 
             var list = Find(originalCode, 0x120B00, 0x120C00);
+            if (list.Count == 0) return;
             tutorMoves = ReadPointer(list[0] - 4);
             tutorCompatibility = ReadPointer(list[0] + originalCode.Length);
             if (tutorMoves < 0 || tutorMoves > Count || tutorCompatibility < 0 || tutorCompatibility > Count) return;

--- a/src/HexManiac.Core/Models/IDataModel.cs
+++ b/src/HexManiac.Core/Models/IDataModel.cs
@@ -220,7 +220,9 @@ namespace HavenSoft.HexManiac.Core.Models {
       }
 
       public static IReadOnlyList<AutoCompleteSelectionItem> GetNewWordAutocompleteOptions(this IDataModel model, string text, int selectedIndex) {
-         var options = model.GetAutoCompleteAnchorNameOptions(text.Substring(2));
+         if (text.Length >= 2) text = text.Substring(2);
+         else return null;
+         var options = model.GetAutoCompleteAnchorNameOptions(text);
          options = options.Select(option => $"::{option} ").ToList();
          return AutoCompleteSelectionItem.Generate(options, selectedIndex);
       }

--- a/src/HexManiac.Core/Models/IDataModel.cs
+++ b/src/HexManiac.Core/Models/IDataModel.cs
@@ -34,7 +34,7 @@ namespace HavenSoft.HexManiac.Core.Models {
 
       void ObserveRunWritten(ModelDelta changeToken, IFormattedRun run);
       void ObserveAnchorWritten(ModelDelta changeToken, string anchorName, IFormattedRun run);
-      void MassUpdateFromDelta(IReadOnlyDictionary<int, IFormattedRun> runsToRemove, IReadOnlyDictionary<int, IFormattedRun> runsToAdd, IReadOnlyDictionary<int, string> namesToRemove, IReadOnlyDictionary<int, string> namesToAdd, IReadOnlyDictionary<int, string> unmappedPointersToRemove, IReadOnlyDictionary<int, string> unmappedPointersToAdd);
+      void MassUpdateFromDelta(IReadOnlyDictionary<int, IFormattedRun> runsToRemove, IReadOnlyDictionary<int, IFormattedRun> runsToAdd, IReadOnlyDictionary<int, string> namesToRemove, IReadOnlyDictionary<int, string> namesToAdd, IReadOnlyDictionary<int, string> unmappedPointersToRemove, IReadOnlyDictionary<int, string> unmappedPointersToAdd, IReadOnlyDictionary<int, string> matchedWordsToRemove, IReadOnlyDictionary<int, string> matchedWordsToAdd);
       IFormattedRun RelocateForExpansion(ModelDelta changeToken, IFormattedRun run, int minimumLength);
       void ClearFormat(ModelDelta changeToken, int start, int length);
       void ClearFormatAndData(ModelDelta changeToken, int start, int length);
@@ -107,7 +107,7 @@ namespace HavenSoft.HexManiac.Core.Models {
 
       public abstract void ObserveRunWritten(ModelDelta changeToken, IFormattedRun run);
 
-      public abstract void MassUpdateFromDelta(IReadOnlyDictionary<int, IFormattedRun> runsToRemove, IReadOnlyDictionary<int, IFormattedRun> runsToAdd, IReadOnlyDictionary<int, string> namesToRemove, IReadOnlyDictionary<int, string> namesToAdd, IReadOnlyDictionary<int, string> unmappedPointersToRemove, IReadOnlyDictionary<int, string> unmappedPointersToAdd);
+      public abstract void MassUpdateFromDelta(IReadOnlyDictionary<int, IFormattedRun> runsToRemove, IReadOnlyDictionary<int, IFormattedRun> runsToAdd, IReadOnlyDictionary<int, string> namesToRemove, IReadOnlyDictionary<int, string> namesToAdd, IReadOnlyDictionary<int, string> unmappedPointersToRemove, IReadOnlyDictionary<int, string> unmappedPointersToAdd, IReadOnlyDictionary<int, string> matchedWordsToRemove, IReadOnlyDictionary<int, string> matchedWordsToAdd);
 
       public abstract IFormattedRun RelocateForExpansion(ModelDelta changeToken, IFormattedRun run, int minimumLength);
 
@@ -219,6 +219,12 @@ namespace HavenSoft.HexManiac.Core.Models {
          return AutoCompleteSelectionItem.Generate(options, selectedIndex);
       }
 
+      public static IReadOnlyList<AutoCompleteSelectionItem> GetNewWordAutocompleteOptions(this IDataModel model, string text, int selectedIndex) {
+         var options = model.GetAutoCompleteAnchorNameOptions(text.Substring(2));
+         options = options.Select(option => $"::{option} ").ToList();
+         return AutoCompleteSelectionItem.Generate(options, selectedIndex);
+      }
+
       // wraps an IDataFormat in an anchor format, if it makes sense
       public static IDataFormat WrapFormat(this IDataModel model, IFormattedRun run, IDataFormat format, int dataIndex) {
          if (run.PointerSources != null && run.Start == dataIndex) {
@@ -298,7 +304,7 @@ namespace HavenSoft.HexManiac.Core.Models {
       public override bool IsAtEndOfArray(int dataIndex, out ArrayRun arrayRun) { arrayRun = null; return false; }
       public override void ObserveRunWritten(ModelDelta changeToken, IFormattedRun run) { }
       public override void ObserveAnchorWritten(ModelDelta changeToken, string anchorName, IFormattedRun run) { }
-      public override void MassUpdateFromDelta(IReadOnlyDictionary<int, IFormattedRun> runsToRemove, IReadOnlyDictionary<int, IFormattedRun> runsToAdd, IReadOnlyDictionary<int, string> namesToRemove, IReadOnlyDictionary<int, string> namesToAdd, IReadOnlyDictionary<int, string> unmappedPointersToRemove, IReadOnlyDictionary<int, string> unmappedPointersToAdd) { }
+      public override void MassUpdateFromDelta(IReadOnlyDictionary<int, IFormattedRun> runsToRemove, IReadOnlyDictionary<int, IFormattedRun> runsToAdd, IReadOnlyDictionary<int, string> namesToRemove, IReadOnlyDictionary<int, string> namesToAdd, IReadOnlyDictionary<int, string> unmappedPointersToRemove, IReadOnlyDictionary<int, string> unmappedPointersToAdd, IReadOnlyDictionary<int, string> matchedWordsToRemove, IReadOnlyDictionary<int, string> matchedWordsToAdd) { }
       public override IFormattedRun RelocateForExpansion(ModelDelta changeToken, IFormattedRun run, int minimumLength) => throw new NotImplementedException();
       public override void ClearFormat(ModelDelta changeToken, int start, int length) { }
       public override void ClearFormatAndData(ModelDelta changeToken, int start, int length) {

--- a/src/HexManiac.Core/Models/IDataModel.cs
+++ b/src/HexManiac.Core/Models/IDataModel.cs
@@ -286,11 +286,16 @@ namespace HavenSoft.HexManiac.Core.Models {
 
       /// <summary>
       /// Returns all arrays from the model with a length that depends on the parent array.
+      /// Also returns any array with a BitArraySegment that depends on the parent array.
       /// </summary>
-      public static IEnumerable<ArrayRun> GetDependantArrays(this IDataModel model, ArrayRun parent) {
-         var anchor = model.GetAnchorFromAddress(-1, parent.Start);
+      public static IEnumerable<ArrayRun> GetDependantArrays(this IDataModel model, string anchor) {
          foreach (var array in model.Arrays) {
             if (array.LengthFromAnchor == anchor) yield return array;
+            foreach (var segment in array.ElementContent) {
+               if (segment is ArrayRunBitArraySegment bitSegment) {
+                  if (bitSegment.SourceArrayName == anchor) yield return array;
+               }
+            }
          }
       }
    }

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -62,6 +62,16 @@ namespace HavenSoft.HexManiac.Core.Models {
             if (!unmappedNameToSources.ContainsKey(unmappedPointer.Name)) unmappedNameToSources[unmappedPointer.Name] = new List<int>();
             unmappedNameToSources[unmappedPointer.Name].Add(unmappedPointer.Address);
          }
+         foreach (var word in metadata.MatchedWords) {
+            if (!matchedWords.ContainsKey(word.Name)) matchedWords.Add(word.Name, new List<int>());
+            matchedWords[word.Name].Add(word.Address);
+            var index = BinarySearch(word.Address);
+            if (index > 0) {
+               runs[index] = new WordRun(word.Address, word.Name, runs[index].PointerSources);
+            } else {
+               runs.Insert(~index, new WordRun(word.Address, word.Name));
+            }
+         }
       }
 
       /// <summary>

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -1023,13 +1023,21 @@ namespace HavenSoft.HexManiac.Core.Models {
             anchors.Add(new StoredAnchor(address, name, format));
          }
 
-         var unmappedPointers = new List<StoredUnmappedPointers>();
+         var unmappedPointers = new List<StoredUnmappedPointer>();
          foreach (var kvp in sourceToUnmappedName) {
             var (address, name) = (kvp.Key, kvp.Value);
-            unmappedPointers.Add(new StoredUnmappedPointers(address, name));
+            unmappedPointers.Add(new StoredUnmappedPointer(address, name));
          }
 
-         return new StoredMetadata(anchors, unmappedPointers);
+         var matchedWords = new List<StoredMatchedWord>();
+         foreach (var kvp in this.matchedWords) {
+            var name = kvp.Key;
+            foreach (var address in kvp.Value) {
+               matchedWords.Add(new StoredMatchedWord(address, name));
+            }
+         }
+
+         return new StoredMetadata(anchors, unmappedPointers, matchedWords);
       }
 
       /// <summary>

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -748,6 +748,10 @@ namespace HavenSoft.HexManiac.Core.Models {
             if (run.Start >= start + length) return;
             if (run is PointerRun) ClearPointerFormat(null, changeToken, run.Start);
             if (run is ArrayRun arrayRun) ModifyAnchorsFromPointerArray(changeToken, arrayRun, ClearPointerFormat);
+            if (run is WordRun wordRun) {
+               changeToken.RemoveMatchedWord(wordRun.Start, wordRun.SourceArrayName);
+               matchedWords[wordRun.SourceArrayName].Remove(wordRun.Start);
+            }
 
             ClearAnchorFormat(changeToken, originalStart, run);
 

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -338,6 +338,15 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          return new ArrayRun(owner, newFormat, LengthFromAnchor, Start, ElementCount + elementCount, ElementContent, PointerSources, PointerSourcesForInnerElements);
       }
 
+      public ArrayRun GrowBitArraySegment(int bitSegmentIndex, int additionalBytes) {
+         // all the data has been moved already
+         // just return a new ArrayRun with the desired change.
+         var content = ElementContent.ToList();
+         var oldSegment = (ArrayRunBitArraySegment)content[bitSegmentIndex];
+         content[bitSegmentIndex] = new ArrayRunBitArraySegment(oldSegment.Name, oldSegment.Length + additionalBytes, oldSegment.SourceArrayName);
+         return new ArrayRun(owner, FormatString, LengthFromAnchor, Start, ElementCount, content, PointerSources, PointerSourcesForInnerElements);
+      }
+
       public ArrayRun AddSourcePointingWithinArray(int source) {
          var destination = owner.ReadPointer(source);
          var index = (destination - Start) / ElementLength;

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -99,7 +99,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          if (!format.StartsWith(ArrayStart.ToString()) || closeArray == -1) throw new ArrayRunParseException($"Array Content must be wrapped in {ArrayStart}{ArrayEnd}.");
          var segments = format.Substring(1, closeArray - 1);
          var length = format.Substring(closeArray + 1);
-         ElementContent = ParseSegments(segments);
+         ElementContent = ParseSegments(segments, data);
          if (ElementContent.Count == 0) throw new ArrayRunParseException("Array Content must not be empty.");
          ElementLength = ElementContent.Sum(e => e.Length);
 
@@ -162,7 +162,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          if (!format.StartsWith(ArrayStart.ToString()) || closeArray == -1) throw new ArrayRunParseException($"Array Content must be wrapped in {ArrayStart}{ArrayEnd}");
          var segments = format.Substring(1, closeArray - 1);
          var length = format.Substring(closeArray + 1);
-         var elementContent = ParseSegments(segments);
+         var elementContent = ParseSegments(segments, data);
          if (elementContent.Count == 0) return false;
          var elementLength = elementContent.Sum(e => e.Length);
 
@@ -329,6 +329,10 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
             return new Pointer(offsets.SegmentStart, position, destination, destinationName);
          }
 
+         if (currentSegment.Type == ElementContentType.BitArray) {
+            return new BitArray(offsets.SegmentStart, position, currentSegment.Length);
+         }
+
          throw new NotImplementedException();
       }
 
@@ -478,7 +482,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          return new ArrayRun(owner, FormatString, LengthFromAnchor, Start, ElementCount, ElementContent, newPointerSources, newInnerPointerSources);
       }
 
-      private static List<ArrayRunElementSegment> ParseSegments(string segments) {
+      private static List<ArrayRunElementSegment> ParseSegments(string segments, IDataModel model) {
          var list = new List<ArrayRunElementSegment>();
          segments = segments.Trim();
          while (segments.Length > 0) {
@@ -487,7 +491,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
             var name = segments.Substring(0, nameEnd);
             if (name == string.Empty) throw new ArrayRunParseException("expected name, but none was found: " + segments);
             segments = segments.Substring(nameEnd);
-            var (format, formatLength, segmentLength) = ExtractSingleFormat(segments);
+            var (format, formatLength, segmentLength) = ExtractSingleFormat(segments, model);
 
             // check to see if a name or length is part of the format
             if (format == ElementContentType.Integer && segments.Length > formatLength && segments[formatLength] != ' ') {
@@ -506,6 +510,10 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
                if (!pointerSegment.IsInnerFormatValid) throw new ArrayRunParseException($"pointer format '{pointerSegment.InnerFormat}' was not understood.");
                list.Add(pointerSegment);
                segments = segments.Substring(formatLength).Trim();
+            } else if (format == ElementContentType.BitArray) {
+               var sourceName = segments.Substring(BitArray.SharedFormatString.Length, formatLength - BitArray.SharedFormatString.Length);
+               segments = segments.Substring(formatLength).Trim();
+               list.Add(new ArrayRunBitArraySegment(name, segmentLength, sourceName));
             } else {
                segments = segments.Substring(formatLength).Trim();
                if (format == ElementContentType.Unknown) {
@@ -520,8 +528,8 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          return list;
       }
 
-      private static (ElementContentType format, int formatLength, int segmentLength) ExtractSingleFormat(string segments) {
-         if (segments.Length >= 2 && segments.Substring(0, 2) == PCSRun.StringDelimeter + string.Empty + PCSRun.StringDelimeter) {
+      private static (ElementContentType format, int formatLength, int segmentLength) ExtractSingleFormat(string segments, IDataModel model) {
+         if (segments.Length >= 2 && segments.Substring(0, 2) == PCSRun.SharedFormatString) {
             var format = ElementContentType.PCS;
             var formatLength = 2;
             while (formatLength < segments.Length && char.IsDigit(segments[formatLength])) formatLength++;
@@ -546,6 +554,14 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
             }
             if (openCount > 0) return (ElementContentType.Unknown, 0, 0);
             return (ElementContentType.Pointer, endIndex, 4);
+         } else if (segments.StartsWith(BitArray.SharedFormatString)) {
+            var endIndex = BitArray.SharedFormatString.Length;
+            while (segments.Length > endIndex && char.IsLetterOrDigit(segments[endIndex])) endIndex++;
+            var format = segments.Substring(0, endIndex);
+            var name = format.Substring(BitArray.SharedFormatString.Length);
+            var options = ModelCacheScope.GetCache(model).GetBitOptions(name);
+            var count = options?.Count ?? 8;
+            return (ElementContentType.BitArray, format.Length, (int)Math.Ceiling(count / 8.0));
          }
 
          return (ElementContentType.Unknown, 0, 0);
@@ -620,6 +636,14 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
                   if (!pointerSegment.DestinationDataMatchesPointerFormat(owner, new NoDataChangeDeltaModel(), destination)) return false;
                }
                return true;
+            case ElementContentType.BitArray:
+               var bitArraySegment = (ArrayRunBitArraySegment)segment;
+               var bits = bitArraySegment.GetOptions(owner).Count;
+               bits %= 8;
+               if (bits == 0) return true;
+               var finalByte = owner[start + bitArraySegment.Length - 1];
+               finalByte >>= bits;
+               return finalByte == 0; // all the unneeded bits should be set to zero
             default:
                throw new NotImplementedException();
          }

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -144,7 +144,9 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
 
       public static ErrorInfo TryParse(IDataModel data, string format, int start, IReadOnlyList<int> pointerSources, out ArrayRun self) {
          try {
-            self = new ArrayRun(data, format, start, pointerSources);
+            using (ModelCacheScope.CreateScope(data)) {
+               self = new ArrayRun(data, format, start, pointerSources);
+            }
          } catch (ArrayRunParseException e) {
             self = null;
             return new ErrorInfo(e.Message);

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace HavenSoft.HexManiac.Core.Models.Runs {
    public enum ElementContentType {
@@ -9,6 +10,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       PCS,
       Integer,
       Pointer,
+      BitArray,
    }
 
    public class ArrayRunElementSegment {
@@ -148,6 +150,28 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       }
 
       public void ClearCache() { cachedOptions = null; }
+   }
+
+   public class ArrayRunBitArraySegment : ArrayRunElementSegment {
+      public string SourceArrayName { get; }
+
+      public ArrayRunBitArraySegment(string name, int length, string bitSourceName) : base(name, ElementContentType.BitArray, length) {
+         SourceArrayName = bitSourceName;
+      }
+
+      public override string ToText(IDataModel rawData, int offset) {
+         var result = new StringBuilder(Length * 3);
+         for (int i = 0; i < Length; i++) {
+            result.Append(rawData[offset + i].ToString("X2"));
+            result.Append(" ");
+         }
+         return result.ToString();
+      }
+
+      public IReadOnlyList<string> GetOptions(IDataModel model) {
+         var cache = ModelCacheScope.GetCache(model);
+         return cache.GetBitOptions(SourceArrayName);
+      }
    }
 
    /// <summary>

--- a/src/HexManiac.Core/Models/Runs/PLMRun.cs
+++ b/src/HexManiac.Core/Models/Runs/PLMRun.cs
@@ -110,12 +110,12 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
             if (!int.TryParse(parts[0], out var level)) level = 0;
             var moveName = parts.Length == 1 ? "0" : parts[1];
 
-            var index = moveNames.IndexOf(line);
+            var index = moveNames.IndexOf(moveName);
             if (index != -1) { data.Add(CombineToken(level, index)); continue; }
 
             // look for a partial move match
             for (int i = 0; i < moveNames.Count; i++) {
-               if (moveNames[i].Contains(line)) { data.Add(CombineToken(level, index)); break; }
+               if (moveNames[i].MatchesPartial(moveName)) { data.Add(CombineToken(level, i)); break; }
             }
          }
 

--- a/src/HexManiac.Core/Models/Runs/WordRun.cs
+++ b/src/HexManiac.Core/Models/Runs/WordRun.cs
@@ -1,0 +1,18 @@
+﻿using HavenSoft.HexManiac.Core.ViewModels.DataFormats;
+using System.Collections.Generic;
+
+namespace HavenSoft.HexManiac.Core.Models.Runs {
+   public class WordRun : BaseRun {
+      public string SourceArrayName { get; }
+
+      public override int Length => 4;
+
+      public override string FormatString => "::";
+
+      public WordRun(int start, string name, IReadOnlyList<int> sources = null) : base(start, sources) => SourceArrayName = name;
+
+      public override IDataFormat CreateDataFormat(IDataModel data, int index) => new MatchedWord(Start, index - Start, "::" + SourceArrayName);
+
+      protected override IFormattedRun Clone(IReadOnlyList<int> newPointerSources) => new WordRun(Start, SourceArrayName, newPointerSources);
+   }
+}

--- a/src/HexManiac.Core/SystemExtensions.cs
+++ b/src/HexManiac.Core/SystemExtensions.cs
@@ -26,7 +26,7 @@ namespace HavenSoft.HexManiac.Core {
 
       public static int IndexOf<T>(this IReadOnlyList<T> list, T element) where T : class {
          for (int i = 0; i < list.Count; i++) {
-            if (list[i] == element) return i;
+            if (list[i].Equals(element)) return i;
          }
          return -1;
       }

--- a/src/HexManiac.Core/ViewModels/ConvertCellToText.cs
+++ b/src/HexManiac.Core/ViewModels/ConvertCellToText.cs
@@ -54,5 +54,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       public void Visit(PlmItem item, byte data) => Result = item.ToString();
 
       public void Visit(BitArray array, byte data) => Visit((None)null, data);
+
+      public void Visit(MatchedWord word, byte data) => Visit((None)null, data);
    }
 }

--- a/src/HexManiac.Core/ViewModels/ConvertCellToText.cs
+++ b/src/HexManiac.Core/ViewModels/ConvertCellToText.cs
@@ -52,5 +52,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       public void Visit(EggItem item, byte data) => Result = item.ItemName;
 
       public void Visit(PlmItem item, byte data) => Result = item.ToString();
+
+      public void Visit(BitArray array, byte data) => Visit((None)null, data);
    }
 }

--- a/src/HexManiac.Core/ViewModels/DataFormats.cs
+++ b/src/HexManiac.Core/ViewModels/DataFormats.cs
@@ -31,6 +31,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.DataFormats {
       void Visit(EggSection section, byte data);
       void Visit(EggItem item, byte data);
       void Visit(PlmItem item, byte data);
+      void Visit(BitArray array, byte data);
    }
 
    /// <summary>
@@ -289,5 +290,21 @@ namespace HavenSoft.HexManiac.Core.ViewModels.DataFormats {
       public bool Equals(IDataFormat other) => ToString() == other.ToString();
 
       public void Visit(IDataFormatVisitor visitor, byte data) => visitor.Visit(this, data);
+   }
+
+   public class BitArray : IDataFormatInstance {
+      public int Source { get; }
+
+      public int Position { get; }
+
+      public bool Equals(IDataFormat other) {
+         var that = other as BitArray;
+         if (that == null) return false;
+         return Source == that.Source && Position == that.Position;
+      }
+
+      public void Visit(IDataFormatVisitor visitor, byte data) {
+         visitor.Visit(this, data);
+      }
    }
 }

--- a/src/HexManiac.Core/ViewModels/DataFormats.cs
+++ b/src/HexManiac.Core/ViewModels/DataFormats.cs
@@ -294,8 +294,10 @@ namespace HavenSoft.HexManiac.Core.ViewModels.DataFormats {
 
    public class BitArray : IDataFormatInstance {
       public int Source { get; }
-
       public int Position { get; }
+      public int Length { get; }
+
+      public BitArray(int source, int position, int length) => (Source, Position, Length) = (source, position, length);
 
       public bool Equals(IDataFormat other) {
          var that = other as BitArray;

--- a/src/HexManiac.Core/ViewModels/DataFormats.cs
+++ b/src/HexManiac.Core/ViewModels/DataFormats.cs
@@ -293,6 +293,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels.DataFormats {
    }
 
    public class BitArray : IDataFormatInstance {
+      public static readonly string SharedFormatString = "|b[]";
+
       public int Source { get; }
       public int Position { get; }
       public int Length { get; }

--- a/src/HexManiac.Core/ViewModels/DataFormats.cs
+++ b/src/HexManiac.Core/ViewModels/DataFormats.cs
@@ -32,6 +32,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.DataFormats {
       void Visit(EggItem item, byte data);
       void Visit(PlmItem item, byte data);
       void Visit(BitArray array, byte data);
+      void Visit(MatchedWord word, byte data);
    }
 
    /// <summary>
@@ -303,6 +304,24 @@ namespace HavenSoft.HexManiac.Core.ViewModels.DataFormats {
 
       public bool Equals(IDataFormat other) {
          var that = other as BitArray;
+         if (that == null) return false;
+         return Source == that.Source && Position == that.Position;
+      }
+
+      public void Visit(IDataFormatVisitor visitor, byte data) {
+         visitor.Visit(this, data);
+      }
+   }
+
+   public class MatchedWord : IDataFormatInstance {
+      public int Source { get; }
+      public int Position { get; }
+      public string Name { get; }
+
+      public MatchedWord(int source, int position, string name) => (Source, Position, Name) = (source, position, name);
+
+      public bool Equals(IDataFormat other) {
+         var that = other as MatchedWord;
          if (that == null) return false;
          return Source == that.Source && Position == that.Position;
       }

--- a/src/HexManiac.Core/ViewModels/EditorViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/EditorViewModel.cs
@@ -368,7 +368,10 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          SelectedIndex = tabs.Count - 1;
          CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, content));
          AddContentListeners(content);
-         if (content is IViewPort viewModel) viewModel.UseCustomHeaders = useTableEntryHeaders;
+         if (content is IViewPort viewModel) {
+            viewModel.UseCustomHeaders = useTableEntryHeaders;
+            viewModel.ValidateMatchedWords();
+         }
       }
 
       public void SwapTabs(int a, int b) {

--- a/src/HexManiac.Core/ViewModels/EditorViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/EditorViewModel.cs
@@ -175,6 +175,10 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
       public IToolTrayViewModel Tools => (SelectedTab as IViewPort)?.Tools;
 
+      public IReadOnlyList<IQuickEditItem> QuickEdits { get; } = new List<IQuickEditItem> {
+         new MakeTutorsExpandable(),
+      };
+
       public event EventHandler<Action> RequestDelayedWork;
 
       public event EventHandler MoveFocusToFind;
@@ -245,6 +249,11 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          var zoomLine = metadata.FirstOrDefault(line => line.StartsWith("ZoomLevel ="));
          if (zoomLine != null && int.TryParse(zoomLine.Split('=').Last().Trim(), out var zoomLevel)) ZoomLevel = zoomLevel;
       }
+
+      public static ICommand Wrap(IQuickEditItem quickEdit) => new StubCommand {
+         CanExecute = arg => quickEdit.CanRun((IViewPort)arg),
+         Execute = arg => quickEdit.Run((IViewPort)arg),
+      };
 
       public void WriteAppLevelMetadata() {
          var metadata = new List<string>();

--- a/src/HexManiac.Core/ViewModels/EditorViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/EditorViewModel.cs
@@ -201,6 +201,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                   findPrevious.CanExecuteChanged.Invoke(findPrevious, EventArgs.Empty);
                   findNext.CanExecuteChanged.Invoke(findNext, EventArgs.Empty);
                   UpdateGotoViewModel();
+                  foreach (var edit in QuickEdits) edit.TabChanged();
                }
             }
          }

--- a/src/HexManiac.Core/ViewModels/IQuickEditItem.cs
+++ b/src/HexManiac.Core/ViewModels/IQuickEditItem.cs
@@ -1,0 +1,112 @@
+﻿using HavenSoft.HexManiac.Core.Models;
+using HavenSoft.HexManiac.Core.ViewModels.DataFormats;
+using System;
+using System.Linq;
+
+namespace HavenSoft.HexManiac.Core.ViewModels {
+   public interface IQuickEditItem {
+      string Name { get; }
+      string Description { get; }
+
+      bool CanRun(IViewPort viewPort);
+      ErrorInfo Run(IViewPort viewPort);
+   }
+
+   public class MakeTutorsExpandable : IQuickEditItem {
+      public string Name => "Make Tutors Expandable";
+      public string Description => "The initial games limited to have exactly 18 (FireRed) or no more than 32 (Emerald) tutors." +
+               Environment.NewLine + "This change will allow you to freely add new tutors, up to 256.";
+
+      public bool CanRun(IViewPort viewPortInterface) {
+         // require that I have a tab with real data, not a search tab or a diff tab or something
+         if (!(viewPortInterface is ViewPort viewPort)) return false;
+
+         // require that this data actually supports this change
+         var model = viewPort.Model;
+         var (getTutorMove, canPokemonLearnTutorMove, getTutorMove_Length, canPokemonLearnTutorMove_Length) = GetOffsets(viewPort);
+         if (getTutorMove < 0 || canPokemonLearnTutorMove < 0) return false;
+
+         // require that this data has a tutormoves and tutorcompatibility table, since we're messing with those
+         var tutormoves = model.GetAddressFromAnchor(viewPort.CurrentChange, -1, "tutormoves");
+         var tutorcompatibility = model.GetAddressFromAnchor(viewPort.CurrentChange, -1, "tutorcompatibility");
+         if (tutormoves == Pointer.NULL || tutorcompatibility == Pointer.NULL) {
+            return false;
+         }
+
+         // if the patch has already been applied, you can't apply it again
+         if (viewPort.Model.GetNextRun(canPokemonLearnTutorMove + 0x20) is MatchedWord) return false;
+         return true;
+      }
+
+      public ErrorInfo Run(IViewPort viewPortInterface) {
+         var viewPort = (ViewPort)viewPortInterface;
+         var model = viewPort.Model;
+         var (getTutorMove, canPokemonLearnTutorMove, getTutorMove_Length, canPokemonLearnTutorMove_Length) = GetOffsets(viewPort);
+         var tutormoves = model.GetAddressFromAnchor(viewPort.CurrentChange, -1, "tutormoves");
+         var tutorcompatibility = model.GetAddressFromAnchor(viewPort.CurrentChange, -1, "tutorcompatibility");
+
+         InsertRoutine_GetTutorMove(viewPort, getTutorMove, getTutorMove_Length);
+         InsertRoutine_CanPokemonLearnTutorMove(viewPort, canPokemonLearnTutorMove, canPokemonLearnTutorMove_Length);
+
+         return ErrorInfo.NoError;
+      }
+
+      public static (int getTutorMove, int canPokemonLearnTutorMove, int getTutorMove_Length, int canPokemonLearnTutorMove_Length) GetOffsets(ViewPort viewPort) {
+         var model = viewPort.Model;
+         var gameCode = new string(Enumerable.Range(0xAC, 4).Select(i => ((char)model[i])).ToArray());
+         if (gameCode == "BPRE") {
+            return (0x120BA8, 0x120BE8, 0x40, 0x54);
+         } else if (gameCode == "BPGE") {
+            return (0x120B80, 0x120BC0, 0x40, 0x54);
+         } else if (gameCode == "BPEE") {
+            return (0x1B2360, 0x1B2370, 0x10, 0x2C);
+         } else {
+            return (-1, -1, 0, 0);
+         }
+      }
+
+      private void InsertRoutine_GetTutorMove(ViewPort viewPort, int address, int originalLength) {
+         /*
+         GetTutorMove(index)
+             lsl   r0, r0, #1            @ 00000_00001_000_000   0040
+             ldr   r1, =move_tutor_list  @ 01001_001_00000001    4901
+             ldrh  r0, [r0, r1]          @ 0101101_001_000_000   5A40
+             bx    lr                    @ 010001110_1_110_000   4770
+         move_tutor_list:
+             .word <tutormoves>
+         */
+
+         viewPort.Edit($"@{address:X6} 40 00 01 49 40 5A 70 47 <tutormoves> "); // new data only 0xC long
+         for (int i = 0x0C; i < originalLength; i++) viewPort.Edit("00 ");
+      }
+
+      private void InsertRoutine_CanPokemonLearnTutorMove(ViewPort viewPort, int address, int originalLength) {
+         /*
+         CanPokemonLearnTutorMove(pokemon, tutor_move)
+             ldr     r2, =move_tutor_count          @ 01001_010_00000111    4A07
+             add     r2, #7                         @ 00110_010_00000111    3207
+             lsr     r2, r2, #3                     @ 00001_00011_010_010   08D2
+             mul     r0, r2                         @ 0100001101_010_000    4350
+             lsr     r2, r1, #3                     @ 00001_00011_001_010   08CA
+             add     r0, r0, r2                     @ 0001100_010_000_000   1880
+             mov     r2, #7                         @ 00100_010_00000111    2207
+             and     r1, r2                         @ 0100000000_010_001    4011
+             ldr     r2, =move_tutor_compatibility  @ 01001_010_00000010    4A02
+             ldrb    r0, [r2, r0]                   @ 0101110_000_010_000   5C10
+             lsr     r0, r1                         @ 0100000011_001_000    40C8
+             mov     r2, #1                         @ 00100_010_00000001    2201
+             and     r0, r2                         @ 0100000000_010_000    4010
+             bx      lr                             @ 010001110_1_110_000   4770
+         move_tutor_compatibility:
+             .word <tutorcompatibility>
+         move_tutor_count:
+             .word ::tutormoves
+         */
+         viewPort.Edit($"@{address:X6} ");
+         viewPort.Edit("07 4A 07 32 D2 08 50 43 CA 08 80 18 07 22 11 40 ");
+         viewPort.Edit("02 4A 10 5C C8 40 01 22 10 40 70 47 ");
+         viewPort.Edit("<tutorcompatibility> ::tutormoves ");  // new data only 0x24 long
+         for (int i = 0x24; i < originalLength; i++) viewPort.Edit("00 ");
+      }
+   }
+}

--- a/src/HexManiac.Core/ViewModels/IQuickEditItem.cs
+++ b/src/HexManiac.Core/ViewModels/IQuickEditItem.cs
@@ -3,6 +3,8 @@ using HavenSoft.HexManiac.Core.ViewModels.DataFormats;
 using System;
 using System.Linq;
 
+using static HavenSoft.HexManiac.Core.Models.AutoSearchModel;
+
 namespace HavenSoft.HexManiac.Core.ViewModels {
    public interface IQuickEditItem {
       string Name { get; }
@@ -27,8 +29,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          if (getTutorMove < 0 || canPokemonLearnTutorMove < 0) return false;
 
          // require that this data has a tutormoves and tutorcompatibility table, since we're messing with those
-         var tutormoves = model.GetAddressFromAnchor(viewPort.CurrentChange, -1, "tutormoves");
-         var tutorcompatibility = model.GetAddressFromAnchor(viewPort.CurrentChange, -1, "tutorcompatibility");
+         var tutormoves = model.GetAddressFromAnchor(viewPort.CurrentChange, -1, MoveTutors);
+         var tutorcompatibility = model.GetAddressFromAnchor(viewPort.CurrentChange, -1, TutorCompatibility);
          if (tutormoves == Pointer.NULL || tutorcompatibility == Pointer.NULL) {
             return false;
          }
@@ -42,8 +44,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          var viewPort = (ViewPort)viewPortInterface;
          var model = viewPort.Model;
          var (getTutorMove, canPokemonLearnTutorMove, getTutorMove_Length, canPokemonLearnTutorMove_Length) = GetOffsets(viewPort);
-         var tutormoves = model.GetAddressFromAnchor(viewPort.CurrentChange, -1, "tutormoves");
-         var tutorcompatibility = model.GetAddressFromAnchor(viewPort.CurrentChange, -1, "tutorcompatibility");
+         var tutormoves = model.GetAddressFromAnchor(viewPort.CurrentChange, -1, MoveTutors);
+         var tutorcompatibility = model.GetAddressFromAnchor(viewPort.CurrentChange, -1, TutorCompatibility);
 
          InsertRoutine_GetTutorMove(viewPort, getTutorMove, getTutorMove_Length);
          InsertRoutine_CanPokemonLearnTutorMove(viewPort, canPokemonLearnTutorMove, canPokemonLearnTutorMove_Length);
@@ -54,11 +56,11 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       public static (int getTutorMove, int canPokemonLearnTutorMove, int getTutorMove_Length, int canPokemonLearnTutorMove_Length) GetOffsets(ViewPort viewPort) {
          var model = viewPort.Model;
          var gameCode = new string(Enumerable.Range(0xAC, 4).Select(i => ((char)model[i])).ToArray());
-         if (gameCode == "BPRE") {
+         if (gameCode == FireRed) {
             return (0x120BA8, 0x120BE8, 0x40, 0x54);
-         } else if (gameCode == "BPGE") {
+         } else if (gameCode == LeafGreen) {
             return (0x120B80, 0x120BC0, 0x40, 0x54);
-         } else if (gameCode == "BPEE") {
+         } else if (gameCode == Emerald) {
             return (0x1B2360, 0x1B2370, 0x10, 0x2C);
          } else {
             return (-1, -1, 0, 0);
@@ -76,7 +78,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
              .word <tutormoves>
          */
 
-         viewPort.Edit($"@{address:X6} 40 00 01 49 40 5A 70 47 <tutormoves> "); // new data only 0xC long
+         viewPort.Edit($"@{address:X6} 40 00 01 49 40 5A 70 47 <{MoveTutors}> "); // new data only 0xC long
          for (int i = 0x0C; i < originalLength; i++) viewPort.Edit("00 ");
       }
 
@@ -105,7 +107,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          viewPort.Edit($"@{address:X6} ");
          viewPort.Edit("07 4A 07 32 D2 08 50 43 CA 08 80 18 07 22 11 40 ");
          viewPort.Edit("02 4A 10 5C C8 40 01 22 10 40 70 47 ");
-         viewPort.Edit("<tutorcompatibility> ::tutormoves ");  // new data only 0x24 long
+         viewPort.Edit($"<{TutorCompatibility}> ::{MoveTutors} ");  // new data only 0x24 long
          for (int i = 0x24; i < originalLength; i++) viewPort.Edit("00 ");
       }
    }

--- a/src/HexManiac.Core/ViewModels/IQuickEditItem.cs
+++ b/src/HexManiac.Core/ViewModels/IQuickEditItem.cs
@@ -1,4 +1,5 @@
 ﻿using HavenSoft.HexManiac.Core.Models;
+using HavenSoft.HexManiac.Core.Models.Runs;
 using HavenSoft.HexManiac.Core.ViewModels.DataFormats;
 using System;
 using System.Linq;
@@ -10,14 +11,18 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       string Name { get; }
       string Description { get; }
 
+      event EventHandler CanRunChanged;
       bool CanRun(IViewPort viewPort);
       ErrorInfo Run(IViewPort viewPort);
+      void TabChanged();
    }
 
    public class MakeTutorsExpandable : IQuickEditItem {
       public string Name => "Make Tutors Expandable";
       public string Description => "The initial games limited to have exactly 18 (FireRed) or no more than 32 (Emerald) tutors." +
                Environment.NewLine + "This change will allow you to freely add new tutors, up to 256.";
+
+      public event EventHandler CanRunChanged;
 
       public bool CanRun(IViewPort viewPortInterface) {
          // require that I have a tab with real data, not a search tab or a diff tab or something
@@ -36,7 +41,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          }
 
          // if the patch has already been applied, you can't apply it again
-         if (viewPort.Model.GetNextRun(canPokemonLearnTutorMove + 0x20) is MatchedWord) return false;
+         if (viewPort.Model.GetNextRun(canPokemonLearnTutorMove + 0x20) is WordRun) return false;
          return true;
       }
 
@@ -50,8 +55,12 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          InsertRoutine_GetTutorMove(viewPort, getTutorMove, getTutorMove_Length);
          InsertRoutine_CanPokemonLearnTutorMove(viewPort, canPokemonLearnTutorMove, canPokemonLearnTutorMove_Length);
 
+         CanRunChanged?.Invoke(this, EventArgs.Empty);
+
          return ErrorInfo.NoError;
       }
+
+      public void TabChanged() => CanRunChanged?.Invoke(this, EventArgs.Empty);
 
       public static (int getTutorMove, int canPokemonLearnTutorMove, int getTutorMove_Length, int canPokemonLearnTutorMove_Length) GetOffsets(ViewPort viewPort) {
          var model = viewPort.Model;

--- a/src/HexManiac.Core/ViewModels/IViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/IViewPort.cs
@@ -38,6 +38,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       void ExpandSelection(int x, int y);
       void ConsiderReload(IFileSystem fileSystem);
       void FindAllSources(int x, int y);
+      void ValidateMatchedWords(); // should raise OnMessage if a MatchedWord's value does not match expected.
 
       bool HasTools { get; }
       IToolTrayViewModel Tools { get; }

--- a/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
@@ -26,7 +26,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          get {
             var (childIndex, line) = GetChildLine(y);
             if (line < 0 && x == 3 && childIndex < children.Count && firstChildToUseParent[children[childIndex].Parent] == childIndex) {
-               return new HexElement(0, new PCS(-1, 1, string.Empty, "Results from " + children[childIndex].FileName));
+               return new HexElement(0, new UnderEdit(null, "Results from " + children[childIndex].FileName, width));
             }
             if (line < 0 || childIndex >= children.Count) return HexElement.Undefined;
 

--- a/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
@@ -203,6 +203,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          children[childIndex].FindAllSources(x, y);
       }
 
+      public void ValidateMatchedWords() { }
+
       public IReadOnlyList<IContextItem> GetContextMenuItems(Point selectionPoint) {
          return new[] { new ContextItem("Open in Main Tab", arg => {
             FollowLink(selectionPoint.X, selectionPoint.Y);

--- a/src/HexManiac.Core/ViewModels/Selection.cs
+++ b/src/HexManiac.Core/ViewModels/Selection.cs
@@ -131,14 +131,16 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                var address = args.ToString().Trim();
                if (address.StartsWith(PointerRun.PointerStart.ToString())) address = address.Substring(1);
                if (address.EndsWith(PointerRun.PointerEnd.ToString())) address = address.Substring(0, address.Length - 1);
-               var anchor = model.GetAddressFromAnchor(new ModelDelta(), -1, address);
-               if (anchor != Pointer.NULL) {
-                  GotoAddress(anchor);
-               } else if (int.TryParse(address, NumberStyles.HexNumber, CultureInfo.CurrentCulture, out int result)) {
-                  if (result >= BaseModel.PointerOffset) result -= BaseModel.PointerOffset;
-                  GotoAddress(result);
-               } else {
-                  OnError?.Invoke(this, $"Unable to goto address '{address}'");
+               var anchor = this.model.GetAddressFromAnchor(new ModelDelta(), -1, address);
+               using (ModelCacheScope.CreateScope(this.model)) {
+                  if (anchor != Pointer.NULL) {
+                     GotoAddress(anchor);
+                  } else if (int.TryParse(address, NumberStyles.HexNumber, CultureInfo.CurrentCulture, out int result)) {
+                     if (result >= BaseModel.PointerOffset) result -= BaseModel.PointerOffset;
+                     GotoAddress(result);
+                  } else {
+                     OnError?.Invoke(this, $"Unable to goto address '{address}'");
+                  }
                }
             },
          };

--- a/src/HexManiac.Core/ViewModels/Selection.cs
+++ b/src/HexManiac.Core/ViewModels/Selection.cs
@@ -225,18 +225,20 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
             preferredWidth = DefaultPreferredWidth;
          }
 
-         var startAddress = address;
-         if (!destinationIsArray && preferredWidth > 1) address -= address % preferredWidth;
+         using (ModelCacheScope.CreateScope(model)) {
+            var startAddress = address;
+            if (!destinationIsArray && preferredWidth > 1) address -= address % preferredWidth;
 
-         // first, change the selection and scroll to select the actual requested address
-         SelectionStart = Scroll.DataIndexToViewPoint(startAddress);
-         Scroll.ScrollValue += selectionStart.Y;
+            // first, change the selection and scroll to select the actual requested address
+            SelectionStart = Scroll.DataIndexToViewPoint(startAddress);
+            Scroll.ScrollValue += selectionStart.Y;
 
-         // then, scroll left/right as needed to align everything
-         while (Scroll.DataIndex < address) Scroll.Scroll.Execute(Direction.Right);
-         while (Scroll.DataIndex > address) Scroll.Scroll.Execute(Direction.Left);
+            // then, scroll left/right as needed to align everything
+            while (Scroll.DataIndex < address) Scroll.Scroll.Execute(Direction.Right);
+            while (Scroll.DataIndex > address) Scroll.Scroll.Execute(Direction.Left);
 
-         PreferredWidth = preferredWidth;
+            PreferredWidth = preferredWidth;
+         }
       }
 
       /// <summary>

--- a/src/HexManiac.Core/ViewModels/Theme.cs
+++ b/src/HexManiac.Core/ViewModels/Theme.cs
@@ -77,6 +77,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          var brightnessTravel = .6 + .3 * highlightBrightness;
          hsbHighlightDark.sat *= .8;
          hsbHighlightDark.bright = 1 - brightnessTravel;
+         if (hsbPrimary.bright < hsbBackground.bright) hsbHighlightDark.bright = brightnessTravel;
          Backlight = hsbHighlightDark.ToRgb().ToHexString();
 
          hsbHighlightLight.sat = 0;
@@ -100,6 +101,9 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          Accent = accent[5].ToRgb().ToHexString();
          Text2 = accent[6].ToRgb().ToHexString();
          Stream1 = accent[7].ToRgb().ToHexString();
+
+         NotifyPropertyChanged(nameof(Primary));
+         NotifyPropertyChanged(nameof(Background));
       }
 
       private string secondary, backlight;

--- a/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
@@ -262,10 +262,11 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
 
          var destination = model.ReadPointer(start);
 
-         // by the time we get this far, we're guaranteed that this will be a PCSRun.
-         // if it's not a PCSRun, we shouldn't have asked to construct this object.
+         // by the time we get this far, we're nearly guaranteed that this will be a IStreamRun.
+         // if it's not an IStreamRun, it's because the pointer in the array doesn't actually point to a valid stream.
+         // at which point, we don't want to display any content.
          var run = (IStreamRun)model.GetNextRun(destination);
-         content = run.SerializeRun();
+         content = run.SerializeRun() ?? string.Empty;
       }
    }
 

--- a/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
@@ -315,6 +315,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
       public void UpdateModelFromView() {
          var result = children.Select((child, i) => child.IsChecked ? 1 << i : 0).Sum();
          model.WriteMultiByteValue(start, segment.Length, history.CurrentChange, result);
+         DataChanged?.Invoke(this, EventArgs.Empty);
       }
 
       public void UpdateViewFromModel() {

--- a/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
@@ -2,9 +2,12 @@
 using HavenSoft.HexManiac.Core.Models.Runs;
 using HavenSoft.HexManiac.Core.ViewModels.DataFormats;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
+using System.Linq;
 
 namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
    public enum ElementContentViewModelType {
@@ -263,6 +266,82 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
          // if it's not a PCSRun, we shouldn't have asked to construct this object.
          var run = (IStreamRun)model.GetNextRun(destination);
          content = run.SerializeRun();
+      }
+   }
+
+   public class BitListArrayElementViewModel : ViewModelCore, IReadOnlyList<BitElement>, IArrayElementViewModel {
+      private readonly ChangeHistory<ModelDelta> history;
+      private readonly IDataModel model;
+      private readonly string name;
+      private readonly int start;
+      private readonly List<BitElement> children = new List<BitElement>();
+      private readonly ArrayRunBitArraySegment segment;
+
+      public bool IsInError => !string.IsNullOrEmpty(ErrorText);
+      public string ErrorText { get; private set; }
+
+      public event EventHandler DataChanged;
+
+      public BitListArrayElementViewModel(ChangeHistory<ModelDelta> history, IDataModel model, string name, int start) {
+         this.history = history;
+         this.model = model;
+         this.name = name;
+         this.start = start;
+
+         var array = (ArrayRun)model.GetNextRun(start);
+         var offset = array.ConvertByteOffsetToArrayOffset(start);
+         segment = (ArrayRunBitArraySegment)array.ElementContent[offset.SegmentIndex];
+         var bits = model.ReadMultiByteValue(start, segment.Length);
+         var names = segment.GetOptions(model);
+         for (int i = 0; i < names.Count; i++) {
+            var element = new BitElement {
+               BitLabel = names[i],
+               IsChecked = ((bits >> i) & 1) != 0,
+            };
+            children.Add(element);
+            element.PropertyChanged += ChildChanged;
+         }
+      }
+
+      #region IReadOnlyList<BitElement> Implementation
+
+      public int Count => children.Count;
+      public BitElement this[int index] => children[index];
+      public IEnumerator<BitElement> GetEnumerator() => children.GetEnumerator();
+      IEnumerator IEnumerable.GetEnumerator() => children.GetEnumerator();
+
+      #endregion
+
+      public void UpdateModelFromView() {
+         var result = children.Select((child, i) => child.IsChecked ? 1 << i : 0).Sum();
+         model.WriteMultiByteValue(start, segment.Length, history.CurrentChange, result);
+      }
+
+      public void UpdateViewFromModel() {
+         var bits = model.ReadMultiByteValue(start, segment.Length);
+         for (int i = 0; i < children.Count; i++) {
+            children[i].PropertyChanged -= ChildChanged;
+            children[i].IsChecked = ((bits >> i) & 1) != 0;
+            children[i].PropertyChanged += ChildChanged;
+         }
+      }
+
+      private void ChildChanged(object sender, PropertyChangedEventArgs e) {
+         UpdateModelFromView();
+      }
+   }
+
+   public class BitElement : ViewModelCore {
+      private string bitLabel;
+      public string BitLabel {
+         get => bitLabel;
+         set => TryUpdate(ref bitLabel, value);
+      }
+
+      private bool isChecked;
+      public bool IsChecked {
+         get => isChecked;
+         set => TryUpdate(ref isChecked, value);
       }
    }
 }

--- a/src/HexManiac.Core/ViewModels/Tools/TableTool.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/TableTool.cs
@@ -150,6 +150,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
             if (item.Type == ElementContentType.Unknown) viewModel = new FieldArrayElementViewModel(history, model, item.Name, itemAddress, item.Length, new HexFieldStratgy());
             else if (item.Type == ElementContentType.PCS) viewModel = new FieldArrayElementViewModel(history, model, item.Name, itemAddress, item.Length, new TextFieldStratgy());
             else if (item.Type == ElementContentType.Pointer) viewModel = new FieldArrayElementViewModel(history, model, item.Name, itemAddress, item.Length, new AddressFieldStratgy());
+            else if (item.Type == ElementContentType.BitArray) viewModel = new BitListArrayElementViewModel(history, model, item.Name, itemAddress);
             else if (item.Type == ElementContentType.Integer) {
                if (item is ArrayRunEnumSegment enumSegment) {
                   viewModel = new ComboBoxArrayElementViewModel(history, model, item.Name, itemAddress, item.Length);

--- a/src/HexManiac.Core/ViewModels/Tools/TableTool.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/TableTool.cs
@@ -164,7 +164,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
             viewModel.DataChanged += ForwardModelChanged;
             if (item is ArrayRunPointerSegment pointerSegment) {
                var destination = model.ReadPointer(itemAddress);
-               if (destination != Pointer.NULL && pointerSegment.DestinationDataMatchesPointerFormat(model, new NoDataChangeDeltaModel(), destination)) {
+               if (destination != Pointer.NULL && model.GetNextRun(destination) is IStreamRun && pointerSegment.DestinationDataMatchesPointerFormat(model, new NoDataChangeDeltaModel(), destination)) {
                   if (pointerSegment.InnerFormat == PCSRun.SharedFormatString || pointerSegment.InnerFormat == PLMRun.SharedFormatString) {
                      var streamElement = new StreamArrayElementViewModel(history, (FieldArrayElementViewModel)viewModel, model, item.Name, itemAddress);
                      streamElement.DataChanged += ForwardModelChanged;

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -238,6 +238,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
       private readonly ChangeHistory<ModelDelta> history;
 
+      public ModelDelta CurrentChange => history.CurrentChange;
+
       public ICommand Undo => history.Undo;
 
       public ICommand Redo => history.Redo;

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -1147,7 +1147,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
          var offset = array.ConvertByteOffsetToArrayOffset(index);
          var type = array.ElementContent[offset.SegmentIndex].Type;
-         if (type == ElementContentType.Pointer || type == ElementContentType.Integer) {
+         if (type == ElementContentType.Pointer || type == ElementContentType.Integer || type == ElementContentType.BitArray) {
             return pair(offset.SegmentStart, offset.SegmentStart + array.ElementContent[offset.SegmentIndex].Length - 1);
          }
 

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -1066,6 +1066,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                var plmRun = (PLMRun)Model.GetNextRun(((IDataFormatInstance)originalFormat).Source);
                var allOptions = plmRun.GetAutoCompleteOptions(newText.Split(' ')[0]);
                return AutoCompleteSelectionItem.Generate(allOptions.Where(option => option.MatchesPartial(moveName)), selectedIndex);
+            } else if (newText.StartsWith(":")) {
+               return Model.GetNewWordAutocompleteOptions(newText, selectedIndex);
             } else {
                throw new NotImplementedException();
             }

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -247,7 +247,9 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       private ModelDelta RevertChanges(ModelDelta changes) {
          var reverse = changes.Revert(Model);
          var point = scroll.DataIndexToViewPoint(reverse.EarliestChange);
-         if (!scroll.ScrollToPoint(ref point)) RefreshBackingData();
+         using (ModelCacheScope.CreateScope(Model)) {
+            if (!scroll.ScrollToPoint(ref point)) RefreshBackingData();
+         }
          return reverse;
       }
 

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -1026,6 +1026,22 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          RequestMenuClose?.Invoke(this, EventArgs.Empty);
       }
 
+      public void ValidateMatchedWords() {
+         // TODO if this is too slow, add a method to the model to get the set of only MatchedWordRuns.
+         for (var run = Model.GetNextRun(0); run != NoInfoRun.NullRun; run = Model.GetNextRun(run.Start + run.Length)) {
+            if (!(run is WordRun wordRun)) continue;
+            var address = Model.GetAddressFromAnchor(history.CurrentChange, -1, wordRun.SourceArrayName);
+            if (address == Pointer.NULL) continue;
+            var array = Model.GetNextRun(address) as ArrayRun;
+            if (array == null) continue;
+            var actualValue = Model.ReadValue(wordRun.Start);
+            if (array.ElementCount == actualValue) continue;
+            OnMessage?.Invoke(this, $"MatchedWord at {wordRun.Start:X6} was expected to have value {array.ElementCount}, but was {actualValue}.");
+            Goto.Execute(wordRun.Start.ToString("X6"));
+            break;
+         }
+      }
+
       private void Edit(char input) {
          var point = GetEditPoint();
          var element = currentView[point.X, point.Y];

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -70,7 +70,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
       public int ScrollValue {
          get => scroll.ScrollValue;
-         set => scroll.ScrollValue = value;
+         set { using (ModelCacheScope.CreateScope(Model)) scroll.ScrollValue = value; }
       }
 
       public int MaximumScroll => scroll.MaximumScroll;

--- a/src/HexManiac.Core/ViewModels/Visitors/CompleteEditOperation.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/CompleteEditOperation.cs
@@ -241,8 +241,9 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          Model.ExpandData(CurrentChange, memoryLocation + 3);
 
          var currentRun = Model.GetNextRun(memoryLocation);
-         bool inArray = currentRun.Start <= memoryLocation && currentRun is ArrayRun;
-         var sources = currentRun.PointerSources;
+         if (currentRun.Start > memoryLocation) currentRun = null;
+         bool inArray = currentRun is ArrayRun && currentRun.Start <= memoryLocation;
+         var sources = currentRun?.PointerSources;
 
          if (!inArray) {
             if (destination != string.Empty) {

--- a/src/HexManiac.Core/ViewModels/Visitors/CompleteEditOperation.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/CompleteEditOperation.cs
@@ -156,6 +156,14 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          }
       }
 
+      public void Visit(BitArray array, byte data) {
+         if (CurrentText.Length < 2) return;
+         var byteValue = byte.Parse(CurrentText, NumberStyles.HexNumber);
+         CurrentChange.ChangeData(Model, memoryLocation, byteValue);
+         NewDataIndex = memoryLocation + 1;
+         Result = true;
+      }
+
       /// <summary>
       /// Parses text in a PLM run to get the level and move.
       /// returns an error string if the parse fails.

--- a/src/HexManiac.Core/ViewModels/Visitors/CompleteEditOperation.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/CompleteEditOperation.cs
@@ -40,6 +40,10 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
             if (CurrentText.Last() != PointerEnd && CurrentText.Last() != ' ') return;
             CompletePointerEdit();
             Result = true;
+         } else if (CurrentText.StartsWith("::")) {
+            if (CurrentText.Last() != ' ') return;
+            CompleteWordEdit();
+            Result = true;
          } else {
             if (CurrentText.Length < 2) return;
             CompleteHexEdit(CurrentText);
@@ -164,6 +168,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          Result = true;
       }
 
+      public void Visit(MatchedWord word, byte data) => Visit((None)null, data);
+
       /// <summary>
       /// Parses text in a PLM run to get the level and move.
       /// returns an error string if the parse fails.
@@ -277,6 +283,14 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          } else {
             ErrorText = $"Address {fullValue.ToString("X2")} is not within the data.";
          }
+      }
+
+      private void CompleteWordEdit() {
+         var parentName = CurrentText.Substring(2).Trim();
+         Model.ExpandData(CurrentChange, memoryLocation + 3);
+         Model.ClearFormat(CurrentChange, memoryLocation, 4);
+         CurrentChange.AddMatchedWord(Model, memoryLocation, parentName);
+         Model.ObserveRunWritten(CurrentChange, new WordRun(memoryLocation, parentName));
       }
 
       private void CompleteStringEdit() {

--- a/src/HexManiac.Core/ViewModels/Visitors/CompleteEditOperation.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/CompleteEditOperation.cs
@@ -291,6 +291,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          Model.ClearFormat(CurrentChange, memoryLocation, 4);
          CurrentChange.AddMatchedWord(Model, memoryLocation, parentName);
          Model.ObserveRunWritten(CurrentChange, new WordRun(memoryLocation, parentName));
+         NewDataIndex = memoryLocation + 4;
       }
 
       private void CompleteStringEdit() {

--- a/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
@@ -136,6 +136,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          Results.AddRange(GetTableChildren(arrayRun));
       }
 
+      public void Visit(MatchedWord word, byte data) => Results.AddRange(GetFormattedChildren());
+
       private IEnumerable<IContextItem> GetTableChildren(ArrayRun array) {
          if (ViewPort.Tools.TableTool.Append.CanExecute(null)) {
             yield return new ContextItem("Extend Table", ViewPort.Tools.TableTool.Append.Execute);

--- a/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
@@ -131,6 +131,11 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          Results.AddRange(GetFormattedChildren());
       }
 
+      public void Visit(BitArray array, byte data) {
+         var arrayRun = (ArrayRun)ViewPort.Model.GetNextRun(ViewPort.Tools.TableTool.Address);
+         Results.AddRange(GetTableChildren(arrayRun));
+      }
+
       private IEnumerable<IContextItem> GetTableChildren(ArrayRun array) {
          if (ViewPort.Tools.TableTool.Append.CanExecute(null)) {
             yield return new ContextItem("Extend Table", ViewPort.Tools.TableTool.Append.Execute);

--- a/src/HexManiac.Core/ViewModels/Visitors/ContinueCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/ContinueCellEdit.cs
@@ -30,6 +30,15 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
             return;
          }
 
+         if (UnderEdit.CurrentText[0] == ':') {
+            if (UnderEdit.CurrentText.Length == 1) {
+               Result = Input == ':';
+            } else {
+               Result = char.IsLetterOrDigit(Input) || Input == ' ';
+            }
+            return;
+         }
+
          Result = ViewPort.AllHexCharacters.Contains(Input);
       }
 
@@ -106,5 +115,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
       public void Visit(BitArray array, byte data) {
          Result = ViewPort.AllHexCharacters.Contains(Input);
       }
+
+      public void Visit(MatchedWord word, byte data) => Visit((None)null, data);
    }
 }

--- a/src/HexManiac.Core/ViewModels/Visitors/ContinueCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/ContinueCellEdit.cs
@@ -102,5 +102,9 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
             Result = Input == StringDelimeter || char.IsLetterOrDigit(Input) || specialCharacters.Contains(Input);
          }
       }
+
+      public void Visit(BitArray array, byte data) {
+         Result = ViewPort.AllHexCharacters.Contains(Input);
+      }
    }
 }

--- a/src/HexManiac.Core/ViewModels/Visitors/ContinueCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/ContinueCellEdit.cs
@@ -25,18 +25,20 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
       public void Visit(Undefined dataFormat, byte data) => Visit((None)null, data);
 
       public void Visit(None dataFormat, byte data) {
-         if (UnderEdit.CurrentText[0] == PointerStart) {
-            Result = char.IsLetterOrDigit(Input) || Input == ArrayAnchorSeparator || Input == PointerEnd || Input == ' ';
-            return;
-         }
-
-         if (UnderEdit.CurrentText[0] == ':') {
-            if (UnderEdit.CurrentText.Length == 1) {
-               Result = Input == ':';
-            } else {
-               Result = char.IsLetterOrDigit(Input) || Input == ' ';
+         if (UnderEdit.CurrentText.Length > 0) {
+            if (UnderEdit.CurrentText[0] == PointerStart) {
+               Result = char.IsLetterOrDigit(Input) || Input == ArrayAnchorSeparator || Input == PointerEnd || Input == ' ';
+               return;
             }
-            return;
+
+            if (UnderEdit.CurrentText[0] == ':') {
+               if (UnderEdit.CurrentText.Length == 1) {
+                  Result = Input == ':';
+               } else {
+                  Result = char.IsLetterOrDigit(Input) || Input == ' ';
+               }
+               return;
+            }
          }
 
          Result = ViewPort.AllHexCharacters.Contains(Input);

--- a/src/HexManiac.Core/ViewModels/Visitors/DataClear.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/DataClear.cs
@@ -52,5 +52,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
       public void Visit(PlmItem item, byte data) => buffer.WriteMultiByteValue(index, 2, currentChange, 0x0200);
 
       public void Visit(BitArray array, byte data) => buffer.WriteMultiByteValue(index, array.Length, currentChange, 0x00);
+
+      public void Visit(MatchedWord word, byte data) => Visit((None)null, data);
    }
 }

--- a/src/HexManiac.Core/ViewModels/Visitors/DataClear.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/DataClear.cs
@@ -50,5 +50,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
       public void Visit(EggItem item, byte data) => buffer.WriteMultiByteValue(index, 2, currentChange, 0x0000);
 
       public void Visit(PlmItem item, byte data) => buffer.WriteMultiByteValue(index, 2, currentChange, 0x0200);
+
+      public void Visit(BitArray array, byte data) => buffer.WriteMultiByteValue(index, array.Length, currentChange, 0x00);
    }
 }

--- a/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
@@ -140,5 +140,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
             NewFormat = new UnderEdit(item, Input.ToString(), 2, autocomplete);
          }
       }
+      public void Visit(BitArray array, byte data) {
+         // TODO
+      }
    }
 }

--- a/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
@@ -141,7 +141,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          }
       }
       public void Visit(BitArray array, byte data) {
-         // TODO
+         Result = ViewPort.AllHexCharacters.Contains(Input);
       }
    }
 }
+

--- a/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
@@ -32,7 +32,9 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
       // Treat it the same as a None.
       public void Visit(Undefined dataFormat, byte data) => Visit((None)null, data);
 
-      public void Visit(None dataFormat, byte data) {
+      public void Visit(None dataFormat, byte data) => BasicVisit(dataFormat, data);
+
+      private void BasicVisit(IDataFormat dataFormat, byte data) {
          // you can write a pointer into a space with no current format
          if (Input == PointerStart) {
             var editText = Input.ToString();
@@ -75,6 +77,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
       }
 
       public void Visit(Pointer pointer, byte data) {
+         if (Input == ':') { BasicVisit(pointer, data); return; }
          if (Input != PointerStart && !char.IsLetterOrDigit(Input)) return;
 
          var editText = Input.ToString();
@@ -151,7 +154,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
       public void Visit(BitArray array, byte data) {
          Result = ViewPort.AllHexCharacters.Contains(Input);
       }
-      public void Visit(MatchedWord word, byte data) => Visit((None)null, data);
+      public void Visit(MatchedWord word, byte data) => BasicVisit(word, data);
    }
 }
 

--- a/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
@@ -17,7 +17,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
    ///     if the new UnderEdit is just the character, NewFormat can be left null, and the calling code will create the appropriate new UnderEdit object.
    /// </summary>
    public class StartCellEdit : IDataFormatVisitor {
-      private static readonly char[] SpecialAnchorAllowedCharacters = new[] { AnchorStart, ArrayStart, ArrayEnd, StringDelimeter, StreamDelimeter, PointerStart, PointerEnd, SingleByteIntegerFormat, DoubleByteIntegerFormat };
+      private static readonly char[] SpecialAnchorAllowedCharacters = new[] { AnchorStart, ArrayStart, ArrayEnd, StringDelimeter, StreamDelimeter, PointerStart, PointerEnd, '|', SingleByteIntegerFormat, DoubleByteIntegerFormat };
 
       public IDataModel Model { get; }
       public int MemoryLocation { get; }

--- a/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
@@ -42,6 +42,14 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
             return;
          }
 
+         if (Input == ':') {
+            var editText = Input.ToString();
+            var autocompleteOptions = Model.GetNewWordAutocompleteOptions("::", -1);
+            NewFormat = new UnderEdit(dataFormat, editText, 4, autocompleteOptions);
+            Result = true;
+            return;
+         }
+
          Result = ViewPort.AllHexCharacters.Contains(Input);
       }
 
@@ -143,6 +151,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
       public void Visit(BitArray array, byte data) {
          Result = ViewPort.AllHexCharacters.Contains(Input);
       }
+      public void Visit(MatchedWord word, byte data) => Visit((None)null, data);
    }
 }
 

--- a/src/HexManiac.Tests/ArrayRunTests.cs
+++ b/src/HexManiac.Tests/ArrayRunTests.cs
@@ -1012,6 +1012,7 @@ namespace HavenSoft.HexManiac.Tests {
          var run = model.GetNextRun(0x50);
          Assert.IsType<WordRun>(run);
          Assert.IsType<MatchedWord>(viewPort[1, 5].Format);
+         Assert.Equal(new Point(4, 5), viewPort.SelectionStart);
 
          var length = model.ReadValue(0x50);
          Assert.Equal(4, length);

--- a/src/HexManiac.Tests/ArrayRunTests.cs
+++ b/src/HexManiac.Tests/ArrayRunTests.cs
@@ -1048,6 +1048,23 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.Equal(4, length);
       }
 
+      [Fact]
+      public void CanSaveLooseWordRuns() {
+         var fileSystem = new StubFileSystem();
+         string[] metadata = null;
+         fileSystem.Save = file => true;
+         fileSystem.SaveMetadata = (file, lines) => { metadata = lines; return true; };
+         StandardSetup(out var data, out var model, out var viewPort);
+
+         viewPort.Edit("::test ");
+         viewPort.Save.Execute(fileSystem);
+
+         var storedMetadata = new StoredMetadata(metadata);
+         var matchedWord = storedMetadata.MatchedWords.First();
+         Assert.Equal(0, matchedWord.Address);
+         Assert.Equal("test", matchedWord.Name);
+      }
+
       private static void StandardSetup(out byte[] data, out PokemonModel model, out ViewPort viewPort) {
          data = new byte[0x200];
          model = new PokemonModel(data);

--- a/src/HexManiac.Tests/ArrayRunTests.cs
+++ b/src/HexManiac.Tests/ArrayRunTests.cs
@@ -1035,6 +1035,7 @@ namespace HavenSoft.HexManiac.Tests {
          viewPort.Edit("::table ");                  // should create a new 4-byte run that stays in sync with the table
 
          // remove the format
+         viewPort.SelectionStart = new Point(0, 5);
          var items = viewPort.GetContextMenuItems(new Point(0, 5));
          var contextItem = items.Single(item => item.Text == "Clear Format");
          contextItem.Command.Execute();

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -1,6 +1,7 @@
 ﻿
 using HavenSoft.HexManiac.Core.Models;
 using HavenSoft.HexManiac.Core.Models.Runs;
+using HavenSoft.HexManiac.Core.ViewModels;
 using HavenSoft.HexManiac.Core.ViewModels.DataFormats;
 using System;
 using System.Collections.Generic;
@@ -16,7 +17,7 @@ namespace HavenSoft.HexManiac.Tests {
    /// </summary>
    public class AutoSearchTests {
 
-      public static IEnumerable<object[]> PokemonGames => new[] {
+      public static IEnumerable<object[]> PokemonGames { get; } = new[] {
          "Ruby",
          "Sapphire",
          "FireRed",
@@ -226,6 +227,41 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.Equal(compatibilityElementLength, compatibility.ElementContent[0].Length);
       }
 
+      // this one actually changes the data, so I can't use the same shared model as everone else.
+      [SkippableTheory]
+      [MemberData(nameof(PokemonGames))]
+      public void ExpandableTutorsWorks(string game) {
+         var fileSystem = new StubFileSystem();
+         var model = LoadModelNoCache(game);
+         var editor = new EditorViewModel(fileSystem, false);
+         var viewPort = new ViewPort(game, model);
+         editor.Add(viewPort);
+         var expandTutors = editor.QuickEdits.Single(edit => edit.Name == "Make Tutors Expandable");
+
+         // ruby/sapphire/gaia do not support this quick-edit
+         var canRun = expandTutors.CanRun(viewPort);
+         if (game.Contains("Ruby") || game.Contains("Sapphire") || game.Contains("Gaia")) {
+            Assert.False(canRun);
+            return;
+         } else {
+            Assert.True(canRun);
+         }
+
+         // run the actual quick-edit
+         expandTutors.Run(viewPort);
+
+         // extend the table
+         var table = (ArrayRun)model.GetNextRun(model.GetAddressFromAnchor(new ModelDelta(), -1, "tutormoves"));
+         viewPort.Goto.Execute((table.Start + table.Length).ToString("X6"));
+         viewPort.Edit("+");
+
+         // the 4 bytes after the last pointer to tutor-compatibility should store the length of tutormoves
+         table = (ArrayRun)model.GetNextRun(model.GetAddressFromAnchor(new ModelDelta(), -1, "tutormoves"));
+         var tutorCompatibilityPointerSources = model.GetNextRun(model.GetAddressFromAnchor(new ModelDelta(), -1, "tutorcompatibility")).PointerSources;
+         var word = (WordRun)model.GetNextRun(tutorCompatibilityPointerSources.Last() + 4);
+         Assert.Equal(table.ElementCount, model.ReadValue(word.Start));
+      }
+
       /// <summary>
       /// Loading the model can take a while.
       /// We want to know that loading the model created the correct arrays,
@@ -233,17 +269,21 @@ namespace HavenSoft.HexManiac.Tests {
       /// Go ahead and cache a model loaded from a file the first time,
       /// so each individual test doesn't have to do it again.
       /// </summary>
-      private static IDictionary<string, AutoSearchModel> modelCache = new Dictionary<string, AutoSearchModel>();
+      private static IDictionary<string, Lazy<AutoSearchModel>> modelCache = new Dictionary<string, Lazy<AutoSearchModel>>();
       private static AutoSearchModel LoadModel(string name) {
          lock (modelCache) {
-            if (modelCache.TryGetValue(name, out var cachedModel)) return cachedModel;
-            Skip.IfNot(File.Exists(name));
-            var data = File.ReadAllBytes(name);
-            var metadata = new StoredMetadata(new string[0]);
-            var model = new AutoSearchModel(data, metadata);
-            modelCache[name] = model;
-            return model;
+            if (!modelCache.ContainsKey(name)) modelCache[name] = new Lazy<AutoSearchModel>(() => LoadModelNoCache(name));
          }
+
+         return modelCache[name].Value;
+      }
+
+      private static AutoSearchModel LoadModelNoCache(string name) {
+         Skip.IfNot(File.Exists(name));
+         var data = File.ReadAllBytes(name);
+         var metadata = new StoredMetadata(new string[0]);
+         var model = new AutoSearchModel(data, metadata);
+         return model;
       }
    }
 }

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -209,7 +209,8 @@ namespace HavenSoft.HexManiac.Tests {
          var compatibilityLocation = model.GetAddressFromAnchor(noChange, -1, "tutorcompatibility");
 
          // ruby and sapphire have no tutors
-         if (game.Contains("Ruby") || game.Contains("Sapphire")) {
+         // Gaia has move tutors, but it does a bunch of custom stuff (multiple tables) so I don't feel bad about not supporting it by default.
+         if (game.Contains("Ruby") || game.Contains("Sapphire") || game.Contains("Gaia")) {
             Assert.Equal(Pointer.NULL, movesLocation);
             Assert.Equal(Pointer.NULL, compatibilityLocation);
             return;

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -206,8 +206,8 @@ namespace HavenSoft.HexManiac.Tests {
          var model = LoadModel(game);
          var noChange = new NoDataChangeDeltaModel();
 
-         var movesLocation = model.GetAddressFromAnchor(noChange, -1, "tutormoves");
-         var compatibilityLocation = model.GetAddressFromAnchor(noChange, -1, "tutorcompatibility");
+         var movesLocation = model.GetAddressFromAnchor(noChange, -1, AutoSearchModel.MoveTutors);
+         var compatibilityLocation = model.GetAddressFromAnchor(noChange, -1, AutoSearchModel.TutorCompatibility);
 
          // ruby and sapphire have no tutors
          // Gaia has move tutors, but it does a bunch of custom stuff (multiple tables) so I don't feel bad about not supporting it by default.
@@ -251,13 +251,13 @@ namespace HavenSoft.HexManiac.Tests {
          expandTutors.Run(viewPort);
 
          // extend the table
-         var table = (ArrayRun)model.GetNextRun(model.GetAddressFromAnchor(new ModelDelta(), -1, "tutormoves"));
+         var table = (ArrayRun)model.GetNextRun(model.GetAddressFromAnchor(new ModelDelta(), -1, AutoSearchModel.MoveTutors));
          viewPort.Goto.Execute((table.Start + table.Length).ToString("X6"));
          viewPort.Edit("+");
 
          // the 4 bytes after the last pointer to tutor-compatibility should store the length of tutormoves
-         table = (ArrayRun)model.GetNextRun(model.GetAddressFromAnchor(new ModelDelta(), -1, "tutormoves"));
-         var tutorCompatibilityPointerSources = model.GetNextRun(model.GetAddressFromAnchor(new ModelDelta(), -1, "tutorcompatibility")).PointerSources;
+         table = (ArrayRun)model.GetNextRun(model.GetAddressFromAnchor(new ModelDelta(), -1, AutoSearchModel.MoveTutors));
+         var tutorCompatibilityPointerSources = model.GetNextRun(model.GetAddressFromAnchor(new ModelDelta(), -1, AutoSearchModel.TutorCompatibility)).PointerSources;
          var word = (WordRun)model.GetNextRun(tutorCompatibilityPointerSources.Last() + 4);
          Assert.Equal(table.ElementCount, model.ReadValue(word.Start));
       }

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -1,6 +1,7 @@
 ﻿
 using HavenSoft.HexManiac.Core.Models;
 using HavenSoft.HexManiac.Core.Models.Runs;
+using HavenSoft.HexManiac.Core.ViewModels.DataFormats;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -196,6 +197,32 @@ namespace HavenSoft.HexManiac.Tests {
          var expectedLength = expectedLastElement + 1;
          var actualLength = run.Length / 2 - 1;  // remove the closing element.
          Assert.InRange(actualLength, 790, expectedLength);
+      }
+
+      [SkippableTheory]
+      [MemberData(nameof(PokemonGames))]
+      public void TutorsAreFound(string game) {
+         var model = LoadModel(game);
+         var noChange = new NoDataChangeDeltaModel();
+
+         var movesLocation = model.GetAddressFromAnchor(noChange, -1, "tutormoves");
+         var compatibilityLocation = model.GetAddressFromAnchor(noChange, -1, "tutorcompatibility");
+
+         // ruby and sapphire have no tutors
+         if (game.Contains("Ruby") || game.Contains("Sapphire")) {
+            Assert.Equal(Pointer.NULL, movesLocation);
+            Assert.Equal(Pointer.NULL, compatibilityLocation);
+            return;
+         }
+
+         var moves = (ArrayRun)model.GetNextRun(movesLocation);
+         var compatibility = (ArrayRun)model.GetNextRun(compatibilityLocation);
+
+         var expectedMoves = game.Contains("Emerald") || game.Contains("Altair") ? 30 : 15;
+         var compatibilityElementLength = (int)Math.Ceiling(expectedMoves / 8.0);
+
+         Assert.Equal(expectedMoves, moves.ElementCount);
+         Assert.Equal(compatibilityElementLength, compatibility.ElementContent[0].Length);
       }
 
       /// <summary>

--- a/src/HexManiac.Tests/NestedTablesTests.cs
+++ b/src/HexManiac.Tests/NestedTablesTests.cs
@@ -367,6 +367,22 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.True(viewPort.IsSelected(new Point(5, 0)));
       }
 
+      [Fact]
+      public void CanExpandBitArrays() {
+         // Arrange a table with 8 elements
+         // and a second table that uses those elements as bits
+         SetupMoveTable(0x00);
+         viewPort.Edit($"@40 ^mymoves[move:{EggMoveRun.MoveNamesTable}]8 "); // setup a table that uses 'movenames' as an enum
+         viewPort.Edit($"@60 ^table[data|b[]mymoves]4 @61 FF "); // set all 8 name bits to true for the table[1]    // 60 - 64
+
+         // Act: expand the enum table to have 9 entries
+         viewPort.Edit("@50 +");
+
+         // Assert that the 8 true bits moved based on the expansion, and the new table uses 2 bytes per element.
+         Assert.Equal(0xFF, data[0x62]);
+         Assert.Equal(8, model.GetNextRun(0x60).Length);
+      }
+
       // creates a move table that is 0x40 bytes long
       private void SetupMoveTable(int start) {
          viewPort.Goto.Execute(start.ToString("X6"));

--- a/src/HexManiac.Tests/NestedTablesTests.cs
+++ b/src/HexManiac.Tests/NestedTablesTests.cs
@@ -349,6 +349,24 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.IsType<BitArray>(((Anchor)viewPort[0, 0].Format).OriginalFormat);
       }
 
+      [Fact]
+      public void BitArraySelectionSelectsAllBytesInCurrentBitArray() {
+         SetupMoveTable(0x00);
+         SetupNameTable(0x40);
+
+         // setup a table for 5 tutor moves
+         viewPort.Goto.Execute("000080");
+         viewPort.Edit("^tutormoves[move:movenames]10 One One Two Two Four Four Five Five Seven Seven "); // note that 10 bits takes 2 bytes
+
+         viewPort.Goto.Execute("0000100");
+         viewPort.Edit("^table[moves|b[]tutormoves]pokenames ");
+         var run = (ArrayRun)model.GetNextRun(0x100);
+         Assert.Equal(16, run.Length); // 2 bytes each for 8 pokemon
+
+         viewPort.SelectionStart = new Point(4, 0);
+         Assert.True(viewPort.IsSelected(new Point(5, 0)));
+      }
+
       // creates a move table that is 0x40 bytes long
       private void SetupMoveTable(int start) {
          viewPort.Goto.Execute(start.ToString("X6"));

--- a/src/HexManiac.Tests/NestedTablesTests.cs
+++ b/src/HexManiac.Tests/NestedTablesTests.cs
@@ -341,9 +341,9 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.Equal(8, run.Length);
 
          var bitList = (BitListArrayElementViewModel)viewPort.Tools.TableTool.Children[0];
-         Assert.Equal("Carl", bitList[2].BitLabel);
+         Assert.Equal("Four", bitList[2].BitLabel);
 
-         bitList[2].IsChecked = true;      // "Carl" should be able to learn "Four"
+         bitList[2].IsChecked = true;      // "Adam" should be able to learn "Four"
          Assert.Equal(0x04, model[0x90]);  // the third bit up is set because "Four" is the first tutor move
 
          Assert.IsType<BitArray>(((Anchor)viewPort[0, 0].Format).OriginalFormat);

--- a/src/HexManiac.WPF/Controls/StartScreen.xaml
+++ b/src/HexManiac.WPF/Controls/StartScreen.xaml
@@ -26,6 +26,9 @@
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>pokestats<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>abilitydescriptions<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>movedata<LineBreak/>
+      <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>eggmoves<LineBreak/>
+      <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>tutormoves<LineBreak/>
+      <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>tutorcompatibility<LineBreak/>
    </TextBlock>
    <StackPanel Grid.Column="2" VerticalAlignment="Center" TextBlock.Foreground="{DynamicResource Primary}" >
       <Border Margin="5" Padding="5" Background="{DynamicResource Background}" BorderBrush="{DynamicResource Secondary}" CornerRadius="5,5,5,5" BorderThickness="1" Cursor="Hand" MouseLeftButtonDown="PointerHelp">

--- a/src/HexManiac.WPF/Controls/TabView.xaml
+++ b/src/HexManiac.WPF/Controls/TabView.xaml
@@ -129,6 +129,15 @@
                            <ComboBox SelectedIndex="{Binding SelectedIndex}" ItemsSource="{Binding Options}" Grid.Column="1"/>
                         </Grid>
                      </DataTemplate>
+                     <DataTemplate DataType="{x:Type hsg3hvmtr:BitListArrayElementViewModel}">
+                        <ItemsControl ItemsSource="{Binding}">
+                           <ItemsControl.ItemTemplate>
+                              <DataTemplate>
+                                 <CheckBox Margin="5,1" IsChecked="{Binding IsChecked}" Content="{Binding BitLabel}"/>
+                              </DataTemplate>
+                           </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                     </DataTemplate>
                      <DataTemplate DataType="{x:Type hsg3hvmtr:StreamArrayElementViewModel}">
                         <TextBox Text="{Binding Content, UpdateSourceTrigger=PropertyChanged}" Margin="20,2,2,2" AcceptsReturn="True"/>
                      </DataTemplate>

--- a/src/HexManiac.WPF/Controls/TabView.xaml
+++ b/src/HexManiac.WPF/Controls/TabView.xaml
@@ -106,7 +106,17 @@
                   <Button Margin="5" Content="Previous" Command="{Binding TableTool.Previous}" HorizontalAlignment="Left"/>
                   <Button Margin="5" Content="Next" Command="{Binding TableTool.Next}" HorizontalAlignment="Right"/>
                </Grid>
-               <Button Margin="5" Content="Append" Command="{Binding TableTool.Append}" HorizontalAlignment="Right"/>
+               <Border Margin="5" HorizontalAlignment="Right">
+                  <Border.ToolTip>
+                     <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{DynamicResource Accent}" BorderThickness="1">
+                        <TextBlock TextAlignment="Left">
+                           Select the last element of the table <LineBreak/>
+                           and press this to extend the table.
+                        </TextBlock>
+                     </ToolTip>
+                  </Border.ToolTip>
+                  <Button Content="Add New" Command="{Binding TableTool.Append}"/>
+               </Border>
                <ItemsControl ItemsSource="{Binding TableTool.Children}" Grid.IsSharedSizeScope="True">
                   <ItemsControl.Resources>
                      <DataTemplate DataType="{x:Type hsg3hvmtr:FieldArrayElementViewModel}">

--- a/src/HexManiac.WPF/Controls/TabView.xaml
+++ b/src/HexManiac.WPF/Controls/TabView.xaml
@@ -131,9 +131,14 @@
                      </DataTemplate>
                      <DataTemplate DataType="{x:Type hsg3hvmtr:BitListArrayElementViewModel}">
                         <ItemsControl ItemsSource="{Binding}">
+                           <ItemsControl.ItemsPanel>
+                              <ItemsPanelTemplate>
+                                 <WrapPanel/>
+                              </ItemsPanelTemplate>
+                           </ItemsControl.ItemsPanel>
                            <ItemsControl.ItemTemplate>
                               <DataTemplate>
-                                 <CheckBox Margin="5,1" IsChecked="{Binding IsChecked}" Content="{Binding BitLabel}"/>
+                                 <CheckBox Margin="5,1,0,1" Width="115" IsChecked="{Binding IsChecked}" Content="{Binding BitLabel}"/>
                               </DataTemplate>
                            </ItemsControl.ItemTemplate>
                         </ItemsControl>

--- a/src/HexManiac.WPF/Implementations/FormatDrawer.cs
+++ b/src/HexManiac.WPF/Implementations/FormatDrawer.cs
@@ -72,6 +72,7 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
          collector.Initialize<IntegerEnum>(typeface, fontSize * .75);
          collector.Initialize<Integer>(typeface, fontSize);
          collector.Initialize<BitArray>(typeface, fontSize);
+         collector.Initialize<MatchedWord>(typeface, fontSize * .75);
 
          for (int x = 0; x < modelWidth; x++) {
             var cell = viewPort[x, position.Y];
@@ -101,6 +102,8 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
                else collector.Collect<None>(x, 1, byteText[cell.Value]);
             } else if (format is BitArray array) {
                collector.Collect<BitArray>(x, 1, byteText[cell.Value]);
+            } else if (format is MatchedWord word) {
+               collector.Collect<MatchedWord>(x, 4, word.Name);
             }
          }
 
@@ -119,6 +122,7 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
          collector.Render<Undefined>(context, Brush(nameof(Theme.Secondary)));
          collector.Render<ErrorPCS>(context, Brush(nameof(Theme.Error)));
          collector.Render<BitArray>(context, Brush(nameof(Theme.Data1)));
+         collector.Render<MatchedWord>(context, Brush(nameof(Theme.Data1)));
 
          context.Pop();
       }
@@ -192,6 +196,8 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
       public void Visit(PlmItem item, byte data) { }
 
       public void Visit(BitArray array, byte data) { }
+
+      public void Visit(MatchedWord word, byte data) { }
 
       /// <summary>
       /// This function is full of dragons. You probably don't want to touch it.

--- a/src/HexManiac.WPF/Implementations/FormatDrawer.cs
+++ b/src/HexManiac.WPF/Implementations/FormatDrawer.cs
@@ -102,7 +102,7 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
                else collector.Collect<None>(x, 1, byteText[cell.Value]);
             } else if (format is BitArray array) {
                collector.Collect<BitArray>(x, 1, byteText[cell.Value]);
-            } else if (format is MatchedWord word) {
+            } else if (format is MatchedWord word && word.Position == 0) {
                collector.Collect<MatchedWord>(x, 4, word.Name);
             }
          }

--- a/src/HexManiac.WPF/Implementations/FormatDrawer.cs
+++ b/src/HexManiac.WPF/Implementations/FormatDrawer.cs
@@ -71,6 +71,7 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
          collector.Initialize<EggItem>(typeface, fontSize * .75);
          collector.Initialize<IntegerEnum>(typeface, fontSize * .75);
          collector.Initialize<Integer>(typeface, fontSize);
+         collector.Initialize<BitArray>(typeface, fontSize);
 
          for (int x = 0; x < modelWidth; x++) {
             var cell = viewPort[x, position.Y];
@@ -98,6 +99,8 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
                if (cell.Value == 0x00) collector.Collect<UnderEdit>(x, 1, "00");
                else if (cell.Value == 0xFF) collector.Collect<Undefined>(x, 1, "FF");
                else collector.Collect<None>(x, 1, byteText[cell.Value]);
+            } else if (format is BitArray array) {
+               collector.Collect<BitArray>(x, 1, byteText[cell.Value]);
             }
          }
 
@@ -115,6 +118,7 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
          collector.Render<UnderEdit>(context, Brush(nameof(Theme.Secondary)));
          collector.Render<Undefined>(context, Brush(nameof(Theme.Secondary)));
          collector.Render<ErrorPCS>(context, Brush(nameof(Theme.Error)));
+         collector.Render<BitArray>(context, Brush(nameof(Theme.Data1)));
 
          context.Pop();
       }
@@ -186,6 +190,8 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
       public void Visit(EggItem item, byte data) { }
 
       public void Visit(PlmItem item, byte data) { }
+
+      public void Visit(BitArray array, byte data) { }
 
       /// <summary>
       /// This function is full of dragons. You probably don't want to touch it.

--- a/src/HexManiac.WPF/Implementations/WindowsFileSystem.cs
+++ b/src/HexManiac.WPF/Implementations/WindowsFileSystem.cs
@@ -82,7 +82,12 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
          // make sure the required directory exists
          var path = Path.GetDirectoryName(file.Name);
          Directory.CreateDirectory(path);
-         File.WriteAllBytes(file.Name, file.Contents);
+         try {
+            File.WriteAllBytes(file.Name, file.Contents);
+         } catch (IOException) {
+            ShowCustomMessageBox("Could not save. The file might be ReadOnly or in use by another application.", showYesNoCancel: false);
+            return false;
+         }
          return true;
       }
 
@@ -99,7 +104,43 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
          return Save(file);
       }
 
-      public MessageBoxResult ShowCustomMessageBox(string message) {
+      public MessageBoxResult ShowCustomMessageBox(string message, bool showYesNoCancel = true) {
+         var choices = showYesNoCancel ? new StackPanel {
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Orientation = Orientation.Horizontal,
+            Children = {
+               new Button {
+                  HorizontalContentAlignment = HorizontalAlignment.Center,
+                  Content = new Label { Foreground = Brush(nameof(Theme.Primary)), Content = "_Yes" },
+                  MinWidth = 70,
+                  Margin = new Thickness(5)
+               }.SetEvent(Button.ClickEvent, MessageBoxButtonClick),
+               new Button {
+                  HorizontalContentAlignment = HorizontalAlignment.Center,
+                  Content = new Label { Foreground = Brush(nameof(Theme.Primary)), Content = "_No" },
+                  MinWidth = 70,
+                  Margin = new Thickness(5)
+               }.SetEvent(Button.ClickEvent, MessageBoxButtonClick),
+               new Button {
+                  HorizontalContentAlignment = HorizontalAlignment.Center,
+                  Content = new Label { Foreground = Brush(nameof(Theme.Primary)), Content = "Cancel" },
+                  MinWidth = 70,
+                  Margin = new Thickness(5)
+               }.SetEvent(Button.ClickEvent, MessageBoxButtonClick),
+            }
+         } : new StackPanel {
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Orientation = Orientation.Horizontal,
+            Children = {
+               new Button {
+                  HorizontalContentAlignment = HorizontalAlignment.Center,
+                  Content = new Label { Foreground = Brush(nameof(Theme.Primary)), Content = "OK" },
+                  MinWidth = 70,
+                  Margin = new Thickness(5)
+               }.SetEvent(Button.ClickEvent, MessageBoxButtonClick),
+            }
+         };
+
          var window = new Window {
             Background = Brush(nameof(Theme.Background)),
             Foreground = Brush(nameof(Theme.Primary)),
@@ -110,30 +151,7 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
                Orientation = Orientation.Vertical,
                Children = {
                   new TextBlock { Text = message, Margin = new Thickness(5, 10, 5, 10) },
-                  new StackPanel {
-                     HorizontalAlignment = HorizontalAlignment.Right,
-                     Orientation = Orientation.Horizontal,
-                     Children = {
-                        new Button {
-                           HorizontalContentAlignment = HorizontalAlignment.Center,
-                           Content = new Label { Foreground = Brush(nameof(Theme.Primary)), Content = "_Yes" },
-                           MinWidth = 70,
-                           Margin = new Thickness(5)
-                        }.SetEvent(Button.ClickEvent, MessageBoxButtonClick),
-                        new Button {
-                           HorizontalContentAlignment = HorizontalAlignment.Center,
-                           Content = new Label { Foreground = Brush(nameof(Theme.Primary)), Content = "_No" },
-                           MinWidth = 70,
-                           Margin = new Thickness(5)
-                        }.SetEvent(Button.ClickEvent, MessageBoxButtonClick),
-                        new Button {
-                           HorizontalContentAlignment = HorizontalAlignment.Center,
-                           Content = new Label { Foreground = Brush(nameof(Theme.Primary)), Content = "Cancel" },
-                           MinWidth = 70,
-                           Margin = new Thickness(5)
-                        }.SetEvent(Button.ClickEvent, MessageBoxButtonClick),
-                     }
-                  }
+                  choices,
                }
             },
             Owner = Application.Current.MainWindow,
@@ -153,6 +171,7 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
             case "_Yes": passingResult = MessageBoxResult.Yes; break;
             case "_No": passingResult = MessageBoxResult.No; break;
             case "Cancel": passingResult = MessageBoxResult.Cancel; break;
+            case "OK": passingResult = MessageBoxResult.OK; break;
          }
          var parent = (FrameworkElement)button.Parent;
          while (parent.Parent is FrameworkElement) parent = (FrameworkElement)parent.Parent;

--- a/src/HexManiac.WPF/Windows/App.xaml
+++ b/src/HexManiac.WPF/Windows/App.xaml
@@ -622,5 +622,59 @@
             </Setter.Value>
          </Setter>
       </Style>
+
+      <Style TargetType="{x:Type CheckBox}">
+         <Setter Property="SnapsToDevicePixels" Value="true"/>
+         <Setter Property="OverridesDefaultStyle" Value="true"/>
+         <Setter Property="Template">
+            <Setter.Value>
+               <ControlTemplate TargetType="{x:Type CheckBox}">
+                  <BulletDecorator Background="Transparent">
+                     <BulletDecorator.Bullet>
+                        <Border x:Name="Border" 
+                           Width="13" 
+                           Height="13" 
+                           CornerRadius="0" 
+                           Background="{DynamicResource Background}"
+                           BorderThickness="1"
+                           BorderBrush="{DynamicResource Secondary}">
+                           <Path 
+                              Width="7" Height="7" 
+                              x:Name="CheckMark"
+                              SnapsToDevicePixels="False" 
+                              Stroke="{DynamicResource Accent}"
+                              StrokeThickness="2"
+                              Data="M 0 0 L 7 7 M 0 7 L 7 0" />
+                        </Border>
+                     </BulletDecorator.Bullet>
+                     <ContentPresenter Margin="4,0,0,0"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Left"
+                        RecognizesAccessKey="True"/>
+                  </BulletDecorator>
+                  <ControlTemplate.Triggers>
+                     <Trigger Property="IsChecked" Value="false">
+                        <Setter TargetName="CheckMark" Property="Visibility" Value="Collapsed"/>
+                     </Trigger>
+                     <Trigger Property="IsChecked" Value="{x:Null}">
+                        <Setter TargetName="CheckMark" Property="Data" Value="M 0 7 L 7 0" />
+                     </Trigger>
+                     <Trigger Property="IsMouseOver" Value="true">
+                        <Setter TargetName="Border" Property="Background" Value="{DynamicResource Backlight}" />
+                     </Trigger>
+                     <Trigger Property="IsPressed" Value="true">
+                        <Setter TargetName="Border" Property="Background" Value="{DynamicResource Backlight}" />
+                        <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource Primary}" />
+                     </Trigger>
+                     <Trigger Property="IsEnabled" Value="false">
+                        <Setter TargetName="Border" Property="Opacity" Value=".8" />
+                        <Setter TargetName="Border" Property="Opacity" Value=".8" />
+                        <Setter Property="Foreground" Value="{DynamicResource Secondary}"/>
+                     </Trigger>
+                  </ControlTemplate.Triggers>
+               </ControlTemplate>
+            </Setter.Value>
+         </Setter>
+      </Style>
    </Application.Resources>
 </Application>

--- a/src/HexManiac.WPF/Windows/App.xaml
+++ b/src/HexManiac.WPF/Windows/App.xaml
@@ -629,14 +629,16 @@
          <Setter Property="Template">
             <Setter.Value>
                <ControlTemplate TargetType="{x:Type CheckBox}">
-                  <BulletDecorator Background="Transparent">
+                  <BulletDecorator Background="Transparent" Width="{TemplateBinding Width}" Height="15">
                      <BulletDecorator.Bullet>
                         <Border x:Name="Border" 
                            Width="13" 
                            Height="13" 
+                           Margin="1"
                            CornerRadius="0" 
                            Background="{DynamicResource Background}"
                            BorderThickness="1"
+                           VerticalAlignment="Center"
                            BorderBrush="{DynamicResource Secondary}">
                            <Path 
                               Width="7" Height="7" 
@@ -647,10 +649,9 @@
                               Data="M 0 0 L 7 7 M 0 7 L 7 0" />
                         </Border>
                      </BulletDecorator.Bullet>
-                     <ContentPresenter Margin="4,0,0,0"
-                        VerticalAlignment="Center"
-                        HorizontalAlignment="Left"
-                        RecognizesAccessKey="True"/>
+                     <Viewbox Margin="3,0,0,0" HorizontalAlignment="Left">
+                        <ContentPresenter RecognizesAccessKey="True"/>
+                     </Viewbox>
                   </BulletDecorator>
                   <ControlTemplate.Triggers>
                      <Trigger Property="IsChecked" Value="false">

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml
@@ -132,8 +132,10 @@
                   <Separator/>
                   <MenuItem Header="Toggle _Text Tool" Command="{Binding Tools.StringToolCommand}"/>
                   <MenuItem Header="Toggle T_able Tool" Command="{Binding Tools.TableToolCommand}"/>
-                  <MenuItem Header="Toggle _Extra Tool" Command="{Binding Tools.Tool3Command}"/>
+                  <MenuItem Header="Toggle _Code Tool" Command="{Binding Tools.CodeToolCommand}"/>
+                  <Separator/>
                </MenuItem>
+               <MenuItem Name="QuickEdits" Header="Utilities"/>
                <MenuItem Header="_Help">
                   <MenuItem Header="_Wiki" Click="WikiClick"/>
                   <MenuItem Header="_Report an Issue" Click="ReportIssueClick"/>

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
@@ -45,6 +45,69 @@ namespace HavenSoft.HexManiac.WPF.Windows {
                AnimateFocusToCorner(MessagePanel, default);
             }
          };
+
+         FillQuickEditMenu();
+      }
+
+      private void FillQuickEditMenu() {
+         foreach (var edit in ViewModel.QuickEdits) {
+            QuickEdits.Items.Add(new MenuItem {
+               Header = edit.Name,
+               Command = new StubCommand {
+                  CanExecute = arg => edit.CanRun(ViewModel[ViewModel.SelectedIndex] as IViewPort),
+                  Execute = arg => {
+                     Window window = default;
+                     window = new Window {
+                        Title = edit.Name,
+                        Background = (SolidColorBrush)Application.Current.Resources.MergedDictionaries[0][nameof(Theme.Background)],
+                        SizeToContent = SizeToContent.WidthAndHeight,
+                        WindowStyle = WindowStyle.ToolWindow,
+                        Content = new Grid {
+                           Width = 300,
+                           Height = 100,
+                           Children = {
+                              new TextBlock {
+                                 Margin = new Thickness(5),
+                                 FontSize = 14,
+                                 Text = edit.Description,
+                                 TextWrapping = TextWrapping.Wrap,
+                              },
+                              new StackPanel {
+                                 Orientation = Orientation.Horizontal,
+                                 VerticalAlignment = VerticalAlignment.Bottom,
+                                 HorizontalAlignment = HorizontalAlignment.Right,
+                                 Children = {
+                                    new Button {
+                                       Content = "Run",
+                                       Margin = new Thickness(5),
+                                       Command = new StubCommand {
+                                          CanExecute = arg1 => true,
+                                          Execute = arg1 => {
+                                             var error = edit.Run(ViewModel[ViewModel.SelectedIndex] as IViewPort);
+                                             // TODO do something with the error?
+                                             window.Close();
+                                          }
+                                       },
+                                    },
+                                    new Button {
+                                       Content = "Cancel",
+                                       IsCancel = true,
+                                       Margin = new Thickness(5),
+                                       Command = new StubCommand {
+                                          CanExecute = arg1 => true,
+                                          Execute = arg1 => window.Close(),
+                                       },
+                                    },
+                                 },
+                              },
+                           },
+                        },
+                     };
+                     window.ShowDialog();
+                  },
+               },
+            });
+         }
       }
 
       protected override void OnDrop(DragEventArgs e) {

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using HavenSoft.HexManiac.Core.Models;
 using HavenSoft.HexManiac.Core.ViewModels;
 using HavenSoft.HexManiac.Core.ViewModels.Tools;
 using HavenSoft.HexManiac.WPF.Controls;
+using HavenSoft.HexManiac.WPF.Implementations;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -21,7 +22,7 @@ namespace HavenSoft.HexManiac.WPF.Windows {
       private ThemeSelector themeWindow;
 
       public EditorViewModel ViewModel { get; }
-      public IFileSystem FileSystem => (IFileSystem)Resources["FileSystem"];
+      public WindowsFileSystem FileSystem => (WindowsFileSystem)Resources["FileSystem"];
 
       public MainWindow(EditorViewModel viewModel) {
          InitializeComponent();
@@ -44,6 +45,14 @@ namespace HavenSoft.HexManiac.WPF.Windows {
             ) {
                AnimateFocusToCorner(MessagePanel, default);
             }
+         };
+
+         Application.Current.DispatcherUnhandledException += (sender, e) => {
+            File.AppendAllText("crash.log", e.Exception.Message + Environment.NewLine + e.Exception.StackTrace);
+            FileSystem.ShowCustomMessageBox("An unhandled error occured. Please report it on Discord or open an issue on GitHub." + Environment.NewLine +
+               "HexManiac might be in a bad state. You should close as soon as possible." + Environment.NewLine +
+               "The error has been logged to crash.log", showYesNoCancel: false);
+            e.Handled = true;
          };
 
          FillQuickEditMenu();

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
@@ -51,21 +51,19 @@ namespace HavenSoft.HexManiac.WPF.Windows {
 
       private void FillQuickEditMenu() {
          foreach (var edit in ViewModel.QuickEdits) {
-            QuickEdits.Items.Add(new MenuItem {
-               Header = edit.Name,
-               Command = new StubCommand {
-                  CanExecute = arg => edit.CanRun(ViewModel[ViewModel.SelectedIndex] as IViewPort),
-                  Execute = arg => {
-                     Window window = default;
-                     window = new Window {
-                        Title = edit.Name,
-                        Background = (SolidColorBrush)Application.Current.Resources.MergedDictionaries[0][nameof(Theme.Background)],
-                        SizeToContent = SizeToContent.WidthAndHeight,
-                        WindowStyle = WindowStyle.ToolWindow,
-                        Content = new Grid {
-                           Width = 300,
-                           Height = 100,
-                           Children = {
+            var command = new StubCommand {
+               CanExecute = arg => ViewModel.SelectedIndex >= 0 && edit.CanRun(ViewModel[ViewModel.SelectedIndex] as IViewPort),
+               Execute = arg => {
+                  Window window = default;
+                  window = new Window {
+                     Title = edit.Name,
+                     Background = (SolidColorBrush)Application.Current.Resources.MergedDictionaries[0][nameof(Theme.Background)],
+                     SizeToContent = SizeToContent.WidthAndHeight,
+                     WindowStyle = WindowStyle.ToolWindow,
+                     Content = new Grid {
+                        Width = 300,
+                        Height = 100,
+                        Children = {
                               new TextBlock {
                                  Margin = new Thickness(5),
                                  FontSize = 14,
@@ -101,11 +99,17 @@ namespace HavenSoft.HexManiac.WPF.Windows {
                                  },
                               },
                            },
-                        },
-                     };
-                     window.ShowDialog();
-                  },
+                     },
+                  };
+                  window.ShowDialog();
                },
+            };
+
+            edit.CanRunChanged += (sender, e) => command.CanExecuteChanged.Invoke(command, EventArgs.Empty);
+
+            QuickEdits.Items.Add(new MenuItem {
+               Header = edit.Name,
+               Command = command,
             });
          }
       }

--- a/src/HexManiac.WPF/Windows/ThemeSelector.xaml
+++ b/src/HexManiac.WPF/Windows/ThemeSelector.xaml
@@ -12,7 +12,7 @@
       <StackPanel HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,0,0,10">
          <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
             <TextBlock Text="Text Color:" Foreground="{Binding PrimaryColor}"/>
-            <TextBox Name="Primary" Foreground="{Binding PrimaryColor}" Background="{Binding Backlight}" Text="{Binding PrimaryColor, UpdateSourceTrigger=PropertyChanged}" Width="200" Margin="5,0"/>
+            <TextBox Name="Primary" Foreground="{Binding Primary}" Background="{Binding Backlight}" Text="{Binding PrimaryColor, UpdateSourceTrigger=PropertyChanged}" Width="200" Margin="5,0"/>
             <Popup PlacementTarget="{Binding ElementName=Primary}" Placement="Bottom" HorizontalOffset="-30" IsOpen="{Binding ElementName=Primary, Path=IsKeyboardFocused, Mode=OneWay}">
                <controls:Swatch Result="{Binding PrimaryColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="230" Height="200"/>
             </Popup>


### PR DESCRIPTION
* Found the `TutorCompatibility` table.
* Found the `TutorMoves` table.
* Added Utilities -> "Make Tutors Expandable"
trying to edit tutors without this option works. You can edit any of the existing tutors, as well as edit any of the existing compatibility. But if you want to expand to new tutors, that requires changes to the ASM inside the ROM. Luckily, I can make those changes for you. But since that's generally more than what a Hex Editor should do automatically, I included an option to let you do it manually. For FireRed / LeafGreen, this also removes the three 'special' tutors for the elemental hyperbeams. But you can easily add them back if you want to.
* No tutor support for Ruby / Sapphire
Those games don't have tutors in them. I didn't take the time to make it possible to add them. If you want tutors in your game, pick a game that already has them. But I do support LeafGreen.
* Better error display
When I run, I always have a debugger attached. But my users don't have a debugger. So now HexManiac will give a crash.log file whenever an error happens, and give the user a little more info as to what's going on. It'll also recommend that they INFORM ME about issues that they find.
