### PR TITLE
Egg crash

### DIFF
--- a/src/HexManiac.Core/Models/HardcodeTablesModel.cs
+++ b/src/HexManiac.Core/Models/HardcodeTablesModel.cs
@@ -79,7 +79,7 @@ namespace HavenSoft.HexManiac.Core.Models {
 
          // in vanilla emerald, this pointer isn't four-byte aligned
          // it's at the very front of the ROM, so if there's no metadata we can be pretty sure that the pointer is still there
-         if (gameCode == Emerald && data[0x1C3] == 0x08) ObserveRunWritten(noChangeDelta, new PointerRun(0x1C0));
+         if (gameCode == Emerald && data.Length > EarliestAllowedAnchor && data[0x1C3] == 0x08) ObserveRunWritten(noChangeDelta, new PointerRun(0x1C0));
 
          var gamesToDecode = new[] { Ruby, Sapphire, Emerald, FireRed, LeafGreen, Ruby1_1, Sapphire1_1, FireRed1_1, LeafGreen1_1 };
          if (gamesToDecode.Contains(gameCode)) {
@@ -138,7 +138,13 @@ namespace HavenSoft.HexManiac.Core.Models {
             case Ruby: case Sapphire: source = 0x041B44; break;
             case Ruby1_1: case Sapphire1_1: source = 0x041B64; break;
          }
-         if (source > 0) ObserveAnchorWritten(noChangeDelta, EggMovesTableName, new EggMoveRun(this, ReadPointer(source)));
+         if (source > 0 && source < Count) {
+            var address = ReadPointer(source);
+            var eggRun = new EggMoveRun(this, address);
+            if (eggRun.Length > 0) {
+               ObserveAnchorWritten(noChangeDelta, EggMovesTableName, eggRun);
+            }
+         }
 
          // type chart
          source = 0;

--- a/src/HexManiac.Core/Models/IDataModel.cs
+++ b/src/HexManiac.Core/Models/IDataModel.cs
@@ -171,7 +171,7 @@ namespace HavenSoft.HexManiac.Core.Models {
 
    public static class IDataModelExtensions {
       public static string GetGameCode(this IDataModel model) {
-         var code = new string(Enumerable.Range(0xAC, 4).Select(i => ((char)model[i])).ToArray());
+         var code = new string(Enumerable.Range(0xAC, 4).Select(i => (char)model[i]).ToArray());
          code += model[0xBC]; // should be "0" or "1"
          return code;
       }

--- a/src/HexManiac.Core/Models/Runs/EggMoveRun.cs
+++ b/src/HexManiac.Core/Models/Runs/EggMoveRun.cs
@@ -22,6 +22,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       public EggMoveRun(IDataModel dataModel, int dataIndex, IReadOnlyList<int> pointerSources = null) : base(dataIndex, pointerSources) {
          model = dataModel;
          Length = 0;
+         if (Start < 0) return;
          for (int i = Start; i < model.Count; i += 2) {
             if (model[i] == 0xFF && model[i + 1] == 0xFF) {
                Length = i - Start + 2;

--- a/src/HexManiac.Tests/BadFileLoadTests.cs
+++ b/src/HexManiac.Tests/BadFileLoadTests.cs
@@ -1,0 +1,26 @@
+﻿using HavenSoft.HexManiac.Core.Models;
+using Xunit;
+
+namespace HavenSoft.HexManiac.Tests {
+   public class BadFileLoadTests {
+      [Theory]
+      [InlineData(HardcodeTablesModel.Ruby)]
+      [InlineData(HardcodeTablesModel.Sapphire)]
+      [InlineData(HardcodeTablesModel.Ruby1_1)]
+      [InlineData(HardcodeTablesModel.Sapphire1_1)]
+      [InlineData(HardcodeTablesModel.FireRed)]
+      [InlineData(HardcodeTablesModel.LeafGreen)]
+      [InlineData(HardcodeTablesModel.FireRed1_1)]
+      [InlineData(HardcodeTablesModel.LeafGreen1_1)]
+      [InlineData(HardcodeTablesModel.Emerald)]
+      public void HardcodeTableModelCanLoadEvenAllBlank(string gamecode) {
+         var data = new byte[0x100];
+         data[0xAC + 0] = (byte)gamecode[0];
+         data[0xAC + 1] = (byte)gamecode[1];
+         data[0xAC + 2] = (byte)gamecode[2];
+         data[0xAC + 3] = (byte)gamecode[3];
+
+         var model = new HardcodeTablesModel(data);
+      }
+   }
+}

--- a/src/HexManiac.Tests/HexManiac.Tests.csproj
+++ b/src/HexManiac.Tests/HexManiac.Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="ArrayColumnHeaderTests.cs" />
     <Compile Include="ArrayRunTests.cs" />
     <Compile Include="AutoSearchTests.cs" />
+    <Compile Include="BadFileLoadTests.cs" />
     <Compile Include="BaseViewModelTestClass.cs" />
     <Compile Include="BasicLoadTests.cs" />
     <Compile Include="ChangeHistoryTests.cs" />


### PR DESCRIPTION
Fix issue found by BreadCrumbs. The EggMoves would sometimes come back with length 0, which would cause a Debug.Assert. We should properly handle this case (and similar edge cases) in HardcodeTablesModel. Added unit tests to prove that this works.