### PR TITLE
habitat editor

### DIFF
--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -33,3 +33,6 @@ nationaldex,         03F83C, 03F83C, 03F83C, 03F83C, 04323C, 04323C, 043250, 043
 hoennToNational,     03F888, 03F888, 03F888, 03F888, 043288, 043288, 04329C, 04329C, 06D494, [index:]pokenames-1
 dexinfo,             08F508, 08F508, 08F528, 08F528, 088E34, 088E30, 088E48, 088E1C,       , [species""12 height: weight: description1<""> description2<""> unused: pokemonScale: pokemonOffset: trainerScale: trainerOffset: unused:]
 dexinfo,                   ,       ,       ,       ,       ,       ,       ,       , 0BFA20, [species""12 height: weight: description<""> unused: pokemonScale: pokemonOffset: trainerScale: trainerOffset: unused:]
+
+habitatnames,              ,       ,       ,       , 104F84, 104F5C, 104FFC, 104FD4,       , [name<"">]
+habitats,                  ,       ,       ,       , 106888, 106860, 106900, 1068D8,       , [data<[pokemon<[species:pokenames]/pokecount> pokecount::]/count> count::]habitatnames

--- a/src/HexManiac.Core/Models/Runs/ArrayRun.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRun.cs
@@ -1,6 +1,7 @@
 ﻿using HavenSoft.HexManiac.Core.ViewModels.DataFormats;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
@@ -707,6 +708,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       }
 
       public static bool DataMatchesSegmentFormat(IDataModel owner, int start, ArrayRunElementSegment segment, FormatMatchFlags flags, IReadOnlyList<ArrayRunElementSegment> sourceSegments) {
+         Debug.Assert(sourceSegments.Contains(segment), "Expected segment to be one among sourceSegments.");
          switch (segment.Type) {
             case ElementContentType.PCS:
                int readLength = PCSString.ReadString(owner, start, true, segment.Length);

--- a/src/HexManiac.Core/Models/Runs/TableStreamRun.cs
+++ b/src/HexManiac.Core/Models/Runs/TableStreamRun.cs
@@ -31,7 +31,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          for (int i = 0; i < tableStream.ElementCount; i++) {
             int subStart = start + tableStream.ElementLength * i;
             for (int j = 0; j < tableStream.ElementContent.Count; j++) {
-               if (!ArrayRun.DataMatchesSegmentFormat(model, subStart, tableStream.ElementContent[j], default, sourceSegments)) return false;
+               if (!ArrayRun.DataMatchesSegmentFormat(model, subStart, tableStream.ElementContent[j], default, tableStream.ElementContent)) return false;
                subStart += tableStream.ElementContent[j].Length;
             }
          }

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -1,4 +1,5 @@
 ﻿
+using HavenSoft.HexManiac.Core;
 using HavenSoft.HexManiac.Core.Models;
 using HavenSoft.HexManiac.Core.Models.Runs;
 using HavenSoft.HexManiac.Core.ViewModels;
@@ -392,6 +393,27 @@ namespace HavenSoft.HexManiac.Tests {
          var specialsAddress = model.GetAddressFromAnchor(noChange, -1, HardcodeTablesModel.SpecialsTable);
          var specials = (ITableRun)model.GetNextRun(specialsAddress);
          Assert.NotInRange(specials.ElementCount, 0, 300);
+      }
+
+      [SkippableTheory]
+      [MemberData(nameof(PokemonGames))]
+      public void HabitatsAreFound(string game) {
+         var model = fixture.LoadModel(game);
+         var noChange = new NoDataChangeDeltaModel();
+
+         var habitatNamesAddress = model.GetAddressFromAnchor(noChange, -1, "habitatnames");
+         var habitatsAddress = model.GetAddressFromAnchor(noChange, -1, "habitats");
+
+         // ruby / sapphire / emerald have no habitats
+         if (model.GetGameCode().IsAny(AutoSearchModel.Ruby, AutoSearchModel.Ruby1_1, AutoSearchModel.Sapphire, AutoSearchModel.Sapphire1_1, AutoSearchModel.Emerald)) {
+            Assert.Equal(Pointer.NULL, habitatNamesAddress);
+            Assert.Equal(Pointer.NULL, habitatsAddress);
+            return;
+         }
+
+         var habitatNames = (ITableRun)model.GetNextRun(habitatNamesAddress);
+         var habitats = (ITableRun)model.GetNextRun(habitatsAddress);
+         Assert.InRange(habitats.ElementCount, 8, 12);
       }
 
       public static IEnumerable<object[]> ListData => PokemonGames.Select(array => array[0]).SelectMany(game =>

--- a/src/HexManiac.WPF/Controls/StartScreen.xaml
+++ b/src/HexManiac.WPF/Controls/StartScreen.xaml
@@ -28,6 +28,7 @@
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>tutormoves / tutorcompatibility<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>tmmoves / tmcompatibility<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>dexinfo / regionaldex / nationaldex / hoennToNational<LineBreak/>
+      <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>habitatnames / habitats<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>wild<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>multichoice<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>decorations<LineBreak/>


### PR DESCRIPTION
'Habitat' is a pokedex feature in FireRed / LeafGreen. It involves having pokemon viewable based on where they can be caught, organized into pages, instead of just in dex order. The format is rather nested, but the table tool still works fine.