### PR TITLE
Add remaining required features for first public beta

### DIFF
--- a/src/HexManiac.Core/Models/Code/ThumbParser.cs
+++ b/src/HexManiac.Core/Models/Code/ThumbParser.cs
@@ -219,6 +219,8 @@ namespace HavenSoft.HexManiac.Core.Models.Code {
             if (part.StartsWith("0") || part.StartsWith("1")) {
                var code = ToBits(part);
                instructionParts.Add(new InstructionPart(InstructionArgType.OpCode, code, part.Length));
+            } else if (part == "lr") {
+               instructionParts.Add(new InstructionPart(InstructionArgType.Register, 0, 3, part));
             } else if (part.StartsWith("r")) {
                instructionParts.Add(new InstructionPart(InstructionArgType.Register, 0, 3, part));
             } else if (part.StartsWith("#")) {
@@ -478,6 +480,7 @@ namespace HavenSoft.HexManiac.Core.Models.Code {
 
             // read a register
             if (template[0] == 'r') {
+               if (line.StartsWith("lr")) line = "r14" + line.Substring(2);
                if (line[0] != 'r') return false;
                var name = "r" + template[1];
                var instruction = instructionParts.Single(i => i.Name == name);

--- a/src/HexManiac.Core/Models/HardcodeTablesModel.cs
+++ b/src/HexManiac.Core/Models/HardcodeTablesModel.cs
@@ -15,6 +15,7 @@ namespace HavenSoft.HexManiac.Core.Models {
    /// </summary>
    public class HardcodeTablesModel : PokemonModel {
       public const string WildTableName = "wild";
+      public const string SpecialsTable = "specials";
       public const string ItemsTableName = "items";
       public const string DexInfoTableName = "dexinfo";
       public const string TrainerTableName = "trainerdata";
@@ -248,6 +249,15 @@ namespace HavenSoft.HexManiac.Core.Models {
          source = Find("0348048009E00000FFFF0000");
          string table(int length) => $"<[rate:: list<[low. high. species:pokenames]{length}>]1>";
          AddTable(source, WildTableName, $"[bank. map. unused: grass{table(12)} surf{table(5)} tree{table(5)} fish{table(10)}]");
+
+         // specials
+         switch (gameCode) {
+            case FireRed: case LeafGreen: source = 0x069F18; break;
+            case Ruby: source = 0x0658B4; break;
+            case Sapphire: source = 0x0658B8; break;
+            case Emerald: source = 0x099314; break;
+         }
+         AddTable(source, SpecialsTable, "[code<>]");
       }
 
       private void DecodeDexArrays() {

--- a/src/HexManiac.Core/Models/HardcodeTablesModel.cs
+++ b/src/HexManiac.Core/Models/HardcodeTablesModel.cs
@@ -31,6 +31,13 @@ namespace HavenSoft.HexManiac.Core.Models {
       public const string MoveDescriptionsName = "movedescriptions";
       public const string ConversionDexTableName = "hoennToNational";
 
+      public const string MoveInfoListName = "moveinfo";
+      public const string MoveEffectListName = "moveeffects";
+      public const string MoveTargetListName = "movetarget";
+      public const string DecorationsShapeListName = "decorshape";
+      public const string DecorationsCategoryListName = "decorcategory";
+      public const string DecorationsPermissionListName = "decorpermissions";
+
       private readonly string gameCode;
       private readonly ModelDelta noChangeDelta = new NoDataChangeDeltaModel();
 
@@ -53,6 +60,7 @@ namespace HavenSoft.HexManiac.Core.Models {
 
          var gamesToDecode = new[] { Ruby, Sapphire, Emerald, FireRed, LeafGreen };
          if (gamesToDecode.Contains(gameCode)) {
+            AddDefaultLists();
             DecodeHeader();
             DecodeNameArrays();
             DecodeDataArrays();
@@ -171,7 +179,7 @@ namespace HavenSoft.HexManiac.Core.Models {
             case FireRed: case LeafGreen: case Emerald: source = 0x0001CC; break;
             case Ruby: case Sapphire: source = 0x00CA54; break;
          }
-         format = $"[effect. power. type.types accuracy. pp. effectAccuracy. target. priority. more::]{EggMoveRun.MoveNamesTable}";
+         format = $"[effect.{MoveEffectListName} power. type.types accuracy. pp. effectAccuracy. target|b[]{MoveTargetListName} priority. info|b[]{MoveInfoListName} unused. unused:]{EggMoveRun.MoveNamesTable}";
          AddTable(source, "movedata", format);
 
          // lvlmoves
@@ -180,7 +188,9 @@ namespace HavenSoft.HexManiac.Core.Models {
             case Emerald: source = 0x06930C; break;
             case Ruby: case Sapphire: source = 0x03B7BC; break;
          }
-         AddTable(source, LevelMovesTableName, $"[movesFromLevel<{PLMRun.SharedFormatString}>]{EggMoveRun.PokemonNameTable}");
+         using (ModelCacheScope.CreateScope(this)) { // cares about pokenames and movenames
+            AddTable(source, LevelMovesTableName, $"[movesFromLevel<{PLMRun.SharedFormatString}>]{EggMoveRun.PokemonNameTable}");
+         }
 
          // tutormoves / tutorcompatibility
          if (gameCode != Ruby && gameCode != Sapphire) {
@@ -243,7 +253,7 @@ namespace HavenSoft.HexManiac.Core.Models {
             case FireRed: case LeafGreen: case Emerald: source = 0x00014C; break;
             case Ruby: case Sapphire: source = 0x0B3AC8; break;
          }
-         AddTable(source, DecorationsTableName, $"[id. name\"\"16 permission. shape. category. price:: description<\"\"> graphics<>]");
+         AddTable(source, DecorationsTableName, $"[id. name\"\"16 permission.{DecorationsPermissionListName} shape.{DecorationsShapeListName} category.{DecorationsCategoryListName} price:: description<\"\"> graphics<>]");
 
          // wild pokemon
          source = Find("0348048009E00000FFFF0000");
@@ -324,6 +334,288 @@ namespace HavenSoft.HexManiac.Core.Models {
          AddTable(source, TypeChartTableName, "[attack.types defend.types strength.]!FEFE00");
          var run = GetNextAnchor(GetAddressFromAnchor(noChangeDelta, -1, TypeChartTableName)) as ITableRun;
          if (run != null) AddTableDirect(run.Start + run.Length, TypeChartTableName2, "[attack.types defend.types strength.]!FFFF00");
+      }
+
+      private void AddDefaultLists() {
+         #region Move Effects
+         var moveEffects = new string[214];
+         moveEffects[0] = "None";
+         moveEffects[1] = "SleepPrimary";
+         moveEffects[2] = "Poison";
+         moveEffects[3] = "HealHalf";
+         moveEffects[4] = "Burn";
+         moveEffects[5] = "Freeze";
+         moveEffects[6] = "Paralyze";
+         moveEffects[7] = "Suicide";
+         moveEffects[8] = "HealHalfIfOpponentSleeping";
+         moveEffects[9] = "RepeatFoeMove";
+         moveEffects[10] = "RaiseAttackPrimary";
+         moveEffects[11] = "RaiseDefensePrimary";
+         moveEffects[12] = "???RaiseSpeedPrimary???";
+         moveEffects[13] = "RaiseAttackSpAttackPrimary";
+         moveEffects[14] = "unknown1";
+         moveEffects[15] = "???RaiseAccuracyPrimary???";
+         moveEffects[16] = "RaiseEvasivenessPrimary";
+         moveEffects[17] = "NeverMiss";
+         moveEffects[18] = "LowerAttackPrimary";
+         moveEffects[19] = "LowerDefensePrimary";
+         moveEffects[20] = "LowerSpeedPrimary";
+         moveEffects[21] = "???LowerAttackSpAttackPrimary???";
+         moveEffects[22] = "unknown2";
+         moveEffects[23] = "LowerAccuracyPrimary";
+         moveEffects[24] = "LowerEvasionPrimary";
+         moveEffects[25] = "RemoveStateChanges";
+         moveEffects[26] = "Bide";
+         moveEffects[27] = "2to3turnsThenConfused";
+         moveEffects[28] = "OpponentSwitch";
+         moveEffects[29] = "2to5hits";
+         moveEffects[30] = "ChangeTypeToFriendlyMove";
+         moveEffects[31] = "Flinch";
+         moveEffects[32] = "Recover";
+         moveEffects[33] = "BadPoisonPrimary";
+         moveEffects[34] = "Money";
+         moveEffects[35] = "RaiseSpDef2Wall";
+         moveEffects[36] = "ParalyzeBurnFreeze";
+         moveEffects[37] = "Rest";
+         moveEffects[38] = "OHKO";
+         moveEffects[39] = "2turnHighCrit";
+         moveEffects[40] = "HalfDamage";
+         moveEffects[41] = "20Damage";
+         moveEffects[42] = "2to5turnTrap";
+         moveEffects[43] = "HighCrit";
+         moveEffects[44] = "2hits";
+         moveEffects[45] = "MissHurtSelf";
+         moveEffects[46] = "PreventStatReduction";
+         moveEffects[47] = "RaiseCriticalRate";
+         moveEffects[48] = "25Recoil";
+         moveEffects[49] = "ConfusionPrimary";
+         moveEffects[50] = "RaiseAttack2Primary";
+         moveEffects[51] = "RaiseDefense2Primary";
+         moveEffects[52] = "RaiseSpeed2Primary";
+         moveEffects[53] = "RaiseSpAtk2Primary";
+         moveEffects[54] = "RaiseSpDef2Primary";
+         moveEffects[55] = "???RaiseAccuracy2Primary???";
+         moveEffects[56] = "???RaiseEvasiveness2Primary???";
+         moveEffects[57] = "Transform";
+         moveEffects[58] = "LowerAttack2Primary";
+         moveEffects[59] = "LowerDefense2Primary";
+         moveEffects[60] = "LowerSpeed2Primary";
+         moveEffects[61] = "???LowerSpAtk2Primary???";
+         moveEffects[62] = "LowerSpDef2Primary";
+         moveEffects[63] = "???";
+         moveEffects[64] = "????";
+         moveEffects[65] = "RaiseDefense2Wall";
+         moveEffects[66] = "PoisonPrimary";
+         moveEffects[67] = "ParalyzePrimary";
+         moveEffects[68] = "LowerAttack";
+         moveEffects[69] = "LowerDefense";
+         moveEffects[70] = "LowerSpeed";
+         moveEffects[71] = "LowerSpAtk";
+         moveEffects[72] = "LowerSpDef";
+         moveEffects[73] = "LowerAccuracy";
+         moveEffects[74] = "?????";
+         moveEffects[75] = "2turnHighCritFlinch";
+         moveEffects[76] = "Confusion";
+         moveEffects[77] = "2hitsPoison";
+         moveEffects[78] = "NeverMiss(VitalThrow)";
+         moveEffects[79] = "Substitute";
+         moveEffects[80] = "SkipNextTurn";
+         moveEffects[81] = "StrongerForLessHealth";
+         moveEffects[82] = "Mimic";
+         moveEffects[83] = "RandomMove";
+         moveEffects[84] = "SeedOpponent";
+         moveEffects[85] = "Splash";
+         moveEffects[86] = "Disable";
+         moveEffects[87] = "DamageBasedOnLevel";
+         moveEffects[88] = "DamageRandom";
+         moveEffects[89] = "DoublePhysicalDamage";
+         moveEffects[90] = "OpponentRepeatMoveFor2to6turns";
+         moveEffects[91] = "PainSplit";
+         moveEffects[92] = "WhileSleepingFlinch";
+         moveEffects[93] = "ChangeTypeToResistPreviousHit";
+         moveEffects[94] = "NextAttackHits";
+         moveEffects[95] = "Sketch";
+         moveEffects[96] = "??????";
+         moveEffects[97] = "SleepTalk";
+         moveEffects[98] = "DestinyBond";
+         moveEffects[99] = "StrengthDependsOnHealth";
+         moveEffects[100] = "ReducePP";
+         moveEffects[101] = "FalseSwipe";
+         moveEffects[102] = "HealPartyStatus";
+         moveEffects[103] = "NormalPlusPriority";
+         moveEffects[104] = "3turnTripleHit";
+         moveEffects[105] = "StealItem";
+         moveEffects[106] = "NoSwitch";
+         moveEffects[107] = "Nightmare";
+         moveEffects[108] = "RaiseEvasivenessAndBecomeSmaller";
+         moveEffects[109] = "Curse";
+         moveEffects[110] = "??";
+         moveEffects[111] = "EvadeNextAttack";
+         moveEffects[112] = "Spikes";
+         moveEffects[113] = "FoeCannnotRaiseEvasion";
+         moveEffects[114] = "PerishSong";
+         moveEffects[115] = "Sandstorm";
+         moveEffects[116] = "Endure";
+         moveEffects[117] = "5turnsUntilMiss";
+         moveEffects[118] = "ConfuseAndRaiseAttack2";
+         moveEffects[119] = "GetStrongerEachHit";
+         moveEffects[120] = "Attract";
+         moveEffects[121] = "StrongerWithFriendship";
+         moveEffects[122] = "Present";
+         moveEffects[123] = "WeakerWithFriendship";
+         moveEffects[124] = "PreventStatus5Turns";
+         moveEffects[125] = "BurnRaiseSpeed";
+         moveEffects[126] = "Magnitude";
+         moveEffects[127] = "BatonPass";
+         moveEffects[128] = "DoublePowerIfOpponentSwitching";
+         moveEffects[129] = "RemoveBindSeedSpikes";
+         moveEffects[130] = "20Damage";
+         moveEffects[131] = "???????";
+         moveEffects[132] = "MorningSun";
+         moveEffects[133] = "Synthesis";
+         moveEffects[134] = "Moonlight";
+         moveEffects[135] = "HiddenPower";
+         moveEffects[136] = "Rain5turns";
+         moveEffects[137] = "Sun5turns";
+         moveEffects[138] = "RaiseDefense";
+         moveEffects[139] = "RaiseAttack";
+         moveEffects[140] = "RaiseAllStats";
+         moveEffects[141] = "????????";
+         moveEffects[142] = "HalfHealthToRaiseAttack6";
+         moveEffects[143] = "CopyFoeStatChangesPrimary";
+         moveEffects[144] = "DoubleSpecialDamage";
+         moveEffects[145] = "RaiseDefenseThenAttackTurn2";
+         moveEffects[146] = "FlinchAndDoubleDamageToFly";
+         moveEffects[147] = "DoubleDamageToDig";
+         moveEffects[148] = "DamageIn2Turns";
+         moveEffects[149] = "DoubleDamageToFly";
+         moveEffects[150] = "FlinchAndDoubleDamageToMinimize";
+         moveEffects[151] = "ChargeFirstTurn";
+         moveEffects[152] = "ParalyzeAndIncreaseAccuracyInRain";
+         moveEffects[153] = "Escape";
+         moveEffects[154] = "DamageBasedOnPartySize";
+         moveEffects[155] = "2turn";
+         moveEffects[156] = "RaiseDefenseAndImproveRollingMoves";
+         moveEffects[157] = "RecoverOrFriend";
+         moveEffects[158] = "OnlyWorksOnce";
+         moveEffects[159] = "2to5turnsNoSleep";
+         moveEffects[160] = "Stockpile";
+         moveEffects[161] = "Spit Up";
+         moveEffects[162] = "Swallow";
+         moveEffects[163] = "?????????";
+         moveEffects[164] = "Hail5turns";
+         moveEffects[165] = "Torment";
+         moveEffects[166] = "ConfuseAndRaiseSpAtk2";
+         moveEffects[167] = "BurnPrimary";
+         moveEffects[168] = "SuicideLowerAtkSpAtk2";
+         moveEffects[169] = "DoubleDamageIfStatus";
+         moveEffects[170] = "SelfFlinchIfHit";
+         moveEffects[171] = "DoubleDamageToParalyzeAndHealParalyze";
+         moveEffects[172] = "ForceFoesAttackMe";
+         moveEffects[173] = "NaturePower";
+         moveEffects[174] = "BoostNextElectricMove";
+         moveEffects[175] = "Taunt";
+         moveEffects[176] = "BoostAllyPower";
+         moveEffects[177] = "TradeHeldItems";
+         moveEffects[178] = "CopyAbility";
+         moveEffects[179] = "HealHalfNextTurn";
+         moveEffects[180] = "UseAllyMove";
+         moveEffects[181] = "Ingrain";
+         moveEffects[182] = "LowerSelfAtkDef";
+         moveEffects[183] = "ReflectStatusMoves";
+         moveEffects[184] = "Recycle";
+         moveEffects[185] = "DoubleDamageIfHitThisTurn";
+         moveEffects[186] = "BreakWall";
+         moveEffects[187] = "Yawn";
+         moveEffects[188] = "KnockOff";
+         moveEffects[189] = "Endeavor";
+         moveEffects[190] = "DamageBasedOnHighRemainingHealth";
+         moveEffects[191] = "SkillSwap";
+         moveEffects[192] = "Imprison";
+         moveEffects[193] = "HealSelfStatus";
+         moveEffects[194] = "Grudge";
+         moveEffects[195] = "Snatch";
+         moveEffects[196] = "DamageBasedOnWeight";
+         moveEffects[197] = "SecondEffectBasedOnTerrain";
+         moveEffects[198] = "33Recoil";
+         moveEffects[199] = "ConfuseAllPokemon";
+         moveEffects[200] = "HighCritBurn";
+         moveEffects[201] = "MudSport";
+         moveEffects[202] = "BadPoison";
+         moveEffects[203] = "WeatherBall";
+         moveEffects[204] = "LowerSpAtk2Self";
+         moveEffects[205] = "LowerAttackDefensePrimary";
+         moveEffects[206] = "RaiseDefenseSpDef";
+         moveEffects[207] = "CanDamageFly";
+         moveEffects[208] = "RaiseAttackDefensePrimary";
+         moveEffects[209] = "HighCritPoison";
+         moveEffects[210] = "WaterSport";
+         moveEffects[211] = "RaiseSpAtkSpDefPrimary";
+         moveEffects[212] = "RaiseAttackSpeedPrimary";
+         moveEffects[213] = "ChangetypeFromTerrain";
+         SetList(MoveEffectListName, moveEffects);
+         #endregion
+
+         #region Move Info
+         SetList(MoveInfoListName, new[] {
+            "Makes Contact",
+            "Affected by Protect",
+            "Affected by Magic Coat",
+            "Affected by Snatch",
+            "Affected by Mirror Move",
+            "Affected by King's Rock",
+         });
+         #endregion
+
+         #region Move Target
+         SetList(MoveTargetListName, new[] {
+            "RecentAttacker",
+            "Unused",
+            "Random",
+            "Both",
+            "Self",
+            "Everyone",
+            "Hazard",
+         });
+         #endregion
+
+         #region Decorations Permission
+         SetList(DecorationsPermissionListName, new[] {
+            "Normal",
+            "Put On Floor",
+            "Object",
+            "Place On Wall",
+            "Doll or Cushion",
+         });
+         #endregion
+
+         #region Decorations Category
+         SetList(DecorationsCategoryListName, new[] {
+            "Desk",
+            "Chair",
+            "Plant",
+            "Unique",
+            "Mat",
+            "Poster",
+            "Doll",
+            "Cushion",
+         });
+         #endregion
+
+         #region Decorations Shape
+         SetList(DecorationsShapeListName, new[] {
+            "1x1",
+            "unused",
+            "unused",
+            "1x1t",
+            "2x2p",
+            "1x1p",
+            "unused",
+            "3x1",
+            "2x2",
+            "2x1",
+         });
+         #endregion
       }
 
       private IReadOnlyList<int> AllSourcesToSameDestination(int source) {

--- a/src/HexManiac.Core/Models/HardcodeTablesModel.cs
+++ b/src/HexManiac.Core/Models/HardcodeTablesModel.cs
@@ -34,6 +34,7 @@ namespace HavenSoft.HexManiac.Core.Models {
       public const string MoveInfoListName = "moveinfo";
       public const string MoveEffectListName = "moveeffects";
       public const string MoveTargetListName = "movetarget";
+      public const string EvolutionMethodListName = "evolutionmethods";
       public const string DecorationsShapeListName = "decorshape";
       public const string DecorationsCategoryListName = "decorcategory";
       public const string DecorationsPermissionListName = "decorpermissions";
@@ -164,7 +165,7 @@ namespace HavenSoft.HexManiac.Core.Models {
             case Ruby: case Sapphire: source = 0x3F534; break;
             case Emerald: source = 0x6D140; break;
          }
-         AddTable(source, EvolutionTableName, $"[[method: arg: species:{EggMoveRun.PokemonNameTable} unused:]5]{EggMoveRun.PokemonNameTable}");
+         AddTable(source, EvolutionTableName, $"[[method:{EvolutionMethodListName} arg: species:{EggMoveRun.PokemonNameTable} unused:]5]{EggMoveRun.PokemonNameTable}");
 
          // items
          switch (gameCode) {
@@ -614,6 +615,27 @@ namespace HavenSoft.HexManiac.Core.Models {
             "3x1",
             "2x2",
             "2x1",
+         });
+         #endregion
+
+         #region Evolution Methods
+         SetList(EvolutionMethodListName, new[] {
+            "None",
+            "Happiness",
+            "Happy Day",
+            "Happy Night",
+            "Level",
+            "Trade",
+            "Trade Item",
+            "Stone",
+            "Level High Attack",
+            "Level Attack matches Defense",
+            "Level High Defense",
+            "Level Odd Personality",
+            "Level Even Personality",
+            "Level And New Pokemon",
+            "Level But New Pokemon",
+            "Beauty",
          });
          #endregion
       }

--- a/src/HexManiac.Core/Models/IDataModel.cs
+++ b/src/HexManiac.Core/Models/IDataModel.cs
@@ -33,6 +33,7 @@ namespace HavenSoft.HexManiac.Core.Models {
       IFormattedRun GetNextAnchor(int dataIndex);
 
       bool TryGetUsefulHeader(int address, out string header);
+      bool TryGetList(string name, out IReadOnlyList<string> nameArray);
 
       bool IsAtEndOfArray(int dataIndex, out ITableRun tableRun); // is this byte the first one after the end of a table run? (also return true if the table is length 0 and starts right here)
 
@@ -118,6 +119,8 @@ namespace HavenSoft.HexManiac.Core.Models {
       public abstract IFormattedRun GetNextAnchor(int dataIndex);
 
       public virtual bool TryGetUsefulHeader(int address, out string header) { header = null; return false; }
+
+      public virtual bool TryGetList(string name, out IReadOnlyList<string> list) { list = null; return false; }
 
       public abstract bool IsAtEndOfArray(int dataIndex, out ITableRun tableRun);
 

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -708,7 +708,12 @@ namespace HavenSoft.HexManiac.Core.Models {
             return;
          }
 
-         if (segment == null) return;
+         if (segment == null) {
+            // we don't know anything about the format, but we know a pointer starts here.
+            // clear any existing formats that conflict with this pointer.
+            if (run.Start != nextRun.Start) ClearFormat(token, run.Start, run.Length);
+            return;
+         }
          if (segment.InnerFormat == PCSRun.SharedFormatString) {
             var length = PCSString.ReadString(this, run.Start, true);
             if (length > 0) {

--- a/src/HexManiac.Core/Models/Runs/ModelCacheScope.cs
+++ b/src/HexManiac.Core/Models/Runs/ModelCacheScope.cs
@@ -47,6 +47,9 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       public IReadOnlyList<string> GetBitOptions(string enumName) {
          if (cachedBitOptions.ContainsKey(enumName)) return cachedBitOptions[enumName];
 
+         // if it's from a list, then it's not from an enum, but instead from just a string list
+         if (model.TryGetList(enumName, out var nameArray)) return nameArray;
+
          var sourceAddress = model.GetAddressFromAnchor(new NoDataChangeDeltaModel(), -1, enumName);
          if (sourceAddress == Pointer.NULL) return null;
          var sourceRun = model.GetNextRun(sourceAddress) as ArrayRun;
@@ -71,6 +74,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       }
 
       private static IReadOnlyList<string> GetOptions(IDataModel model, string enumName) {
+         if (model.TryGetList(enumName, out var nameArray)) return nameArray;
 
          if (!model.TryGetNameArray(enumName, out var enumArray)) return new string[0];
 

--- a/src/HexManiac.Core/Models/StoredMetadata.cs
+++ b/src/HexManiac.Core/Models/StoredMetadata.cs
@@ -1,33 +1,49 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 
 namespace HavenSoft.HexManiac.Core.Models {
    public class StoredMetadata {
       public IReadOnlyList<StoredAnchor> NamedAnchors { get; }
       public IReadOnlyList<StoredUnmappedPointer> UnmappedPointers { get; }
       public IReadOnlyList<StoredMatchedWord> MatchedWords { get; }
+      public IReadOnlyList<StoredList> Lists { get; }
 
       public bool IsEmpty => NamedAnchors.Count == 0 && UnmappedPointers.Count == 0;
 
-      public StoredMetadata(IReadOnlyList<StoredAnchor> anchors, IReadOnlyList<StoredUnmappedPointer> unmappedPointers, IReadOnlyList<StoredMatchedWord> matchedWords) {
+      public StoredMetadata(IReadOnlyList<StoredAnchor> anchors, IReadOnlyList<StoredUnmappedPointer> unmappedPointers, IReadOnlyList<StoredMatchedWord> matchedWords, IReadOnlyList<StoredList> lists) {
          NamedAnchors = anchors;
          UnmappedPointers = unmappedPointers;
          MatchedWords = matchedWords;
+         Lists = lists;
       }
 
       public StoredMetadata(string[] lines) {
          var anchors = new List<StoredAnchor>();
          var pointers = new List<StoredUnmappedPointer>();
          var matchedWords = new List<StoredMatchedWord>();
+         var lists = new List<StoredList>();
 
          foreach (var line in lines) {
             var cleanLine = line.Split('#').First().Trim();
             if (cleanLine == string.Empty) continue;
             if (cleanLine.StartsWith("[")) {
-               CloseCurrentItem(anchors, pointers, matchedWords);
+               CloseCurrentItem(anchors, pointers, matchedWords, lists);
                currentItem = cleanLine;
+               continue;
+            }
+
+            if (cleanLine.StartsWith("]")) {
+               continueCurrentItemIndex = false;
+               continue;
+            }
+
+            if (continueCurrentItemIndex) {
+               if (cleanLine.EndsWith(",")) cleanLine = cleanLine.Substring(0, cleanLine.Length - 1);
+               currentItemChildren.Add(cleanLine.Replace("'''", string.Empty));
                continue;
             }
 
@@ -43,13 +59,33 @@ namespace HavenSoft.HexManiac.Core.Models {
             if (cleanLine.StartsWith("Format = '''")) {
                currentItemFormat = cleanLine.Split("'''")[1];
             }
+
+            if (cleanLine.Contains('=') && int.TryParse(cleanLine.Split('=')[0].Trim(), out currentItemIndex)) {
+               if (currentItemChildren == null) currentItemChildren = new List<string>();
+               while (currentItemChildren.Count < currentItemIndex) currentItemChildren.Add(null);
+               if (!cleanLine.Split("'''")[0].Contains("[")) {
+                  // this is the only element, easy peasy
+                  var elementStart = cleanLine.IndexOf("'''") + 3;
+                  var elementLength = cleanLine.Substring(elementStart).IndexOf("'''");
+                  if (elementStart > 3 && elementLength > 0) currentItemChildren.Add(cleanLine.Substring(elementStart, elementLength));
+               } else if (cleanLine.EndsWith("]")) {
+                  // this is a one line list
+                  var lineList = cleanLine.Substring(cleanLine.IndexOf("[") + 1);
+                  lineList = lineList.Substring(0, lineList.LastIndexOf("]"));
+                  foreach (var element in lineList.Split(',')) currentItemChildren.Add(element.Replace("'''", string.Empty));
+               } else if (cleanLine.EndsWith("[")) {
+                  // this is a multiline list
+                  continueCurrentItemIndex = true;
+               }
+            }
          }
 
-         CloseCurrentItem(anchors, pointers, matchedWords);
+         CloseCurrentItem(anchors, pointers, matchedWords, lists);
 
          NamedAnchors = anchors;
          UnmappedPointers = pointers;
          MatchedWords = matchedWords;
+         Lists = lists;
       }
 
       public string[] Serialize() {
@@ -81,13 +117,22 @@ namespace HavenSoft.HexManiac.Core.Models {
             lines.Add(string.Empty);
          }
 
+         lines.Add("#################################");
+
+         foreach (var list in Lists) {
+            list.AppendContents(lines);
+         }
+
          return lines.ToArray();
       }
 
       string currentItem, currentItemName, currentItemFormat;
+      int currentItemIndex = 0;
+      List<string> currentItemChildren;
+      bool continueCurrentItemIndex;
       int currentItemAddress = -1;
 
-      private void CloseCurrentItem(IList<StoredAnchor> anchors, IList<StoredUnmappedPointer> pointers, IList<StoredMatchedWord> matchedWords) {
+      private void CloseCurrentItem(IList<StoredAnchor> anchors, IList<StoredUnmappedPointer> pointers, IList<StoredMatchedWord> matchedWords, IList<StoredList> lists) {
          if (currentItem == "[[UnmappedPointers]]") {
             if (currentItemName == null) throw new ArgumentNullException("The Metadata file has an UnmappedPointer that didn't specify a name!");
             if (currentItemAddress == -1) throw new ArgumentOutOfRangeException("The Metadata file has an UnmappedPointer that didn't specify an Address!");
@@ -101,15 +146,23 @@ namespace HavenSoft.HexManiac.Core.Models {
          }
 
          if (currentItem == "[[MatchedWords]]") {
-            if (currentItemName == null) throw new ArgumentNullException("The Metadata file has an UnmappedPointer that didn't specify a name!");
+            if (currentItemName == null) throw new ArgumentNullException("The Metadata file has a MatchedWords that didn't specify a name!");
             if (currentItemAddress == -1) throw new ArgumentOutOfRangeException("The Metadata file has an UnmappedPointer that didn't specify an Address!");
             matchedWords.Add(new StoredMatchedWord(currentItemAddress, currentItemName));
+         }
+
+         if (currentItem == "[[List]]") {
+            if (currentItemName == null) throw new ArgumentNullException("The Metadata file has a list that didn't specify a name!");
+            if (currentItemChildren == null) throw new ArgumentNullException("The Metadata file has a list that didn't specify any children!");
+            lists.Add(new StoredList(currentItemName, currentItemChildren));
          }
 
          currentItem = null;
          currentItemName = null;
          currentItemFormat = null;
          currentItemAddress = -1;
+         continueCurrentItemIndex = false;
+         currentItemChildren = null;
       }
    }
 
@@ -139,5 +192,48 @@ namespace HavenSoft.HexManiac.Core.Models {
       public int Address { get; }
       public string Name { get; }
       public StoredMatchedWord(int address, string name) => (Address, Name) = (address, name);
+   }
+
+   /// <summary>
+   /// An index of Contents being 'null' means sticking with the default value
+   /// </summary>
+   public class StoredList : IReadOnlyList<string> {
+      public string Name { get; }
+      public IReadOnlyList<string> Contents { get; }
+
+      public StoredList(string name, IReadOnlyList<string> contents) => (Name, Contents) = (name, contents);
+
+      public void AppendContents(IList<string> builder) {
+         builder.Add("[[List]]");
+         builder.Add($"Name = '''{Name}'''");
+         for (int i = 0; i < Contents.Count; i++) {
+            var prevNull = i == 0 || Contents[i - 1] == null;
+            var nextNull = i == Contents.Count - 1 || Contents[i + 1] == null;
+
+            if (Contents[i] != null) {
+               if (prevNull && nextNull) {
+                  builder.Add($"{i} = '''{Contents[i]}'''");
+               } else if (prevNull && !nextNull) {
+                  builder.Add($"{i} = [");
+                  builder.Add($"   '''{Contents[i]}''',");
+               } else if (!prevNull && !nextNull) {
+                  builder.Add($"   '''{Contents[i]}''',");
+               } else {
+                  builder.Add($"   '''{Contents[i]}''',");
+                  builder.Add($"]");
+               }
+            }
+         }
+         builder.Add(string.Empty);
+      }
+
+      #region IReadOnlyList members
+
+      public int Count => Contents.Count;
+      public string this[int index] => Contents[index] ?? index.ToString();
+      public IEnumerator<string> GetEnumerator() => Contents.GetEnumerator();
+      IEnumerator IEnumerable.GetEnumerator() => Contents.GetEnumerator();
+
+      #endregion
    }
 }

--- a/src/HexManiac.Core/ViewModels/QuickEditItems/MakeTutorsExpandable.cs
+++ b/src/HexManiac.Core/ViewModels/QuickEditItems/MakeTutorsExpandable.cs
@@ -143,7 +143,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.QuickEditItems {
          const int instructionIndex = 5;
          const int instructionWidth = 2;
          var branchOffset = tutorSpecial + instructionIndex * instructionWidth;
-         viewPort.CurrentChange.ChangeData(viewPort.Model, branchOffset, 0xDE);
+         viewPort.CurrentChange.ChangeData(viewPort.Model, branchOffset, 0xDF);
       }
    }
 }

--- a/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
@@ -354,9 +354,19 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
       }
 
       public string Message { get; private set; }
-      private bool canRepoint;
+      private bool canRepoint, canCreateNew;
       public bool CanRepoint { get => canRepoint; set => TryUpdate(ref canRepoint, value); }
+      public bool CanCreateNew {
+         get => canCreateNew;
+         set {
+            if (TryUpdate(ref canCreateNew, value)) {
+               NotifyPropertyChanged(nameof(ShowContent));
+            }
+         }
+      }
+      public bool ShowContent => !CanCreateNew;
       public ICommand Repoint { get; private set; }
+      public ICommand CreateNew { get; private set; }
 
       public StreamArrayElementViewModel(ViewPort viewPort, IDataModel model, string name, int start) {
          this.viewPort = viewPort;
@@ -378,13 +388,33 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
                Message = $"{sourceCount}";
             }
          }
+         if (destination == Pointer.NULL) {
+            content = string.Empty;
+            CanCreateNew = true;
+         }
          Repoint = new StubCommand {
             CanExecute = arg => CanRepoint,
             Execute = arg => {
-               var originalDestination = this.model.ReadPointer(this.start);
-               this.viewPort.RepointToNewCopy(this.start);
-               var newDestination = this.model.ReadPointer(this.start);
-               CanRepoint = false;
+               using (ModelCacheScope.CreateScope(this.model)) {
+                  var originalDestination = this.model.ReadPointer(this.start);
+                  this.viewPort.RepointToNewCopy(this.start);
+                  CanRepoint = false;
+                  using (new StubDisposable { Dispose = () => overrideCopyAttempt = false }) {
+                     dataChanged?.Invoke(this, EventArgs.Empty);
+                  }
+               }
+            },
+         };
+         CreateNew = new StubCommand {
+            CanExecute = arg => CanCreateNew,
+            Execute = arg => {
+               using (ModelCacheScope.CreateScope(this.model)) {
+                  this.viewPort.RepointToNewCopy(this.start);
+                  CanCreateNew = false;
+                  using (new StubDisposable { Dispose = () => overrideCopyAttempt = false }) {
+                     dataChanged?.Invoke(this, EventArgs.Empty);
+                  }
+               }
             },
          };
       }
@@ -402,6 +432,10 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
          if (CanRepoint != stream.CanRepoint) {
             CanRepoint = stream.CanRepoint;
             ((StubCommand)Repoint).CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+         }
+         if (CanCreateNew != stream.CanCreateNew) {
+            CanCreateNew = stream.CanCreateNew;
+            ((StubCommand)CreateNew).CanExecuteChanged?.Invoke(this, EventArgs.Empty);
          }
          dataChanged = stream.dataChanged;
          dataMoved = stream.dataMoved;

--- a/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/IArrayElementViewModel.cs
@@ -496,7 +496,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
          // get all the bits of this segment and turn them into BitElements
          var optionSource = model.GetAddressFromAnchor(history.CurrentChange, -1, bitSegment.SourceArrayName);
          var bits = model.ReadMultiByteValue(start, bitSegment.Length);
-         var names = bitSegment.GetOptions(model);
+         var names = bitSegment.GetOptions(model) ?? new string[0];
+         Debug.Assert(names.Count > 0, "The user is using a source for a bit array that either doesn't exist or has no length. This is probably not what the user wanted.");
          for (int i = 0; i < names.Count; i++) {
             var element = new BitElement { BitLabel = names[i] };
             children.Add(element);

--- a/src/HexManiac.Core/ViewModels/Tools/TableTool.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/TableTool.cs
@@ -282,10 +282,14 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
 
       private void AddChildrenFromPointerSegment(int itemAddress, ArrayRunElementSegment item, int parentIndex) {
          if (!(item is ArrayRunPointerSegment pointerSegment)) return;
+         if (pointerSegment.InnerFormat == string.Empty) return;
          var destination = model.ReadPointer(itemAddress);
-         if (destination == Pointer.NULL) return;
-         if (!(model.GetNextRun(destination) is IStreamRun streamRun)) return;
-         if (!pointerSegment.DestinationDataMatchesPointerFormat(model, new NoDataChangeDeltaModel(), itemAddress, destination, null)) return;
+         IStreamRun streamRun = null;
+         if (destination != Pointer.NULL) {
+            if (!(model.GetNextRun(destination) is IStreamRun destinationStream)) return;
+            if (!pointerSegment.DestinationDataMatchesPointerFormat(model, new NoDataChangeDeltaModel(), itemAddress, destination, null)) return;
+            streamRun = destinationStream;
+         }
 
          var streamElement = new StreamArrayElementViewModel(viewPort, model, item.Name, itemAddress);
          var streamElementName = item.Name;

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -703,7 +703,13 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       }
 
       public void RepointToNewCopy(int pointer) {
-         var destination = Model.GetNextRun(Model.ReadPointer(pointer));
+         var destinationAddress = Model.ReadPointer(pointer);
+         if (destinationAddress == Pointer.NULL) {
+            CreateNewData(pointer);
+            return;
+         }
+
+         var destination = Model.GetNextRun(destinationAddress);
          if (destination.PointerSources.Count < 2) {
             OnError?.Invoke(this, "This is the only pointer, no need to make a new copy.");
             return;
@@ -730,6 +736,41 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          Model.ObserveRunWritten(CurrentChange, destination2.Duplicate(newDestination, pointer)); // create a new run at the new destination
          OnMessage?.Invoke(this, "New Copy added at " + newDestination.ToString("X6"));
          Refresh();
+      }
+
+      private void CreateNewData(int pointer) {
+         var errorText = "Can only create new data for a pointer with a format within a table.";
+         if (!(Model.GetNextRun(pointer) is ITableRun tableRun)) {
+            OnError?.Invoke(this, errorText);
+            return;
+         }
+         var offsets = tableRun.ConvertByteOffsetToArrayOffset(pointer);
+         if (!(tableRun.ElementContent[offsets.SegmentIndex] is ArrayRunPointerSegment pointerSegment) || !pointerSegment.IsInnerFormatValid) {
+            OnError?.Invoke(this, errorText);
+            return;
+         }
+
+         var insert = 0;
+         var length = 0;
+         var startSearch = (Model as PokemonModel)?.EarliestAllowedAnchor ?? 0;
+         if (pointerSegment.InnerFormat == PCSRun.SharedFormatString) {
+            length = 1;
+         } else if (pointerSegment.InnerFormat == PLMRun.SharedFormatString) {
+            length = 2;
+         } else if (pointerSegment.InnerFormat == TrainerPokemonTeamRun.SharedFormatString) {
+            length = new TrainerPokemonTeamRun(Model, -1, new[] { pointer }).Length;
+         } else if (pointerSegment.InnerFormat.StartsWith("[") && pointerSegment.InnerFormat.Contains("]")) {
+            // don't bother checking that the data is valid: with an invalid starting point, we know the data is garbage.
+            TableStreamRun.TryParseTableStream(Model, -1, new int[] { pointer }, pointerSegment.Name, pointerSegment.InnerFormat, tableRun.ElementContent, out var newStream);
+            length = newStream.Length;
+         } else {
+            Debug.Fail("Not Implemented!");
+         }
+
+         insert = Model.FindFreeSpace(startSearch, length);
+         pointerSegment.WriteNewFormat(Model, CurrentChange, pointer, insert, length, tableRun.ElementContent);
+         OnMessage?.Invoke(this, "New data added at " + insert.ToString("X6"));
+         RefreshBackingData();
       }
 
       private void AcceptBackspace(UnderEdit underEdit, IFormattedRun run, Point point) {

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -264,7 +264,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          var dataIndex2 = scroll.ViewPointToDataIndex(SelectionEnd);
          var left = Math.Min(dataIndex1, dataIndex2);
          var length = Math.Abs(dataIndex1 - dataIndex2) + 1;
-         if (left < 0) { length += left;left = 0; }
+         if (left < 0) { length += left; left = 0; }
          if (left + length > Model.Count) length = Model.Count - left;
          var result = new StringBuilder();
          for (int i = 0; i < length; i++) result.Append(Model[left + i].ToString("X2") + " ");
@@ -953,7 +953,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
             }
             // option 3: the value is in an enum used by a custom table stream
             if (child is TableStreamRun table) {
-               foreach(var result in table.Search(parentArrayName, offsets.ElementIndex)) yield return result;
+               foreach (var result in table.Search(parentArrayName, offsets.ElementIndex)) yield return result;
             }
          }
       }

--- a/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
@@ -58,9 +58,14 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          Results.Add(new ContextItem("Follow Pointer", arg => ViewPort.FollowLink(point.X, point.Y)) { ShortcutText = "Ctrl+Click" });
 
          var pointerAddress = ViewPort.ConvertViewPointToAddress(point);
-         var destination = ViewPort.Model.GetNextRun(ViewPort.Model.ReadPointer(pointerAddress));
-         if (!(destination is NoInfoRun)) {
-            Results.Add(new ContextItem("Repoint to New Copy", arg => ViewPort.RepointToNewCopy(pointerAddress)));
+         var pointerDestination = ViewPort.Model.ReadPointer(pointerAddress);
+         if (pointerDestination == Pointer.NULL) {
+            Results.Add(new ContextItem("Create New Data", arg => ViewPort.RepointToNewCopy(pointerAddress)));
+         } else {
+            var destination = ViewPort.Model.GetNextRun(pointerDestination);
+            if (!(destination is NoInfoRun)) {
+               Results.Add(new ContextItem("Repoint to New Copy", arg => ViewPort.RepointToNewCopy(pointerAddress)));
+            }
          }
 
          var arrayRun = ViewPort.Model.GetNextRun(pointerAddress) as ITableRun;

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -398,6 +398,7 @@ namespace HavenSoft.HexManiac.Tests {
             new[] { game, HardcodeTablesModel.DecorationsShapeListName, 10 },
             new[] { game, HardcodeTablesModel.DecorationsPermissionListName, 5 },
             new[] { game, HardcodeTablesModel.DecorationsCategoryListName, 8 },
+            new[] { game, HardcodeTablesModel.EvolutionMethodListName, 16 },
          }
       );
 

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -379,6 +379,17 @@ namespace HavenSoft.HexManiac.Tests {
          var typeChart2 = (ITableRun)model.GetNextRun(typeChartAddress2);
       }
 
+      [SkippableTheory]
+      [MemberData(nameof(PokemonGames))]
+      public void SpecialsAreFound(string game) {
+         var model = fixture.LoadModel(game);
+         var noChange = new NoDataChangeDeltaModel();
+
+         var specialsAddress = model.GetAddressFromAnchor(noChange, -1, HardcodeTablesModel.SpecialsTable);
+         var specials = (ITableRun)model.GetNextRun(specialsAddress);
+         Assert.NotInRange(specials.ElementCount, 0, 300);
+      }
+
       // this one actually changes the data, so I can't use the same shared model as everone else.
       [SkippableTheory]
       [MemberData(nameof(PokemonGames))]

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -390,6 +390,27 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.NotInRange(specials.ElementCount, 0, 300);
       }
 
+      public static IEnumerable<object[]> ListData => PokemonGames.Select(array => array[0]).SelectMany(game =>
+         new[] {
+            new[] { game, HardcodeTablesModel.MoveEffectListName, 214 },
+            new[] { game, HardcodeTablesModel.MoveInfoListName, 6 },
+            new[] { game, HardcodeTablesModel.MoveTargetListName, 7 },
+            new[] { game, HardcodeTablesModel.DecorationsShapeListName, 10 },
+            new[] { game, HardcodeTablesModel.DecorationsPermissionListName, 5 },
+            new[] { game, HardcodeTablesModel.DecorationsCategoryListName, 8 },
+         }
+      );
+
+      [SkippableTheory]
+      [MemberData(nameof(ListData))]
+      public void ListFound(string game, string listName, int listCount) {
+         var model = fixture.LoadModel(game);
+         using (ModelCacheScope.CreateScope(model)) {
+            var options = ModelCacheScope.GetCache(model).GetOptions(listName);
+            Assert.Equal(listCount, options.Count);
+         }
+      }
+
       // this one actually changes the data, so I can't use the same shared model as everone else.
       [SkippableTheory]
       [MemberData(nameof(PokemonGames))]

--- a/src/HexManiac.Tests/HexManiac.Tests.csproj
+++ b/src/HexManiac.Tests/HexManiac.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="..\..\artifacts\$(AssemblyName)\codegen\StubFileSystem.cs" />
     <Compile Include="..\..\artifacts\$(AssemblyName)\codegen\StubTabContent.cs" />
     <Compile Include="..\..\artifacts\$(AssemblyName)\codegen\StubViewPort.cs" />
+    <Compile Include="ListTests.cs" />
     <Compile Include="NestedTablesTests.cs" />
     <Compile Include="PointerModelTests.cs" />
     <Compile Include="NavigationTests.cs" />

--- a/src/HexManiac.Tests/ListTests.cs
+++ b/src/HexManiac.Tests/ListTests.cs
@@ -1,0 +1,74 @@
+﻿using HavenSoft.HexManiac.Core;
+using HavenSoft.HexManiac.Core.Models;
+using HavenSoft.HexManiac.Core.Models.Runs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace HavenSoft.HexManiac.Tests {
+   public class List : BaseViewModelTestClass {
+      [Fact]
+      public void MetadataCanLoadList() {
+         var lines = new List<string>();
+         lines.Add("[[List]]");
+         lines.Add("Name = '''moveeffects'''");
+         lines.Add("1 = [");
+         lines.Add("   '''abc''',");
+         lines.Add("   '''\"def\"''',");
+         lines.Add("]");
+         lines.Add("5 = ['''xyz''']");
+         lines.Add("7 = '''bob'''");
+
+         var metadata = new StoredMetadata(lines.ToArray());
+
+         var moveEffects = metadata.Lists.Single(list => list.Name == "moveeffects");
+         Assert.Equal(8, moveEffects.Count);
+         Assert.Equal("0", moveEffects[0]);
+         Assert.Equal("abc", moveEffects[1]);
+         Assert.Equal("\"def\"", moveEffects[2]);
+         Assert.Equal("3", moveEffects[3]);
+         Assert.Equal("4", moveEffects[4]);
+         Assert.Equal("xyz", moveEffects[5]);
+         Assert.Equal("6", moveEffects[6]);
+         Assert.Equal("bob", moveEffects[7]);
+      }
+
+      [Fact]
+      public void MetadataCanSaveList() {
+         var input = new List<string> {
+            "bob",
+            "tom",
+            null,
+            "sam",
+            "fry",
+            "kevin",
+            null,
+            null,
+            "carl",
+         };
+         var list = new StoredList("Input", input);
+
+         var lines = new List<string>();
+         list.AppendContents(lines);
+
+         Assert.Equal(@"[[List]]
+Name = '''Input'''
+0 = [
+   '''bob''',
+   '''tom''',
+]
+3 = [
+   '''sam''',
+   '''fry''',
+   '''kevin''',
+]
+8 = '''carl'''
+".Split(Environment.NewLine).ToList(), lines);
+      }
+
+      // TODO add tests to verify that the model loads and saves stored lists correctly.
+   }
+}
+

--- a/src/HexManiac.Tests/ToolTests.cs
+++ b/src/HexManiac.Tests/ToolTests.cs
@@ -395,6 +395,7 @@ namespace HavenSoft.HexManiac.Tests {
       [InlineData("lsl   r1, r2", 0b0100000010_010_001)]
       [InlineData("lsl   r1, r2 @ comment", 0b0100000010_010_001)]
       [InlineData("mov   r7, r8", 0b01000110_0_1_000_111)]
+      [InlineData("bx lr", 0b010001110_1_110_000)]
       public void ThumbCompilerTests(string input, uint output) {
          var bytes = new List<byte> { (byte)output, (byte)(output >> 8) };
          var model = new PokemonModel(new byte[0x200]);

--- a/src/HexManiac.WPF/Controls/StartScreen.xaml
+++ b/src/HexManiac.WPF/Controls/StartScreen.xaml
@@ -5,7 +5,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:hsg3hwr="clr-namespace:HavenSoft.HexManiac.WPF.Resources"
              mc:Ignorable="d" Background="{DynamicResource Background}"
-             d:DesignHeight="450" d:DesignWidth="800">
+             d:DesignHeight="450" d:DesignWidth="800"
+             HorizontalAlignment="Center">
    <Grid.ColumnDefinitions>
       <ColumnDefinition/>
       <ColumnDefinition Width="20"/>
@@ -22,11 +23,13 @@
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>movenames / movedata / movedescriptions<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>abilitynames / abilitydescriptions<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>trainerclassnames / trainerdata<LineBreak/>
-      <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>types<LineBreak/>
+      <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>types / typechart<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>items / itemimages<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>tutormoves / tutorcompatibility<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>tmmoves / tmcompatibility<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>dexinfo / regionaldex / nationaldex / hoennToNational<LineBreak/>
+      <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>wild<LineBreak/>
+      <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>multichoice<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>decorations<LineBreak/>
    </TextBlock>
    <StackPanel Grid.Column="2" VerticalAlignment="Center" TextBlock.Foreground="{DynamicResource Primary}" >

--- a/src/HexManiac.WPF/Controls/StartScreen.xaml
+++ b/src/HexManiac.WPF/Controls/StartScreen.xaml
@@ -31,6 +31,7 @@
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>wild<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>multichoice<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>decorations<LineBreak/>
+      <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>specials<LineBreak/>
    </TextBlock>
    <StackPanel Grid.Column="2" VerticalAlignment="Center" TextBlock.Foreground="{DynamicResource Primary}" >
       <Border Margin="5" Padding="5" Background="{DynamicResource Background}" BorderBrush="{DynamicResource Secondary}" CornerRadius="5,5,5,5" BorderThickness="1" Cursor="Hand" MouseLeftButtonDown="PointerHelp">

--- a/src/HexManiac.WPF/Controls/TabView.xaml
+++ b/src/HexManiac.WPF/Controls/TabView.xaml
@@ -233,7 +233,20 @@
                                     <Run Text="pointers."/>
                                  </TextBlock>
                               </DockPanel>
-                              <TextBox UndoLimit="0" Text="{Binding Content, UpdateSourceTrigger=PropertyChanged}" Margin="20,2,2,2" AcceptsReturn="True"/>
+                              <DockPanel Visibility="{Binding CanCreateNew, Converter={StaticResource BoolToVisibility}}">
+                                 <Button Content="Cretae new data" Command="{Binding CreateNew}" DockPanel.Dock="Right">
+                                    <Button.ToolTip>
+                                       <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{DynamicResource Accent}" BorderThickness="1">
+                                          <TextBlock TextAlignment="Left">
+                                             Create new data in free space that <LineBreak/>
+                                             matches the expected format.
+                                          </TextBlock>
+                                       </ToolTip>
+                                    </Button.ToolTip>
+                                 </Button>
+                              </DockPanel>
+                              <TextBox UndoLimit="0" Text="{Binding Content, UpdateSourceTrigger=PropertyChanged}" Margin="20,2,2,2" AcceptsReturn="True"
+                                 Visibility="{Binding ShowContent, Converter={StaticResource BoolToVisibility}}"/>
                            </StackPanel>
                         </DataTemplate>
                         <DataTemplate DataType="{x:Type hsg3hvmtr:ButtonArrayElementViewModel}">

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
         Icon="..\Resources\AppIcon.ico"
         PreviewMouseDown="RunDeferredActions"
-        Title="Hex Maniac Advance" Height="470" Width="880" AllowDrop="True" Background="{DynamicResource Backlight}">
+        Title="Hex Maniac Advance" Height="470" MinHeight="300" Width="880" MinWidth="400" AllowDrop="True" Background="{DynamicResource Backlight}">
    <Window.Resources>
       <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
    </Window.Resources>


### PR DESCRIPTION
* Given a table with null pointer entry, if the format of the data is known, allow the user to create data with that format and point to it automatically.
* Improve Tutor Expansion. It still looks wrong after tutor 15, but should function correctly.
* Auto-find the 'specials' table. These are thumb routines usable by scripts.
* Add the 'lists' feature, allowing useful names to be applied to enums when those names aren't actually stored in the ROM. Example: evolution methods.
