### PR TITLE
Bugfixes

### DIFF
--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -500,6 +500,7 @@ namespace HavenSoft.HexManiac.Core.Models {
             var requiredByteLength = (int)Math.Ceiling(arrayRun.ElementCount / 8.0);
             for (int segmentIndex = 0; segmentIndex < newTable.ElementContent.Count; segmentIndex++) {
                if (!(newTable.ElementContent[segmentIndex] is ArrayRunBitArraySegment bitSegment)) continue;
+               if (bitSegment.SourceArrayName != anchor) continue;
                if (bitSegment.Length == requiredByteLength) continue;
                newTable = (ArrayRun)RelocateForExpansion(changeToken, table, newTable.ElementCount * (newTable.ElementLength - bitSegment.Length + requiredByteLength));
                // within the new table, shift all the data to fit the new data width

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -401,7 +401,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          length += offsets.SegmentOffset;
          for (int i = offsets.ElementIndex; i < ElementCount && length > 0; i++) {
             var offset = offsets.SegmentStart;
-            if (offsets.SegmentIndex == 0) text.Append(ExtendArray);
+            if (offsets.SegmentIndex == 0 && offsets.ElementIndex > 0) text.Append(ExtendArray);
             for (int j = offsets.SegmentIndex; j < ElementContent.Count && length > 0; j++) {
                var segment = ElementContent[j];
                text.Append(segment.ToText(data, offset).Trim());


### PR DESCRIPTION
* bit arrays should not change the number of bits per element when the source length changes, only when the enum length changes.
* to reduce ambiguity for copy/paste, the first element in a table should not start with the append (+) character, since tables are always guaranteed to have at least one element in them.