### PR TITLE
Stop trying to scroll smartly on Undo

### DIFF
--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -286,10 +286,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
       private ModelDelta RevertChanges(ModelDelta changes) {
          var reverse = changes.Revert(Model);
-         var point = scroll.DataIndexToViewPoint(reverse.EarliestChange);
-         using (ModelCacheScope.CreateScope(Model)) {
-            if (!scroll.ScrollToPoint(ref point)) RefreshBackingData();
-         }
+         RefreshBackingData();
          return reverse;
       }
 

--- a/src/HexManiac.Tests/ViewPortEditTests.cs
+++ b/src/HexManiac.Tests/ViewPortEditTests.cs
@@ -107,13 +107,13 @@ namespace HavenSoft.HexManiac.Tests {
       }
 
       [Fact]
-      public void UndoCanCauseScrolling() {
+      public void UndoDoesNotCauseScrolling() {
          ViewPort.SelectionStart = new Point(0, 0);
          ViewPort.Edit("FF");
          ViewPort.Scroll.Execute(Direction.Down);
          ViewPort.Undo.Execute();
 
-         Assert.Equal(0, ViewPort.ScrollValue);
+         Assert.Equal(1, ViewPort.ScrollValue);
       }
 
       [Fact]


### PR DESCRIPTION
I've tried a bunch of different Heuristics for how to automatically scroll to the appropriate location when undo/redo is used. But none of the metrics have worked. Perhaps I'll try again later, but for now, let's just NOT scroll during undo/redo operations. It's not always the best thing to do, but it's extremely easy to grasp as a mental model.

This fixes Issue #53 