### PR TITLE
Performance Improvement: GetSelectedByteContents

### DIFF
--- a/src/HexManiac.Core/SystemExtensions.cs
+++ b/src/HexManiac.Core/SystemExtensions.cs
@@ -7,6 +7,9 @@ namespace HavenSoft.HexManiac.Core {
 
       ////// Random utility functions on basic types, mostly added to make code easier to read. //////
 
+      private static readonly IReadOnlyList<string> byteToString = Enumerable.Range(0, 0x100).Select(i => i.ToString("X2")).ToArray();
+      public static string ToHexString(this byte value) => byteToString[value];
+
       public static T LimitToRange<T>(this T value, T lower, T upper) where T : IComparable<T> {
          if (upper.CompareTo(lower) < 0) throw new ArgumentException($"upper value {upper} is less than lower value {lower}");
          if (value.CompareTo(lower) < 0) return lower;

--- a/src/HexManiac.Core/ViewModels/Tools/CodeTool.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/CodeTool.cs
@@ -44,18 +44,19 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
       }
 
       public void UpdateContent() {
-         var start = selection.Scroll.ViewPointToDataIndex(selection.SelectionStart);
+         var start = Math.Min(model.Count - 1, selection.Scroll.ViewPointToDataIndex(selection.SelectionStart));
          var end = Math.Min(model.Count - 1, selection.Scroll.ViewPointToDataIndex(selection.SelectionEnd));
 
-         if (mode == CodeMode.Raw) {
-            Content = RawParse(model, start, end - start + 1);
-            return;
-         }
-
-         if (start == end) { Content = string.Empty; return; }
          if (start > end) (start, end) = (end, start);
+         int length = end - start + 1;
 
-         if (mode == CodeMode.Script) {
+         if (length > 0x1000) {
+            Content = "Too many bytes selected.";
+         } else if (mode == CodeMode.Raw) {
+            Content = RawParse(model, start, end - start + 1);
+         } else if (length < 2) {
+            Content = string.Empty;
+         } else if (mode == CodeMode.Script) {
             Content = script.Parse(model, start, end - start + 1);
          } else if (mode == CodeMode.Thumb) {
             Content = thumb.Parse(model, start, end - start + 1);
@@ -67,7 +68,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
       private string RawParse(IDataModel model, int start, int length) {
          var builder = new StringBuilder();
          while (length > 0) {
-            builder.Append(model[start].ToString("X2"));
+            builder.Append(model[start].ToHexString());
             builder.Append(" ");
             length--;
             start++;

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -263,7 +263,6 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       // update the selected bytes lazily. Most of the time we don't really care about the new value.
       private void UpdateSelectedBytes() => SelectedBytes = null;
 
-      private static readonly string[] byteToString = Enumerable.Range(0, 0x100).Select(i => i.ToString("X2") + " ").ToArray();
       private string GetSelectedByteContents(int maxByteCount = int.MaxValue) {
          var dataIndex1 = scroll.ViewPointToDataIndex(SelectionStart);
          var dataIndex2 = scroll.ViewPointToDataIndex(SelectionEnd);
@@ -273,8 +272,9 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          if (left + length > Model.Count) length = Model.Count - left;
          var result = new StringBuilder();
          for (int i = 0; i < length && i < maxByteCount; i++) {
-            var token = byteToString[Model[left + i]];
+            var token = Model[left + i].ToHexString();
             result.Append(token);
+            result.Append(" ");
          }
          if (maxByteCount < length) result.Append("...");
          return result.ToString();

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -253,8 +253,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          get {
             if (selectedBytes != null) return selectedBytes;
 
-            var bytes = GetSelectedByteContents();
-            if (bytes.Length > 0x30) bytes = bytes.Substring(0, 0x30) + "...";
+            var bytes = GetSelectedByteContents(0x10);
             selectedBytes = "Selected Bytes: " + bytes;
             return selectedBytes;
          }
@@ -265,7 +264,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       private void UpdateSelectedBytes() => SelectedBytes = null;
 
       private static readonly string[] byteToString = Enumerable.Range(0, 0x100).Select(i => i.ToString("X2") + " ").ToArray();
-      private string GetSelectedByteContents() {
+      private string GetSelectedByteContents(int maxByteCount = int.MaxValue) {
          var dataIndex1 = scroll.ViewPointToDataIndex(SelectionStart);
          var dataIndex2 = scroll.ViewPointToDataIndex(SelectionEnd);
          var left = Math.Min(dataIndex1, dataIndex2);
@@ -273,10 +272,11 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          if (left < 0) { length += left; left = 0; }
          if (left + length > Model.Count) length = Model.Count - left;
          var result = new StringBuilder();
-         for (int i = 0; i < length; i++) {
+         for (int i = 0; i < length && i < maxByteCount; i++) {
             var token = byteToString[Model[left + i]];
             result.Append(token);
          }
+         if (maxByteCount < length) result.Append("...");
          return result.ToString();
       }
 

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -250,16 +250,21 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
       private string selectedBytes;
       public string SelectedBytes {
-         get => selectedBytes;
+         get {
+            if (selectedBytes != null) return selectedBytes;
+
+            var bytes = GetSelectedByteContents();
+            if (bytes.Length > 0x30) bytes = bytes.Substring(0, 0x30) + "...";
+            selectedBytes = "Selected Bytes: " + bytes;
+            return selectedBytes;
+         }
          private set => TryUpdate(ref selectedBytes, value);
       }
 
-      private void UpdateSelectedBytes() {
-         var bytes = GetSelectedByteContents();
-         if (bytes.Length > 0x30) bytes = bytes.Substring(0, 0x30) + "...";
-         SelectedBytes = "Selected Bytes: " + bytes;
-      }
+      // update the selected bytes lazily. Most of the time we don't really care about the new value.
+      private void UpdateSelectedBytes() => SelectedBytes = null;
 
+      private static readonly string[] byteToString = Enumerable.Range(0, 0x100).Select(i => i.ToString("X2") + " ").ToArray();
       private string GetSelectedByteContents() {
          var dataIndex1 = scroll.ViewPointToDataIndex(SelectionStart);
          var dataIndex2 = scroll.ViewPointToDataIndex(SelectionEnd);
@@ -268,7 +273,10 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          if (left < 0) { length += left; left = 0; }
          if (left + length > Model.Count) length = Model.Count - left;
          var result = new StringBuilder();
-         for (int i = 0; i < length; i++) result.Append(Model[left + i].ToString("X2") + " ");
+         for (int i = 0; i < length; i++) {
+            var token = byteToString[Model[left + i]];
+            result.Append(token);
+         }
          return result.ToString();
       }
 


### PR DESCRIPTION
GetSelectedByteContents was super slow, so I made 2 performance improvements.

(1) Cache off all of the bytes as strings. There's only 256 options, so storing them all isn't too hard, and this keeps us from having to recalculate them all the time.

(2) Update the SelectedBytes lazily. Instead of doing the work in `UpdateSelectedBytes`, have that function just set it to null. Then use the null check when `SelectedBytes.get` is called to actually do the work. This way, if no one asks for it, it's never actually calculated, saving a bunch of time in many situations.

There's no unit test because this is a performance change, not a behavior change.