### PR TITLE
Multiline paste-scripts should work without EOL whitespace

### DIFF
--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -1308,6 +1308,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          var point = GetEditPoint();
          var element = this[point.X, point.Y];
 
+         if (input.IsAny('\r', '\n')) input = ' '; // handle multiline pasting by just treating the newlines as standard whitespace. 
+
          if (!ShouldAcceptInput(point, element, input)) {
             ClearEdits(point);
             return;

--- a/src/HexManiac.Tests/NestedTablesTests.cs
+++ b/src/HexManiac.Tests/NestedTablesTests.cs
@@ -305,6 +305,23 @@ namespace HavenSoft.HexManiac.Tests {
       }
 
       [Fact]
+      public void MultilinePlmPasteWorks() {
+         SetupMoveTable(0x00);
+         SetupPlmStream(0x50, 2);
+         viewPort.Edit(@"@000050
+4 Three
+6 Five
+10 Zero
+[]
+");
+
+         Assert.Equal(0b0000100_000000011, model.ReadMultiByteValue(0x50, 2));
+         Assert.Equal(0b0000110_000000101, model.ReadMultiByteValue(0x52, 2));
+         Assert.Equal(0b0001010_000000000, model.ReadMultiByteValue(0x54, 2));
+         Assert.Equal(0xFFFF, model.ReadMultiByteValue(0x56, 2));
+      }
+
+      [Fact]
       public void ChoosingAutoCompleteOptionClosesPlmEdit() {
          SetupMoveTable(0x00);
          viewPort.SelectionStart = new Point(0, 1); // start of move "Two"


### PR DESCRIPTION
Thanks to petuuuhhh for finding this issue while working with lvlmove paste-scripts.

Basically, if a user pastes in multiple lines of stuff, just treat the newline the same way we treat normal whitespace. The user hitting 'Enter' individually is handled separately by the `Edit(ConsoleKey)` function.