### PR TITLE
Copy Text bugfix

### DIFF
--- a/src/HexManiac.Core/Models/PCSString.cs
+++ b/src/HexManiac.Core/Models/PCSString.cs
@@ -63,6 +63,8 @@ namespace HavenSoft.HexManiac.Core.Models {
                result.Append(data[startIndex + i + 1].ToString("X2"));
                i++;
             }
+
+            if (currentByte == 0xFF) break;
          }
          return result.ToString();
       }

--- a/src/HexManiac.Tests/StringModelTests.cs
+++ b/src/HexManiac.Tests/StringModelTests.cs
@@ -450,5 +450,16 @@ namespace HavenSoft.HexManiac.Tests {
 
          Assert.Equal(0xFF, data[4]);
       }
+
+      [Fact]
+      public void CopyTextArrayEntryDoesNotCopyMultipleEndOfStreams() {
+         var model = new PokemonModel(Enumerable.Range(0, 0x200).Select(i => (byte)0xFF).ToArray());
+         ArrayRun.TryParse(model, "[name\"\"6]4", 0, null, out var run);
+         model.ObserveAnchorWritten(new ModelDelta(), "table", run);
+
+         var text = model.Copy(() => new ModelDelta(), 6, 6).Trim();
+
+         Assert.Equal("+\"\"", text);
+      }
    }
 }

--- a/src/HexManiac.Tests/StringModelTests.cs
+++ b/src/HexManiac.Tests/StringModelTests.cs
@@ -453,7 +453,7 @@ namespace HavenSoft.HexManiac.Tests {
 
       [Fact]
       public void CopyTextArrayEntryDoesNotCopyMultipleEndOfStreams() {
-         var model = new PokemonModel(Enumerable.Range(0, 0x200).Select(i => (byte)0xFF).ToArray());
+         var model = new PokemonModel(Enumerable.Repeat((byte)0xFF, 0x200).ToArray());
          ArrayRun.TryParse(model, "[name\"\"6]4", 0, null, out var run);
          model.ObserveAnchorWritten(new ModelDelta(), "table", run);
 


### PR DESCRIPTION
When copying text, don't copy all the bytes (in the case of a fixed-length string): just copy until the end-of-stream byte. This makes paste work better.