### PR TITLE
Unformatted Anchors can be cleared from right-click menu

### DIFF
--- a/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
@@ -98,6 +98,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          }
 
          anchor.OriginalFormat.Visit(this, data);
+
+         if (anchor.OriginalFormat is None) Results.AddRange(GetFormattedChildren());
       }
 
       public void Visit(PCS pcs, byte data) {

--- a/src/HexManiac.Tests/PointerModelTests.cs
+++ b/src/HexManiac.Tests/PointerModelTests.cs
@@ -757,12 +757,15 @@ namespace HavenSoft.HexManiac.Tests {
       [Fact]
       public void AnchorWithNoFormatContextMenuContainsRemoveOption() {
          var test = new BaseViewModelTestClass();
-         test.ViewPort.Edit("<000020> @20 "); // add a pointer and go to the destination
+         test.ViewPort.Edit("<000020> @20 "); // add a pointer to 0x20 and go there
 
          test.ViewPort.SelectionStart = new Point();
          var contextItems = test.ViewPort.GetContextMenuItems(new Point());
+         var clearFormatItem = contextItems.Single(item => item.Text == "Clear Format");
+         clearFormatItem.Command.Execute();
 
-         contextItems.Single(item => item.Text == "Clear Format");
+         // verify that there is no longer a run starting at 0x20
+         Assert.NotEqual(0x20, test.Model.GetNextRun(0x20).Start);
       }
 
       private void StandardSetup(out byte[] data, out PokemonModel model, out ViewPort viewPort) {

--- a/src/HexManiac.Tests/PointerModelTests.cs
+++ b/src/HexManiac.Tests/PointerModelTests.cs
@@ -754,6 +754,17 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.IsType<PointerRun>(run);
       }
 
+      [Fact]
+      public void AnchorWithNoFormatContextMenuContainsRemoveOption() {
+         var test = new BaseViewModelTestClass();
+         test.ViewPort.Edit("<000020> @20 "); // add a pointer and go to the destination
+
+         test.ViewPort.SelectionStart = new Point();
+         var contextItems = test.ViewPort.GetContextMenuItems(new Point());
+
+         contextItems.Single(item => item.Text == "Clear Format");
+      }
+
       private void StandardSetup(out byte[] data, out PokemonModel model, out ViewPort viewPort) {
          data = new byte[0x200];
          model = new PokemonModel(data);


### PR DESCRIPTION
A common user interaction is to notice that a table is too short and want to extend it. But doing so requires that the user manually clears any formats that are in the way of extension: such as anchors in that area from code that 'looks' like a pointer. To facilitate making this manual process easier, it should be possible to manually clear each false pointer without having to go to the pointer sources.

Basically, just let the user right-click and "Clear Format" even if the anchor has no format.