### PR TITLE
Multiple tabs same model

### DIFF
--- a/src/HexManiac.Core/ViewModels/EditorViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/EditorViewModel.cs
@@ -208,6 +208,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                if (TryUpdate(ref selectedIndex, value)) {
                   findPrevious.CanExecuteChanged.Invoke(findPrevious, EventArgs.Empty);
                   findNext.CanExecuteChanged.Invoke(findNext, EventArgs.Empty);
+                  if (selectedIndex >= 0 && selectedIndex < tabs.Count) tabs[selectedIndex].Refresh();
                   UpdateGotoViewModel();
                   foreach (var edit in QuickEdits) edit.TabChanged();
                }

--- a/src/HexManiac.Core/ViewModels/ITabContent.cs
+++ b/src/HexManiac.Core/ViewModels/ITabContent.cs
@@ -27,5 +27,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       event EventHandler<ITabContent> RequestTabChange;
       event EventHandler<Action> RequestDelayedWork;
       event EventHandler RequestMenuClose;
+
+      void Refresh();
    }
 }

--- a/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/SearchResultsViewPort.cs
@@ -214,6 +214,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          }) { ShortcutText = "Ctrl+Click" } };
       }
 
+      public void Refresh() { }
+
       private void NotifyCollectionChanged() {
          if (children.Count == 0) return;
          UpdateHeaders();

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -464,8 +464,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
       public ViewPort() : this(new LoadedFile(string.Empty, new byte[0])) { }
 
-      public ViewPort(string fileName, IDataModel model) {
-         history = new ChangeHistory<ModelDelta>(RevertChanges);
+      public ViewPort(string fileName, IDataModel model, ChangeHistory<ModelDelta> changeHistory = null) {
+         history = changeHistory ?? new ChangeHistory<ModelDelta>(RevertChanges);
          history.PropertyChanged += HistoryPropertyChanged;
 
          Model = model;
@@ -742,6 +742,12 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          Model.ObserveRunWritten(CurrentChange, destination2.Duplicate(newDestination, pointer)); // create a new run at the new destination
          OnMessage?.Invoke(this, "New Copy added at " + newDestination.ToString("X6"));
          Refresh();
+      }
+
+      public void OpenInNewTab(int destination) {
+         var child = new ViewPort(FileName, Model, history);
+         child.selection.GotoAddress(destination);
+         RequestTabChange?.Invoke(this, child);
       }
 
       private void CreateNewData(int pointer) {

--- a/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
@@ -66,6 +66,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
             if (!(destination is NoInfoRun)) {
                Results.Add(new ContextItem("Repoint to New Copy", arg => ViewPort.RepointToNewCopy(pointerAddress)));
             }
+            Results.Add(new ContextItem("Open in New Tab", arg => ViewPort.OpenInNewTab(pointerDestination)));
          }
 
          var arrayRun = ViewPort.Model.GetNextRun(pointerAddress) as ITableRun;

--- a/src/HexManiac.Tests/BasicLoadTests.cs
+++ b/src/HexManiac.Tests/BasicLoadTests.cs
@@ -7,7 +7,11 @@ using Xunit;
 namespace HavenSoft.HexManiac.Tests {
    public class BasicLoadTests {
       static BasicLoadTests() {
-         SampleFiles = Directory.EnumerateFiles("sampleFiles", "*.gba").Select(file => new object[] { file }).ToArray();
+         if (Directory.Exists("sampleFiles")) {
+            SampleFiles = Directory.EnumerateFiles("sampleFiles", "*.gba").Select(file => new object[] { file }).ToArray();
+         } else {
+            SampleFiles = Enumerable.Empty<object[]>();
+         }
       }
       public static IEnumerable<object[]> SampleFiles { get; }
 

--- a/src/HexManiac.Tests/GeneralAppTests.cs
+++ b/src/HexManiac.Tests/GeneralAppTests.cs
@@ -2,6 +2,7 @@
 using HavenSoft.HexManiac.Core.Models;
 using HavenSoft.HexManiac.Core.ViewModels;
 using System;
+using System.Linq;
 using System.Windows.Input;
 using Xunit;
 
@@ -428,6 +429,21 @@ namespace HavenSoft.HexManiac.Tests {
 
          editor.ResetTheme.Execute();
          Assert.Equal(defaultValue, editor.Theme.AccentValue);
+      }
+
+      [Fact]
+      public void CanOpenSecondTabWithSameModel() {
+         var test = new BaseViewModelTestClass();
+         editor.Add(test.ViewPort);
+         test.ViewPort.Edit("<000100> @00 "); // create a pointer for us to follow
+
+         var item = test.ViewPort.GetContextMenuItems(new Point()).Single(menuItem => menuItem.Text == "Open in New Tab");
+         item.Command.Execute();
+
+         var newTab = (ViewPort)editor[1];
+         Assert.Equal(test.ViewPort.CurrentChange, newTab.CurrentChange); // they have the same change history
+         Assert.Equal(test.ViewPort.Model, newTab.Model);                 // they have the same model
+         Assert.Equal(0x100, newTab.DataOffset);                          // the new tab is scrolled to the desired location
       }
 
       private StubTabContent CreateClosableTab() {

--- a/src/HexManiac.Tests/GeneralAppTests.cs
+++ b/src/HexManiac.Tests/GeneralAppTests.cs
@@ -446,6 +446,20 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.Equal(0x100, newTab.DataOffset);                          // the new tab is scrolled to the desired location
       }
 
+      [Fact]
+      public void TabGetsRefreshedWhenSwitchedIn() {
+         int count = 0;
+         var tab1 = new StubTabContent { Refresh = () => count++ };
+         var tab2 = new StubTabContent();
+         editor.Add(tab1);
+         count = 0;
+
+         tab1.RequestTabChange?.Invoke(tab1, tab2);
+         editor.SelectedIndex = 0;
+
+         Assert.Equal(1, count);
+      }
+
       private StubTabContent CreateClosableTab() {
          var tab = new StubTabContent();
          var close = new StubCommand { CanExecute = arg => true };


### PR DESCRIPTION
Feature request from DemICE:
```
would it be possible to be able to create multiple tabs on the same open rom, to work at various parts at the same time without going back and forth?
for example im at trainerdata,  and i wanna check out the trainers pokemon with a GoTo,  but if i had the option to open it at a new tab, i would be able to toggle between a trainer's team and the pokemon table and do changes between them much faster
```

You still can't pull tabs out, so you can't see both at the same time. But it's possible to switch between the two locations by switching tabs instead of having to manually remember multiple places where you're working.