### PR TITLE
Bugfix: Moving Table Pointers

### DIFF
--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -177,7 +177,7 @@ namespace HavenSoft.HexManiac.Core.Models {
                      Debug.Assert(run.Start <= source);
                      Debug.Assert(ReadPointer(source) == runs[i].Start);
                   } else {
-                     Debug.Fail("Pointer must be a PointerRun or live within an ArrayRun");
+                     Debug.Fail($"Pointer must be a {nameof(PointerRun)} or live within an {nameof(ArrayRun)}");
                   }
                }
             }

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -414,7 +414,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          }
       }
 
-      public IFormattedRun Move(int newStart) {
+      public ArrayRun Move(int newStart) {
          return new ArrayRun(owner, FormatString, LengthFromAnchor, newStart, ElementCount, ElementContent, PointerSources, PointerSourcesForInnerElements);
       }
 


### PR DESCRIPTION
Whenever you move a table, the things that the table points to are aware that they're being pointed to. They need to know about the new location that's pointing to them, and they need to remove the old location that is no longer pointing to them.

This changelist includes:
* Improvements to the `ResolveConflicts` routine to make it more accurate.
* A unit test capturing the bug
* Code changes fixing the bug