### PR TITLE
Selection accounts for horizontal scrolling

### DIFF
--- a/src/HexManiac.WPF/Controls/HexContent.cs
+++ b/src/HexManiac.WPF/Controls/HexContent.cs
@@ -560,7 +560,7 @@ namespace HavenSoft.HexManiac.WPF.Controls {
       private ModelPoint ControlCoordinatesToModelCoordinates(MouseEventArgs e) {
          var point = e.GetPosition(this);
          point = new ScreenPoint(Math.Max(0, point.X + HorizontalScrollValue), Math.Max(0, point.Y)); // out of bounds to the left/top clamps to 0 (useful for headers)
-         return new ModelPoint((int)(point.X / CellWidth), (int)(point.Y / CellHeight));
+         return new ModelPoint(Math.Min((int)(point.X / CellWidth), ViewPort.Width - 1), (int)(point.Y / CellHeight)); // out of bounds right clambs to Width - 1 (prevents weird multiline scrolling.)
       }
    }
 

--- a/src/HexManiac.WPF/Controls/HexContent.cs
+++ b/src/HexManiac.WPF/Controls/HexContent.cs
@@ -560,7 +560,7 @@ namespace HavenSoft.HexManiac.WPF.Controls {
       private ModelPoint ControlCoordinatesToModelCoordinates(MouseEventArgs e) {
          var point = e.GetPosition(this);
          point = new ScreenPoint(Math.Max(0, point.X + HorizontalScrollValue), Math.Max(0, point.Y)); // out of bounds to the left/top clamps to 0 (useful for headers)
-         return new ModelPoint(Math.Min((int)(point.X / CellWidth), ViewPort.Width - 1), (int)(point.Y / CellHeight)); // out of bounds right clambs to Width - 1 (prevents weird multiline scrolling.)
+         return new ModelPoint(Math.Min((int)(point.X / CellWidth), ViewPort.Width - 1), (int)(point.Y / CellHeight)); // out of bounds right clamps to Width - 1 (prevents weird multiline scrolling.)
       }
    }
 

--- a/src/HexManiac.WPF/Controls/HexContent.cs
+++ b/src/HexManiac.WPF/Controls/HexContent.cs
@@ -559,7 +559,7 @@ namespace HavenSoft.HexManiac.WPF.Controls {
 
       private ModelPoint ControlCoordinatesToModelCoordinates(MouseEventArgs e) {
          var point = e.GetPosition(this);
-         point = new ScreenPoint(Math.Max(0, point.X), Math.Max(0, point.Y)); // out of bounds to the left/top clamps to 0 (useful for headers)
+         point = new ScreenPoint(Math.Max(0, point.X + HorizontalScrollValue), Math.Max(0, point.Y)); // out of bounds to the left/top clamps to 0 (useful for headers)
          return new ModelPoint((int)(point.X / CellWidth), (int)(point.Y / CellHeight));
       }
    }


### PR DESCRIPTION
Before this change, if you scrolled horizontally and tried to select, you'd end up selected boxes to the left of the cursor.

The translation logic has to account for whatever horizontal scrolling the user has done.

There's no test because this fix is purely visual and within HexManiac.WPF.