### PR TITLE
Number of bytes selected should always be positive.

### DIFF
--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -241,7 +241,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          }
 
          if (!SelectionStart.Equals(SelectionEnd)) {
-            int length = scroll.ViewPointToDataIndex(SelectionEnd) - scroll.ViewPointToDataIndex(SelectionStart) + 1;
+            int right = dataIndex1 + dataIndex2 - left;
+            int length = right - left + 1;
             result += $" | {length} bytes selected";
          }
 

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -241,8 +241,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          }
 
          if (!SelectionStart.Equals(SelectionEnd)) {
-            int right = dataIndex1 + dataIndex2 - left;
-            int length = right - left + 1;
+            int length = Math.Abs(dataIndex1 - dataIndex2) + 1;
             result += $" | {length} bytes selected";
          }
 

--- a/src/HexManiac.Tests/NavigationTests.cs
+++ b/src/HexManiac.Tests/NavigationTests.cs
@@ -351,6 +351,16 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.Equal(0x100, results[1].start);
       }
 
+      [Fact]
+      public void SelectionLengthIsPositiveWhenSelectingLeft() {
+         var test = new BaseViewModelTestClass();
+
+         test.ViewPort.SelectionStart = new Point(3, 0);
+         test.ViewPort.SelectionEnd = new Point(0, 0);
+
+         Assert.Contains("| 4 bytes selected", test.ViewPort.SelectedAddress);
+      }
+
       private void StandardSetup(out byte[] data, out PokemonModel model, out ViewPort viewPort) {
          data = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
          model = new PokemonModel(data);


### PR DESCRIPTION
Previosly, selecting from right-to-left would accidentally show a negative selection length.