### PR TITLE
Add support for pokedex search tables

### DIFF
--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -33,6 +33,9 @@ nationaldex,         03F83C, 03F83C, 03F83C, 03F83C, 04323C, 04323C, 043250, 043
 hoennToNational,     03F888, 03F888, 03F888, 03F888, 043288, 043288, 04329C, 04329C, 06D494, [index:]pokenames-1
 dexinfo,             08F508, 08F508, 08F528, 08F528, 088E34, 088E30, 088E48, 088E1C,       , [species""12 height: weight: description1<""> description2<""> unused: pokemonScale: pokemonOffset: trainerScale: trainerOffset: unused:]
 dexinfo,                   ,       ,       ,       ,       ,       ,       ,       , 0BFA20, [species""12 height: weight: description<""> unused: pokemonScale: pokemonOffset: trainerScale: trainerOffset: unused:]
-
+searchalpha,         08D930, 08D930, 08D950, 08D950, 103694, 10366C, 10370C, 1036E4, 0BCB74, [species:nationaldex]nationaldex
+searchweight,        08D9BC, 08D9BC, 08D9DC, 08D9DC, 1037CC, 1037A4, 103844, 10381C, 0BCC00, [species:nationaldex]386
+searchsize,          08DAE4, 08DAE4, 08DB04, 08DB04, 103868, 103840, 1038E0, 1038B8, 0BCD28, [species:nationaldex]386
+searchtype,                ,       ,       ,       , 103734, 10370C, 1037AC, 103784,       , [species:pokenames]nationaldex
 habitatnames,              ,       ,       ,       , 104F84, 104F5C, 104FFC, 104FD4,       , [name<"">]
 habitats,                  ,       ,       ,       , 106888, 106860, 106900, 1068D8,       , [data<[pokemon<[species:pokenames]/pokecount> pokecount::]/count> count::]habitatnames

--- a/src/HexManiac.Core/Models/Runs/ModelCacheScope.cs
+++ b/src/HexManiac.Core/Models/Runs/ModelCacheScope.cs
@@ -76,7 +76,10 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       private static IReadOnlyList<string> GetOptions(IDataModel model, string enumName) {
          if (model.TryGetList(enumName, out var nameArray)) return nameArray;
 
-         if (!model.TryGetNameArray(enumName, out var enumArray)) return new string[0];
+         if (!model.TryGetNameArray(enumName, out var enumArray)) {
+            if (model.TryGetIndexNames(enumName, out var indexArray)) return indexArray;
+            return new string[0];
+         }
 
          // array must be at least as long as than the current value
          var optionCount = enumArray.ElementCount;

--- a/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
@@ -22,7 +22,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          ArrayStart, ArrayEnd,
          StringDelimeter, StreamDelimeter,
          PointerStart, PointerEnd,
-         '|', '!', ArrayAnchorSeparator,
+         '|', '!', '-', ArrayAnchorSeparator,
          SingleByteIntegerFormat, DoubleByteIntegerFormat,
       };
 

--- a/src/HexManiac.Tests/NestedTablesTests.cs
+++ b/src/HexManiac.Tests/NestedTablesTests.cs
@@ -399,6 +399,26 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.Equal(8, model.GetNextRun(0x60).Length);
       }
 
+      /// <summary>
+      /// You can not only make an enum out of a string table, but also out of an index list matching the length of a string table
+      /// </summary>
+      [Fact]
+      public void EnumFromEnumFromStringUsesIndexValueAsOptions() {
+         SetupNameTable(0x180);
+         viewPort.Edit($"@00 ^enum1[value.]{EggMoveRun.PokemonNameTable}-1 2 3 4 5 6 7 1 ");
+         using (ModelCacheScope.CreateScope(model)) {
+            var options = ModelCacheScope.GetCache(model).GetOptions("enum1");
+            Assert.Equal("Horton", options[1]); // option 0 should be Horton because enum[Horton] = 0
+            Assert.Equal("Bob", options[2]);
+            Assert.Equal("Carl", options[3]);
+            Assert.Equal("Dave", options[4]);
+            Assert.Equal("Elen", options[5]);
+            Assert.Equal("Fred", options[6]);
+            Assert.Equal("Gary", options[7]);
+            Assert.Equal(7, options.Count);
+         }
+      }
+
       // creates a move table that is 0x40 bytes long
       private void SetupMoveTable(int start) {
          viewPort.Goto.Execute(start.ToString("X6"));

--- a/src/HexManiac.Tests/NestedTablesTests.cs
+++ b/src/HexManiac.Tests/NestedTablesTests.cs
@@ -415,7 +415,7 @@ namespace HavenSoft.HexManiac.Tests {
             Assert.Equal("Elen", options[5]);
             Assert.Equal("Fred", options[6]);
             Assert.Equal("Gary", options[7]);
-            Assert.Equal(7, options.Count);
+            Assert.Equal(8, options.Count);
          }
       }
 

--- a/src/HexManiac.WPF/Controls/StartScreen.xaml
+++ b/src/HexManiac.WPF/Controls/StartScreen.xaml
@@ -27,7 +27,8 @@
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>items / itemimages<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>tutormoves / tutorcompatibility<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>tmmoves / tmcompatibility<LineBreak/>
-      <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>dexinfo / regionaldex / nationaldex / hoennToNational<LineBreak/>
+      <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>dexinfo / regionaldex / nationaldex / hoennToNational<LineBreak/>      
+      <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>searchalpha / searchsize / searchweight / searchtype<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>habitatnames / habitats<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>wild<LineBreak/>
       <BulletDecorator><Ellipse VerticalAlignment="Center" Margin="2" Fill="{DynamicResource Primary}" Width="5" Height="5"/></BulletDecorator>multichoice<LineBreak/>


### PR DESCRIPTION
The tables refer to pokemon by their nationaldex number, not by their pokemon ID. So I needed a way to use an index-enum. That's the new test in NestedTableTests. That's also the reason for the change in StartCellEdit, ModelCacheScope, and IDataModel.

The new test in AutoSearchTests proves that the 4 new tables work correctly. That's also the reason for the change in StartScreen and tableReference.