### PR TITLE
TableTool is open by default

### DIFF
--- a/src/HexManiac.Core/ViewModels/Tools/IToolTrayViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/IToolTrayViewModel.cs
@@ -59,9 +59,9 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
       public ICommand TableToolCommand => tableToolCommand;
       public ICommand CodeToolCommand => codeToolCommand;
 
-      public PCSTool StringTool => (PCSTool)tools[0];
+      public PCSTool StringTool => (PCSTool)tools[1];
 
-      public TableTool TableTool => (TableTool)tools[1];
+      public TableTool TableTool => (TableTool)tools[0];
 
       public CodeTool CodeTool => (CodeTool)tools[2];
 
@@ -89,19 +89,19 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
       public ToolTray(IDataModel model, Selection selection, ChangeHistory<ModelDelta> history, ViewPort viewPort) {
          this.model = model;
          tools = new IToolViewModel[] {
-            new PCSTool(model, selection, history, this),
             new TableTool(model, selection, history, viewPort, this),
+            new PCSTool(model, selection, history, this),
             new CodeTool(model, selection),
          };
 
          stringToolCommand = new StubCommand {
             CanExecute = ICommandExtensions.CanAlwaysExecute,
-            Execute = arg => SelectedIndex = selectedIndex == 0 ? -1 : 0,
+            Execute = arg => SelectedIndex = selectedIndex == 1 ? -1 : 1,
          };
 
          tableToolCommand = new StubCommand {
             CanExecute = ICommandExtensions.CanAlwaysExecute,
-            Execute = arg => SelectedIndex = selectedIndex == 1 ? -1 : 1,
+            Execute = arg => SelectedIndex = selectedIndex == 0 ? -1 : 0,
          };
 
          codeToolCommand = new StubCommand {
@@ -114,7 +114,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
             Execute = arg => SelectedIndex = -1,
          };
 
-         SelectedIndex = -1;
+         SelectedIndex = 0; // table tool is open by default
 
          StringTool.OnError += (sender, e) => OnError?.Invoke(this, e);
          TableTool.OnError += (sender, e) => OnError?.Invoke(this, e);

--- a/src/HexManiac.Tests/ArrayRunTests.cs
+++ b/src/HexManiac.Tests/ArrayRunTests.cs
@@ -210,7 +210,7 @@ namespace HavenSoft.HexManiac.Tests {
          viewPort.FollowLink(0, 7); // 7*16 = 112, right in the middle of our data
          // note that this will change our width to 15, because we're linking to data of width 5 when our maxwidth is 16.
 
-         Assert.Equal(0, viewPort.Tools.SelectedIndex); // string tool is selected
+         Assert.Equal(viewPort.Tools.IndexOf(viewPort.Tools.StringTool), viewPort.Tools.SelectedIndex); // string tool is selected
          Assert.Equal(100, viewPort.Tools.StringTool.Address);
          var lineCount = viewPort.Tools.StringTool.Content.Split(Environment.NewLine).Length;
          Assert.Equal(6, lineCount);

--- a/src/HexManiac.Tests/EggMoveTests.cs
+++ b/src/HexManiac.Tests/EggMoveTests.cs
@@ -157,7 +157,7 @@ Water";
          viewPort.SelectionStart = new Point(2, 0);
          viewPort.FollowLink(2, 0);
 
-         Assert.Equal(0, viewPort.Tools.SelectedIndex);
+         Assert.Equal(viewPort.Tools.IndexOf(viewPort.Tools.StringTool), viewPort.Tools.SelectedIndex);
       }
 
       [Fact]

--- a/src/HexManiac.Tests/ToolTests.cs
+++ b/src/HexManiac.Tests/ToolTests.cs
@@ -26,6 +26,7 @@ namespace HavenSoft.HexManiac.Tests {
          var model = new PokemonModel(buffer);
          var viewPort = new ViewPort("file.txt", model) { Width = 0x10, Height = 0x10 };
          viewPort.Edit("^bob\"\" \"Some Text\" 00 <000100>");
+         viewPort.Tools.SelectedIndex = -1;
          var toolProperties = new List<string>();
          viewPort.Tools.PropertyChanged += (sender, e) => toolProperties.Add(e.PropertyName);
          viewPort.FollowLink(0, 0);

--- a/src/HexManiac.WPF/Controls/TabView.xaml
+++ b/src/HexManiac.WPF/Controls/TabView.xaml
@@ -20,7 +20,7 @@
       </DockPanel>
       <!-- Tool Headers -->
       <StackPanel DockPanel.Dock="Left" Visibility="{Binding HasTools, Converter={StaticResource BoolToVisibility}}">
-         <Button Content="Text" Command="{Binding Tools.StringToolCommand}" Margin="0,2">
+         <Button Content="Table" Command="{Binding Tools.TableToolCommand}" Margin="0,2">
             <Button.LayoutTransform>
                <RotateTransform Angle="-90"/>
             </Button.LayoutTransform>
@@ -34,7 +34,7 @@
                </Style>
             </Button.Style>
          </Button>
-         <Button Content="Table" Command="{Binding Tools.TableToolCommand}" Margin="0,2">
+         <Button Content="Text" Command="{Binding Tools.StringToolCommand}" Margin="0,2">
             <Button.LayoutTransform>
                <RotateTransform Angle="-90"/>
             </Button.LayoutTransform>
@@ -74,50 +74,12 @@
                </Style.Triggers>
             </Style>
          </Grid.Style>
-         <DockPanel Name="StringToolPanel">
-            <DockPanel.Style>
-               <Style TargetType="DockPanel">
-                  <Setter Property="Visibility" Value="Collapsed"/>
-                  <Style.Triggers>
-                     <DataTrigger Binding="{Binding SelectedIndex}" Value="0">
-                        <Setter Property="Visibility" Value="Visible"/>
-                     </DataTrigger>
-                  </Style.Triggers>
-               </Style>
-            </DockPanel.Style>
-            <TextBlock Text="Address:" Margin="5,15,0,0" DockPanel.Dock="Top"/>
-            <TextBox Text="{Binding StringTool.Address, Converter={StaticResource Hex}, UpdateSourceTrigger=PropertyChanged}" Margin="5" DockPanel.Dock="Top"/>
-            <TextBlock DockPanel.Dock="Top" Text="{Binding StringTool.Message}" Width="255" HorizontalAlignment="Center" TextWrapping="Wrap" Visibility="{Binding StringTool.ShowMessage, Converter={StaticResource BoolToVisibility}}"/>
-            <Button Margin="0,3" Command="{Binding StringTool.CheckIsText}" Content="Show As Text" HorizontalAlignment="Right" DockPanel.Dock="Top" Visibility="{Binding StringTool.ShowMessage, Converter={StaticResource BoolToVisibility}}"/>
-            <Button Command="{Binding StringTool.InsertText}" Content="Insert New Text" HorizontalAlignment="Right" DockPanel.Dock="Top" Visibility="{Binding StringTool.ShowMessage, Converter={StaticResource BoolToVisibility}}"/>
-            <TextBlock Text="Content:" Margin="5,30,0,0" DockPanel.Dock="Top"/>
-
-            <Button Command="{Binding StringTool.Search}" Margin="5,0" Content="Search" HorizontalAlignment="Right" DockPanel.Dock="Bottom" />
-            <TextBox Margin="5,0" Width="255" FontFamily="Consolas" Text="{Binding StringTool.SearchText, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding StringTool.Enabled}" DockPanel.Dock="Bottom">
-               <TextBox.InputBindings>
-                  <KeyBinding Key="Return" Command="{Binding StringTool.Search}"/>
-                  <KeyBinding Key="F3" Command="{Binding StringTool.Search}"/>
-               </TextBox.InputBindings>
-            </TextBox>
-            <TextBlock Text="Search:" Margin="5,0" DockPanel.Dock="Bottom"/>
-
-            <Grid Margin="5,5" MinHeight="50" Width="255">
-               <TextBox Name="StringToolTextBox" AcceptsReturn="True" TextWrapping="Wrap" FontFamily="Consolas" VerticalScrollBarVisibility="Auto" UndoLimit="0"
-                  SelectionChanged="StringToolContentSelectionChanged"
-                  LostFocus="ShowManualSelection"
-                  GotFocus="HideManualSelection"
-                  ScrollViewer.ScrollChanged="UpdateManualSelectionFromScroll"
-                  IsEnabled="{Binding StringTool.Enabled}"
-                  Text="{Binding StringTool.Content, UpdateSourceTrigger=PropertyChanged}" />
-               <Rectangle Name="ManualHighlight" HorizontalAlignment="Stretch" VerticalAlignment="Top" Height="14" Fill="{DynamicResource Accent}" Opacity=".4"/>
-            </Grid>
-         </DockPanel>
          <DockPanel Width="265" Name="TableToolPanel">
             <DockPanel.Style>
                <Style TargetType="DockPanel">
                   <Setter Property="Visibility" Value="Collapsed"/>
                   <Style.Triggers>
-                     <DataTrigger Binding="{Binding SelectedIndex}" Value="1">
+                     <DataTrigger Binding="{Binding SelectedIndex}" Value="0">
                         <Setter Property="Visibility" Value="Visible"/>
                      </DataTrigger>
                   </Style.Triggers>
@@ -256,6 +218,44 @@
                   </ItemsControl>
                </StackPanel>
             </ScrollViewer>
+         </DockPanel>
+         <DockPanel Name="StringToolPanel">
+            <DockPanel.Style>
+               <Style TargetType="DockPanel">
+                  <Setter Property="Visibility" Value="Collapsed"/>
+                  <Style.Triggers>
+                     <DataTrigger Binding="{Binding SelectedIndex}" Value="1">
+                        <Setter Property="Visibility" Value="Visible"/>
+                     </DataTrigger>
+                  </Style.Triggers>
+               </Style>
+            </DockPanel.Style>
+            <TextBlock Text="Address:" Margin="5,15,0,0" DockPanel.Dock="Top"/>
+            <TextBox Text="{Binding StringTool.Address, Converter={StaticResource Hex}, UpdateSourceTrigger=PropertyChanged}" Margin="5" DockPanel.Dock="Top"/>
+            <TextBlock DockPanel.Dock="Top" Text="{Binding StringTool.Message}" Width="255" HorizontalAlignment="Center" TextWrapping="Wrap" Visibility="{Binding StringTool.ShowMessage, Converter={StaticResource BoolToVisibility}}"/>
+            <Button Margin="0,3" Command="{Binding StringTool.CheckIsText}" Content="Show As Text" HorizontalAlignment="Right" DockPanel.Dock="Top" Visibility="{Binding StringTool.ShowMessage, Converter={StaticResource BoolToVisibility}}"/>
+            <Button Command="{Binding StringTool.InsertText}" Content="Insert New Text" HorizontalAlignment="Right" DockPanel.Dock="Top" Visibility="{Binding StringTool.ShowMessage, Converter={StaticResource BoolToVisibility}}"/>
+            <TextBlock Text="Content:" Margin="5,30,0,0" DockPanel.Dock="Top"/>
+
+            <Button Command="{Binding StringTool.Search}" Margin="5,0" Content="Search" HorizontalAlignment="Right" DockPanel.Dock="Bottom" />
+            <TextBox Margin="5,0" Width="255" FontFamily="Consolas" Text="{Binding StringTool.SearchText, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding StringTool.Enabled}" DockPanel.Dock="Bottom">
+               <TextBox.InputBindings>
+                  <KeyBinding Key="Return" Command="{Binding StringTool.Search}"/>
+                  <KeyBinding Key="F3" Command="{Binding StringTool.Search}"/>
+               </TextBox.InputBindings>
+            </TextBox>
+            <TextBlock Text="Search:" Margin="5,0" DockPanel.Dock="Bottom"/>
+
+            <Grid Margin="5,5" MinHeight="50" Width="255">
+               <TextBox Name="StringToolTextBox" AcceptsReturn="True" TextWrapping="Wrap" FontFamily="Consolas" VerticalScrollBarVisibility="Auto" UndoLimit="0"
+                  SelectionChanged="StringToolContentSelectionChanged"
+                  LostFocus="ShowManualSelection"
+                  GotFocus="HideManualSelection"
+                  ScrollViewer.ScrollChanged="UpdateManualSelectionFromScroll"
+                  IsEnabled="{Binding StringTool.Enabled}"
+                  Text="{Binding StringTool.Content, UpdateSourceTrigger=PropertyChanged}" />
+               <Rectangle Name="ManualHighlight" HorizontalAlignment="Stretch" VerticalAlignment="Top" Height="14" Fill="{DynamicResource Accent}" Opacity=".4"/>
+            </Grid>
          </DockPanel>
          <DockPanel Name="CodeToolPanel">
             <DockPanel.Style>


### PR DESCRIPTION
To help users understand the features of the program, go ahead and have the table tool open by default. This has the benifit of showing a drop-down list with all the current known tables, so the user can quickly jump to them. This is similar to how other programs show some of their tools by default, helping the user know what things are possible with the application.

Also move the Table Tool to be the top tool for consistency.