### PR TITLE
Replace Autosearch with a more hardcoded, but less finicky method

### DIFF
--- a/src/HexManiac.Core/HexManiac.Core.csproj
+++ b/src/HexManiac.Core/HexManiac.Core.csproj
@@ -48,6 +48,7 @@
     <Compile Include="ICommandExtensions.cs" />
     <Compile Include="Models\Code\ScriptParser.cs" />
     <Compile Include="Models\Code\ThumbParser.cs" />
+    <Compile Include="Models\HardcodeTablesModel.cs" />
     <Compile Include="Models\Runs\ArrayRun.cs" />
     <Compile Include="Models\AutoSearchModel.cs" />
     <Compile Include="Models\ErrorInfo.cs" />

--- a/src/HexManiac.Core/Models/AutoSearchModel.cs
+++ b/src/HexManiac.Core/Models/AutoSearchModel.cs
@@ -6,6 +6,9 @@ using System.Linq;
 using static HavenSoft.HexManiac.Core.Models.Runs.ArrayRun;
 
 namespace HavenSoft.HexManiac.Core.Models {
+   /// <summary>
+   /// Attempt to search through the rom to find tables that we expect to be in there.
+   /// </summary>
    public class AutoSearchModel : PokemonModel {
       public const string
          Ruby = "AXVE",

--- a/src/HexManiac.Core/Models/HardcodeTablesModel.cs
+++ b/src/HexManiac.Core/Models/HardcodeTablesModel.cs
@@ -1,0 +1,219 @@
+﻿using HavenSoft.HexManiac.Core.Models.Runs;
+using System.Collections.Generic;
+using System.Linq;
+using static HavenSoft.HexManiac.Core.Models.AutoSearchModel;
+
+namespace HavenSoft.HexManiac.Core.Models {
+   /// <summary>
+   /// An alternative to the AutoSearchModel.
+   /// Instead of using a 'smart' search algorithm to find all the data,
+   /// follow hard-coded expected pointers to the known data.
+   /// This should still be somewhat robust: the data may move, but the pointers to the data are more likely to be stable.
+   ///
+   /// Lengths of some tables are still calculated dynamically based on best-fit, so operations like adding pokemon from a separate tool should still be picked up correctly.
+   /// </summary>
+   public class HardcodeTablesModel : PokemonModel {
+      private readonly string gameCode;
+      private readonly ModelDelta noChangeDelta = new NoDataChangeDeltaModel();
+
+      /// <summary>
+      /// The first 0x100 bytes of the GBA rom is always the header.
+      /// The next 0x100 bytes contains some tables and some startup code, but nothing interesting to point to.
+      /// Choosing 0x200 might prevent us from seeing an actual anchor, but it will also remove a bunch
+      ///      of false positives and keep us from getting conflicts with the RomName (see DecodeHeader).
+      /// </summary>
+      public override int EarliestAllowedAnchor => 0x200;
+
+      public HardcodeTablesModel(byte[] data, StoredMetadata metadata = null) : base(data, metadata) {
+         if (metadata != null && !metadata.IsEmpty) return;
+
+         gameCode = string.Concat(Enumerable.Range(0xAC, 4).Select(i => ((char)data[i]).ToString()));
+
+         // in vanilla emerald, this pointer isn't four-byte aligned
+         // it's at the very front of the ROM, so if there's no metadata we can be pretty sure that the pointer is still there
+         if (gameCode == Emerald && data[0x1C3] == 0x08) ObserveRunWritten(noChangeDelta, new PointerRun(0x1C0));
+
+         var gamesToDecode = new[] { Ruby, Sapphire, Emerald, FireRed, LeafGreen };
+         if (gamesToDecode.Contains(gameCode)) {
+            DecodeHeader();
+            DecodeNameArrays();
+            DecodeDataArrays();
+            DecodeStreams();
+         }
+
+         ResolveConflicts();
+      }
+
+      private void DecodeHeader() {
+         ObserveAnchorWritten(noChangeDelta, "GameTitle", new AsciiRun(0xA0, 12));
+         ObserveAnchorWritten(noChangeDelta, "GameCode", new AsciiRun(0xAC, 4));
+         ObserveAnchorWritten(noChangeDelta, "MakerCode", new AsciiRun(0xB0, 2));
+
+         if (gameCode != Ruby && gameCode != Sapphire) {
+            ObserveAnchorWritten(noChangeDelta, "RomName", new AsciiRun(0x108, 0x20));
+         }
+      }
+
+      private void DecodeNameArrays() {
+         int source = 0;
+
+         // pokenames
+         switch (gameCode) {
+            case FireRed: case LeafGreen: case Emerald: source = 0x000144; break;
+            case Ruby: case Sapphire:                   source = 0x00FA58; break;
+         }
+         AddTable(source, EggMoveRun.PokemonNameTable, "[name\"\"11]");
+
+         // movenames
+         switch (gameCode) {
+            case FireRed: case LeafGreen: case Emerald: source = 0x000148; break;
+            case Ruby: case Sapphire:                   source = 0x02E180; break;
+         }
+         AddTable(source, EggMoveRun.MoveNamesTable, "[name\"\"13]");
+
+         // abilitynames
+         switch (gameCode) {
+            case FireRed: case LeafGreen: case Emerald: source = 0x0001C0; break;
+            case Ruby: case Sapphire:                   source = 0x09FE64; break;
+         }
+         AddTable(source, "abilitynames", "[name\"\"13]");
+
+         // trainerclassnames
+         switch (gameCode) {
+            case FireRed: case LeafGreen:               source = AllSourcesToSameDestination(source)[1] + 0x9C; break;
+            case Emerald:                               source = 0x0183B4; break;
+            case Ruby: case Sapphire:                   source = 0x1217BC; break;
+         }
+         AddTable(source, "trainerclassnames", "[name\"\"13]");
+
+         // types
+         switch (gameCode) {
+            case FireRed: case LeafGreen:               source = 0x0309C8; break;
+            case Emerald:                               source = 0x0166F4; break;
+            case Ruby: case Sapphire:                   source = 0x02E3A8; break;
+         }
+         AddTable(source, "types", "^[name\"\"7]");
+
+         // abilitydescriptions
+         switch (gameCode) {
+            case FireRed: case LeafGreen: case Emerald: source = 0x0001C4; break;
+            case Ruby: case Sapphire:                   source = 0x09FE68; break;
+         }
+         AddTable(source, "abilitydescriptions", $"[description<{PCSRun.SharedFormatString}>]abilitynames");
+
+      }
+
+      private void DecodeDataArrays() {
+         int source = 0;
+
+         // pokestats
+         switch (gameCode) {
+            case FireRed: case LeafGreen: case Emerald: source = 0x0001BC; break;
+            case Ruby: case Sapphire:                   source = 0x010B64; break;
+         }
+         var format = $"[hp. attack. def. speed. spatk. spdef. type1.types type2.types catchRate. baseExp. evs: item1:items item2:items genderratio. steps2hatch. basehappiness. growthrate. egg1. egg2. ability1.abilitynames ability2.abilitynames runrate. unknown. padding:]{EggMoveRun.PokemonNameTable}";
+         AddTable(source, "pokestats", format);
+
+         // items
+         switch (gameCode) {
+            case FireRed: case LeafGreen: case Emerald: source = 0x0001C8; break;
+            case Ruby: case Sapphire:                   source = 0x0A98F0; break;
+         }
+         format = $"[name\"\"14 index: price: holdeffect: description<{PCSRun.SharedFormatString}> keyitemvalue. bagkeyitem. pocket. type. fieldeffect<> battleusage:: battleeffect<> battleextra::]";
+         AddTable(source, "items", format);
+
+         // movedata
+         switch (gameCode) {
+            case FireRed: case LeafGreen: case Emerald: source = 0x0001CC; break;
+            case Ruby: case Sapphire:                   source = 0x00CA54; break;
+         }
+         format = $"[effect. power. type.types accuracy. pp. effectAccuracy. target. priority. more::]{EggMoveRun.MoveNamesTable}";
+         AddTable(source, "movedata", format);
+
+         // lvlmoves
+         switch (gameCode) {
+            case FireRed: case LeafGreen:               source = 0x03EA7C; break;
+            case Emerald:                               source = 0x06930C; break;
+            case Ruby: case Sapphire:                   source = 0x03B7BC; break;
+         }
+         AddTable(source, "lvlmoves", $"[moves<{PLMRun.SharedFormatString}>]{EggMoveRun.PokemonNameTable}");
+
+         // tutormoves / tutorcompatibility
+         if (gameCode != Ruby && gameCode != Sapphire) {
+            switch (gameCode) {
+               case FireRed:                            source = 0x120BE4; break;
+               case LeafGreen:                          source = 0x120BBC; break;
+               case Emerald:                            source = 0x1B236C; break;
+            }
+            format = $"[move:{EggMoveRun.MoveNamesTable}]" + (gameCode == Emerald ? 30 : 15);
+            AddTable(source, MoveTutors, format);
+            source = GetNextRun(AllSourcesToSameDestination(source).Last() + 4).Start;
+            format = $"[pokemon|b[]{MoveTutors}]{EggMoveRun.PokemonNameTable}";
+            AddTable(source, TutorCompatibility, format);
+         }
+
+         // tmmoves
+         switch (gameCode) {
+            case FireRed: case LeafGreen:               source = 0x125A60; break;
+            case Emerald:                               source = 0x1B6D10; break;
+            case Ruby: case Sapphire:                   source = 0x06F038; break;
+         }
+         source = GetNextRun(source).Start;
+         AddTable(source, TmMoves, $"[move:{EggMoveRun.MoveNamesTable}]58");
+
+         // tmcompatibility
+         switch (gameCode) {
+            case FireRed: case LeafGreen:               source = 0x043C68; break;
+            case Emerald:                               source = 0x06E048; break;
+            case Ruby: case Sapphire:                   source = 0x0403B0; break;
+         }
+         AddTable(source, TmCompatibility, $"[pokemon|b[]{TmMoves}]{EggMoveRun.PokemonNameTable}");
+
+         // hmmoves
+         switch (gameCode) {
+            case FireRed: case LeafGreen:               source = 0x0441DC; break;
+            case Emerald:                               source = 0x06E828; break;
+            case Ruby: case Sapphire:                   source = 0x040A24; break;
+         }
+         AddTable(source, HmMoves, $"[move:{EggMoveRun.MoveNamesTable}]8");
+
+         // itemimages
+         switch (gameCode) {
+            case FireRed: case LeafGreen:               source = 0x098970; break;
+            case Emerald:                               source = 0x1B0034; break;
+            case Ruby: case Sapphire:                   source = -1;       break;
+         }
+         source = GetNextRun(source).Start;
+         AddTable(source, "itemimages", "[image<> palette<>]items");
+      }
+
+      private void DecodeStreams() {
+         int source = 0;
+
+         // eggmoves
+         switch (gameCode) {
+            case FireRed: case LeafGreen:               source = 0x045C50; break;
+            case Emerald:                               source = 0x0703F0; break;
+            case Ruby: case Sapphire:                   source = 0x041B44; break;
+         }
+
+         ObserveAnchorWritten(noChangeDelta, "eggmoves", new EggMoveRun(this, ReadPointer(source)));
+      }
+
+      private IReadOnlyList<int> AllSourcesToSameDestination(int source) {
+         var destination = ReadPointer(source);
+         var run = GetNextRun(destination);
+         return run.PointerSources;
+      }
+
+      private void AddTable(int source, string name, string format) {
+         if (source < 0 || source > RawData.Length) return;
+         var destination = ReadPointer(source);
+         if (destination < 0 || destination > RawData.Length) return;
+         var errorInfo = ArrayRun.TryParse(this, format, destination, null, out var arrayRun);
+         if (!errorInfo.HasError) {
+            ObserveAnchorWritten(noChangeDelta, name, arrayRun);
+         }
+      }
+   }
+}

--- a/src/HexManiac.Core/Models/HardcodeTablesModel.cs
+++ b/src/HexManiac.Core/Models/HardcodeTablesModel.cs
@@ -147,7 +147,9 @@ namespace HavenSoft.HexManiac.Core.Models {
             }
             format = $"[move:{EggMoveRun.MoveNamesTable}]" + (gameCode == Emerald ? 30 : 15);
             AddTable(source, MoveTutors, format);
-            source = GetNextRun(AllSourcesToSameDestination(source).Last() + 4).Start;
+            var compatibilityPointer = GetNextRun(AllSourcesToSameDestination(source).Last() + 4);
+            while (!(compatibilityPointer is PointerRun) && compatibilityPointer.Start < Count) compatibilityPointer = GetNextRun(compatibilityPointer.Start + compatibilityPointer.Length);
+            source = compatibilityPointer.Start;
             format = $"[pokemon|b[]{MoveTutors}]{EggMoveRun.PokemonNameTable}";
             AddTable(source, TutorCompatibility, format);
          }

--- a/src/HexManiac.Core/Models/HardcodeTablesModel.cs
+++ b/src/HexManiac.Core/Models/HardcodeTablesModel.cs
@@ -67,7 +67,7 @@ namespace HavenSoft.HexManiac.Core.Models {
          // movenames
          switch (gameCode) {
             case FireRed: case LeafGreen: case Emerald: source = 0x000148; break;
-            case Ruby: case Sapphire:                   source = 0x02E180; break;
+            case Ruby: case Sapphire:                   source = 0x02E18C; break;
          }
          AddTable(source, EggMoveRun.MoveNamesTable, "[name\"\"13]");
 

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -89,8 +89,8 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          if (ElementContent.Count == 1) flags |= FormatMatchFlags.IsSingleSegment;
 
          if (length.Length == 0) {
-            var nextRun = owner.GetNextRun(Start);
-            while (nextRun is NoInfoRun && nextRun.Start < owner.Count) nextRun = owner.GetNextRun(nextRun.Start + 1);
+            var nextRun = owner.GetNextAnchor(Start + ElementLength);
+            while (nextRun.Start < owner.Count && (nextRun.Start - Start) % ElementLength == 0 && !(nextRun is ArrayRun)) nextRun = owner.GetNextAnchor(nextRun.Start + nextRun.Length);
             var byteLength = 0;
             var elementCount = 0;
             while (Start + byteLength + ElementLength <= nextRun.Start && DataMatchesElementFormat(owner, Start + byteLength, ElementContent, flags, nextRun)) {

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -101,6 +101,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
             while (Start + byteLength + ElementLength <= nextRun.Start && DataMatchesElementFormat(owner, Start + byteLength, ElementContent, flags, nextRun)) {
                byteLength += ElementLength;
                elementCount++;
+               if (elementCount == 100) flags |= FormatMatchFlags.AllowJunkAfterText;
             }
             LengthFromAnchor = string.Empty;
             ElementCount = Math.Max(1, elementCount); // if the user said there's a format here, then there is, even if the format it wrong.

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -105,6 +105,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
             }
             LengthFromAnchor = string.Empty;
             ElementCount = Math.Max(1, elementCount); // if the user said there's a format here, then there is, even if the format it wrong.
+            FormatString += ElementCount;
          } else if (int.TryParse(length, out int result)) {
             // fixed length is easy
             LengthFromAnchor = string.Empty;

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -90,7 +90,12 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
 
          if (length.Length == 0) {
             var nextRun = owner.GetNextAnchor(Start + ElementLength);
-            while (nextRun.Start < owner.Count && (nextRun.Start - Start) % ElementLength == 0 && !(nextRun is ArrayRun)) nextRun = owner.GetNextAnchor(nextRun.Start + nextRun.Length);
+            for (; true; nextRun = owner.GetNextAnchor(nextRun.Start + nextRun.Length)) {
+               if (nextRun.Start > owner.Count) break;
+               var anchorName = owner.GetAnchorFromAddress(-1, nextRun.Start);
+               if (string.IsNullOrEmpty(anchorName)) continue;
+               if ((nextRun.Start - Start) % ElementLength != 0) break;
+            }
             var byteLength = 0;
             var elementCount = 0;
             while (Start + byteLength + ElementLength <= nextRun.Start && DataMatchesElementFormat(owner, Start + byteLength, ElementContent, flags, nextRun)) {

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -133,7 +133,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          var results = new List<string>();
          for (int i = 0; i < optionCount; i++) {
             var elementStart = enumArray.Start + enumArray.ElementLength * i;
-            var valueWithQuotes = PCSString.Convert(model, elementStart, enumArray.ElementContent[0].Length).Trim();
+            var valueWithQuotes = PCSString.Convert(model, elementStart, enumArray.ElementContent[0].Length)?.Trim() ?? string.Empty;
 
             if (valueWithQuotes.Contains(' ')) {
                results.Add(valueWithQuotes);

--- a/src/HexManiac.Core/ViewModels/EditorViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/EditorViewModel.cs
@@ -289,7 +289,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                   metadataText = fileSystem.MetadataFor(file.Name) ?? new string[0];
                }
                var metadata = new StoredMetadata(metadataText);
-               var viewPort = new ViewPort(file.Name, new AutoSearchModel(file.Contents, metadata));
+               var viewPort = new ViewPort(file.Name, new HardcodeTablesModel(file.Contents, metadata));
                if (metadata.IsEmpty) {
                   var createdMetadata = viewPort.Model.ExportMetadata().Serialize();
                   fileSystem.SaveMetadata(file.Name, createdMetadata);

--- a/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
@@ -96,7 +96,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
       }
 
       public string UpdateViewModelFromModel(FieldArrayElementViewModel viewModel) {
-         var text = PCSString.Convert(viewModel.Model, viewModel.Start, viewModel.Length).Trim();
+         var text = PCSString.Convert(viewModel.Model, viewModel.Start, viewModel.Length)?.Trim() ?? string.Empty;
 
          // take off quotes
          if (text.StartsWith("\"")) text = text.Substring(1);

--- a/src/HexManiac.Tests/ArrayRunTests.cs
+++ b/src/HexManiac.Tests/ArrayRunTests.cs
@@ -189,7 +189,7 @@ namespace HavenSoft.HexManiac.Tests {
          viewPort.SelectionStart = new Point(0, 0);
          viewPort.FollowLink(0, 0);
 
-         Assert.Equal("^pokenames[name\"\"11]", viewPort.AnchorText);
+         Assert.Equal("^pokenames[name\"\"11]2", viewPort.AnchorText); // you don't need a length to make one, but a length gets automatically added.
          Assert.Equal("BULBASAUR", viewPort.Tools.StringTool.Content.Split(Environment.NewLine).Last());
       }
 

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -155,14 +155,14 @@ namespace HavenSoft.HexManiac.Tests {
 
          var address = model.GetAddressFromAnchor(noChange, -1, "trainerclassnames");
          var run = (ArrayRun)model.GetNextAnchor(address);
-         if (game.Contains("Altair")) Assert.Equal(66, run.ElementCount);
-         else if (game.Contains("Emerald")) Assert.Equal(66, run.ElementCount);
-         else if (game.Contains("FireRed")) Assert.Equal(107, run.ElementCount);
-         else if (game.Contains("DarkRisingKAIZO")) Assert.Equal(107, run.ElementCount);
-         else if (game.Contains("LeafGreen")) Assert.Equal(107, run.ElementCount);
-         else if (game.Contains("Ruby")) Assert.Equal(58, run.ElementCount);
-         else if (game.Contains("Sapphire")) Assert.Equal(58, run.ElementCount);
-         else if (game.Contains("Vega")) Assert.Equal(107, run.ElementCount);
+         if (game.Contains("Altair")) Assert.Equal(67, run.ElementCount);
+         else if (game.Contains("Emerald")) Assert.Equal(67, run.ElementCount);
+         else if (game.Contains("FireRed")) Assert.Equal(108, run.ElementCount);
+         else if (game.Contains("DarkRisingKAIZO")) Assert.Equal(108, run.ElementCount);
+         else if (game.Contains("LeafGreen")) Assert.Equal(108, run.ElementCount);
+         else if (game.Contains("Ruby")) Assert.Equal(59, run.ElementCount);
+         else if (game.Contains("Sapphire")) Assert.Equal(59, run.ElementCount);
+         else if (game.Contains("Vega")) Assert.Equal(108, run.ElementCount);
       }
 
       [SkippableTheory]
@@ -311,7 +311,7 @@ namespace HavenSoft.HexManiac.Tests {
          // the 4 bytes after the last pointer to tutor-compatibility should store the length of tutormoves
          table = (ArrayRun)model.GetNextRun(model.GetAddressFromAnchor(new ModelDelta(), -1, AutoSearchModel.MoveTutors));
          var tutorCompatibilityPointerSources = model.GetNextRun(model.GetAddressFromAnchor(new ModelDelta(), -1, AutoSearchModel.TutorCompatibility)).PointerSources;
-         var word = (WordRun)model.GetNextRun(tutorCompatibilityPointerSources.Last() + 4);
+         var word = (WordRun)model.GetNextRun(tutorCompatibilityPointerSources.First() + 4);
          Assert.Equal(table.ElementCount, model.ReadValue(word.Start));
       }
 

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -158,7 +158,7 @@ namespace HavenSoft.HexManiac.Tests {
          if (game.Contains("Altair")) Assert.Equal(67, run.ElementCount);
          else if (game.Contains("Emerald")) Assert.Equal(67, run.ElementCount);
          else if (game.Contains("FireRed")) Assert.Equal(108, run.ElementCount);
-         else if (game.Contains("DarkRisingKAIZO")) Assert.Equal(108, run.ElementCount);
+         else if (game.Contains("DarkRisingKAIZO")) Assert.Equal(107, run.ElementCount);
          else if (game.Contains("LeafGreen")) Assert.Equal(108, run.ElementCount);
          else if (game.Contains("Ruby")) Assert.Equal(59, run.ElementCount);
          else if (game.Contains("Sapphire")) Assert.Equal(59, run.ElementCount);
@@ -259,13 +259,6 @@ namespace HavenSoft.HexManiac.Tests {
          var movesLocation = model.GetAddressFromAnchor(noChange, -1, AutoSearchModel.TmMoves);
          var hmLocation = model.GetAddressFromAnchor(noChange, -1, AutoSearchModel.HmMoves);
          var compatibilityLocation = model.GetAddressFromAnchor(noChange, -1, AutoSearchModel.TmCompatibility);
-
-         // Clover changes the code to make HM Moves forgettable, so finding doesn't work automatically.
-         if (game.Contains("Clover")) {
-            Assert.Equal(Pointer.NULL, movesLocation);
-            Assert.Equal(Pointer.NULL, compatibilityLocation);
-            return;
-         }
 
          var tmMoves = (ArrayRun)model.GetNextRun(movesLocation);
          var hmMoves = (ArrayRun)model.GetNextRun(hmLocation);

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -44,7 +44,7 @@ namespace HavenSoft.HexManiac.Tests {
 
          var address = model.GetAddressFromAnchor(noChange, -1, EggMoveRun.PokemonNameTable);
          var run = (ArrayRun)model.GetNextAnchor(address);
-         if (game.Contains("Gaia")) Assert.Equal(925, run.ElementCount);
+         if (game.Contains("Gaia")) Assert.Equal(1111, run.ElementCount);
          else Assert.Equal(412, run.ElementCount);
       }
 
@@ -105,7 +105,7 @@ namespace HavenSoft.HexManiac.Tests {
          var address = model.GetAddressFromAnchor(noChange, -1, "types");
          var run = (ArrayRun)model.GetNextAnchor(address);
          if (game.Contains("Clover")) Assert.Equal(24, run.ElementCount);
-         else if (game.Contains("Gaia")) Assert.Equal(24, run.ElementCount);
+         else if (game.Contains("Gaia")) Assert.Equal(25, run.ElementCount);
          else Assert.Equal(18, run.ElementCount);
       }
 
@@ -233,8 +233,7 @@ namespace HavenSoft.HexManiac.Tests {
          var compatibilityLocation = model.GetAddressFromAnchor(noChange, -1, AutoSearchModel.TutorCompatibility);
 
          // ruby and sapphire have no tutors
-         // Gaia has move tutors, but it does a bunch of custom stuff (multiple tables) so I don't feel bad about not supporting it by default.
-         if (game.Contains("Ruby") || game.Contains("Sapphire") || game.Contains("Gaia")) {
+         if (game.Contains("Ruby") || game.Contains("Sapphire")) {
             Assert.Equal(Pointer.NULL, movesLocation);
             Assert.Equal(Pointer.NULL, compatibilityLocation);
             return;
@@ -284,9 +283,9 @@ namespace HavenSoft.HexManiac.Tests {
          editor.Add(viewPort);
          var expandTutors = editor.QuickEdits.Single(edit => edit.Name == "Make Tutors Expandable");
 
-         // ruby/sapphire/gaia do not support this quick-edit
+         // ruby/sapphire do not support this quick-edit
          var canRun = expandTutors.CanRun(viewPort);
-         if (game.Contains("Ruby") || game.Contains("Sapphire") || game.Contains("Gaia")) {
+         if (game.Contains("Ruby") || game.Contains("Sapphire")) {
             Assert.False(canRun);
             return;
          } else {

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -389,19 +389,19 @@ namespace HavenSoft.HexManiac.Tests {
    /// are part of the same Test Collection (because they're in the same class)
    /// </summary>
    public class AutoSearchFixture {
-      private IDictionary<string, AutoSearchModel> modelCache = new Dictionary<string, AutoSearchModel>();
+      private IDictionary<string, PokemonModel> modelCache = new Dictionary<string, PokemonModel>();
 
       public AutoSearchFixture() {
          Parallel.ForEach(AutoSearchTests.PokemonGames.Select(array => (string)array[0]), name => {
             if (!File.Exists(name)) return;
             var data = File.ReadAllBytes(name);
             var metadata = new StoredMetadata(new string[0]);
-            var model = new AutoSearchModel(data, metadata);
+            var model = new HardcodeTablesModel(data, metadata);
             lock (modelCache) modelCache[name] = model;
          });
       }
 
-      public AutoSearchModel LoadModel(string name) {
+      public PokemonModel LoadModel(string name) {
          Skip.IfNot(modelCache.ContainsKey(name));
          return modelCache[name];
       }


### PR DESCRIPTION
The auto-search was designed to not need to know anything about what points to the data: only the format of the data is enough to find it. However, in practice this is very difficult to get right. So instead, I've implemented a new method that depends on pointers to the data that are unlikely to move.