### PR TITLE
Fix Bug #51

### DIFF
--- a/src/HexManiac.WPF/Controls/HexContent.cs
+++ b/src/HexManiac.WPF/Controls/HexContent.cs
@@ -316,6 +316,7 @@ namespace HavenSoft.HexManiac.WPF.Controls {
 
             if (ViewPort is ViewPort editableViewPort) {
                if (!editableViewPort.IsSelected(p)) editableViewPort.SelectionStart = p;
+               p = editableViewPort.SelectionStart;
             }
             var items = ViewPort.GetContextMenuItems(p);
             children.AddRange(BuildContextMenuUI(items));


### PR DESCRIPTION
Addressing Issue #51 

The HexContent might tries to update the selection before requesting context menu items. In some cases, that selection may be adjusted. Make sure the HexContent asks for the content for the actual selected cell.