### PR TITLE
Cut in table should not delete entire table

### DIFF
--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -440,7 +440,18 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
             var selectionEnd = scroll.ViewPointToDataIndex(selection.SelectionEnd);
             var left = Math.Min(selectionStart, selectionEnd);
             var right = Math.Max(selectionStart, selectionEnd);
-            Model.ClearFormatAndData(history.CurrentChange, left, right - left + 1);
+            var startRun = Model.GetNextRun(left);
+            var endRun = Model.GetNextRun(right);
+            if (startRun == endRun && startRun.Start <= left && (startRun.Start < left || startRun.Start + startRun.Length - 1 > right) && startRun is ArrayRun arrayRun) {
+               for (int i = 0; i < arrayRun.ElementCount; i++) {
+                  var start = arrayRun.Start + arrayRun.ElementLength * i;
+                  if (start + arrayRun.ElementLength <= left) continue;
+                  if (start > right) break;
+                  for (int j = 0; j < arrayRun.ElementLength; j++) history.CurrentChange.ChangeData(Model, start + j, 0xFF);
+               }
+            } else {
+               Model.ClearFormatAndData(history.CurrentChange, left, right - left + 1);
+            }
             RefreshBackingData();
          };
 

--- a/src/HexManiac.Tests/ViewPortEditTests.cs
+++ b/src/HexManiac.Tests/ViewPortEditTests.cs
@@ -401,5 +401,14 @@ namespace HavenSoft.HexManiac.Tests {
          bitArray = (ArrayRunBitArraySegment)((ArrayRun)Model.GetNextRun(0x80)).ElementContent[0];
          Assert.Equal(1, bitArray.Length);
       }
+
+      [Fact]
+      public void ClearTableClearsCurrentItemOnly() {
+         CreateTextTable("table", 0, "A B C D E F G".Split(' '));
+         ViewPort.SelectionStart = new Point(4, 0);
+         ViewPort.Clear.Execute();
+
+         Assert.IsType<PCS>(ViewPort[2, 0].Format);
+      }
    }
 }


### PR DESCRIPTION
Tables can contain many entries. If the user decides to delete or cut an entry, it should only effect that single entry instead of the entire array.

If the cut or delete has the entire table selected or also selects something from outside the table, the correct behavior is less clear, so keep the implementation the same.