### PR TITLE
Store the version in the metadata TOML file

### DIFF
--- a/src/HexManiac.Core/Models/IDataModel.cs
+++ b/src/HexManiac.Core/Models/IDataModel.cs
@@ -60,7 +60,7 @@ namespace HavenSoft.HexManiac.Core.Models {
       int GetAddressFromAnchor(ModelDelta changeToken, int requestSource, string anchor);
       string GetAnchorFromAddress(int requestSource, int destination);
       IReadOnlyList<string> GetAutoCompleteAnchorNameOptions(string partial);
-      StoredMetadata ExportMetadata();
+      StoredMetadata ExportMetadata(IMetadataInfo metadataInfo);
       void UpdateArrayPointer(ModelDelta changeToken, ArrayRunElementSegment segment, int address, int destination);
       int ConsiderResultsAsTextRuns(ModelDelta changeToken, IReadOnlyList<int> startLocations);
    }
@@ -162,7 +162,7 @@ namespace HavenSoft.HexManiac.Core.Models {
 
       public virtual IReadOnlyList<string> GetAutoCompleteAnchorNameOptions(string partial) => new string[0];
 
-      public virtual StoredMetadata ExportMetadata() => null;
+      public virtual StoredMetadata ExportMetadata(IMetadataInfo metadataInfo) => null;
 
       IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/HexManiac.Core/Models/PokemonModel.cs
+++ b/src/HexManiac.Core/Models/PokemonModel.cs
@@ -1322,7 +1322,7 @@ namespace HavenSoft.HexManiac.Core.Models {
          }
       }
 
-      public override StoredMetadata ExportMetadata() {
+      public override StoredMetadata ExportMetadata(IMetadataInfo metadataInfo) {
          var anchors = new List<StoredAnchor>();
          foreach (var kvp in anchorForAddress) {
             var (address, name) = (kvp.Key, kvp.Value);
@@ -1351,7 +1351,7 @@ namespace HavenSoft.HexManiac.Core.Models {
             lists.Add(new StoredList(name, members.ToList()));
          }
 
-         return new StoredMetadata(anchors, unmappedPointers, matchedWords, lists);
+         return new StoredMetadata(anchors, unmappedPointers, matchedWords, lists, metadataInfo);
       }
 
       /// <summary>

--- a/src/HexManiac.Core/Models/Singletons.cs
+++ b/src/HexManiac.Core/Models/Singletons.cs
@@ -1,9 +1,10 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using HavenSoft.HexManiac.Core.Models.Code;
 using static HavenSoft.HexManiac.Core.Models.HardcodeTablesModel;
 
@@ -17,6 +18,7 @@ namespace HavenSoft.HexManiac.Core.Models {
       private const string ThumbReferenceFileName = "resources/armReference.txt";
       private const string ScriptReferenceFileName = "resources/scriptReference.txt";
 
+      public IMetadataInfo MetadataInfo { get; }
       public IReadOnlyDictionary<string, GameReferenceTables> GameReferenceTables { get; }
       public IReadOnlyList<ConditionCode> ThumbConditionalCodes { get; }
       public IReadOnlyList<IInstruction> ThumbInstructionTemplates { get; }
@@ -26,6 +28,7 @@ namespace HavenSoft.HexManiac.Core.Models {
          GameReferenceTables = CreateGameReferenceTables();
          (ThumbConditionalCodes, ThumbInstructionTemplates) = LoadThumbReference();
          ScriptLines = LoadScriptReference();
+         MetadataInfo = new MetadataInfo();
       }
 
       private IReadOnlyList<ScriptLine> LoadScriptReference() {
@@ -94,5 +97,18 @@ namespace HavenSoft.HexManiac.Core.Models {
       public int Address { get; }
       public string Format { get; }
       public ReferenceTable(string name, int address, string format) => (Name, Address, Format) = (name, address, format);
+   }
+
+   public interface IMetadataInfo {
+      string VersionNumber { get; }
+   }
+
+   internal class MetadataInfo : IMetadataInfo {
+      public string VersionNumber { get; }
+      public MetadataInfo() {
+         var assembly = Assembly.GetExecutingAssembly();
+         var fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
+         VersionNumber = $"{fvi.FileMajorPart}.{fvi.FileMinorPart}.{fvi.FileBuildPart}";
+      }
    }
 }

--- a/src/HexManiac.Core/ViewModels/EditorViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/EditorViewModel.cs
@@ -17,7 +17,6 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
       private const int MaxReasonableResults = 400; // limit for performance reasons
 
       private readonly IFileSystem fileSystem;
-      private readonly Singletons singletons = new Singletons();
       private readonly bool allowLoadingMetadata;
       private readonly List<ITabContent> tabs;
 
@@ -207,6 +206,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          // new MakeItemsExpandable(),
       }.Select(edit => new EditItemWrapper(edit)).ToList();
 
+      public Singletons Singletons { get; } = new Singletons();
+
       public event EventHandler<Action> RequestDelayedWork;
 
       public event EventHandler MoveFocusToFind;
@@ -313,9 +314,9 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
                   metadataText = fileSystem.MetadataFor(file.Name) ?? new string[0];
                }
                var metadata = new StoredMetadata(metadataText);
-               var viewPort = new ViewPort(file.Name, new HardcodeTablesModel(singletons, file.Contents, metadata), singletons);
+               var viewPort = new ViewPort(file.Name, new HardcodeTablesModel(Singletons, file.Contents, metadata), Singletons);
                if (metadata.IsEmpty) {
-                  var createdMetadata = viewPort.Model.ExportMetadata().Serialize();
+                  var createdMetadata = viewPort.Model.ExportMetadata(Singletons.MetadataInfo).Serialize();
                   fileSystem.SaveMetadata(file.Name, createdMetadata);
                }
                Add(viewPort);

--- a/src/HexManiac.Core/ViewModels/ViewPort.cs
+++ b/src/HexManiac.Core/ViewModels/ViewPort.cs
@@ -348,7 +348,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
             return;
          }
 
-         var metadata = Model.ExportMetadata();
+         var metadata = Model.ExportMetadata(Singletons.MetadataInfo);
          if (fileSystem.Save(new LoadedFile(FileName, Model.RawData))) {
             fileSystem.SaveMetadata(FileName, metadata?.Serialize());
             history.TagAsSaved();
@@ -360,7 +360,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          var newName = fileSystem.RequestNewName(FileName, "GameBoy Advanced", "gba");
          if (newName == null) return;
 
-         var metadata = Model.ExportMetadata();
+         var metadata = Model.ExportMetadata(Singletons.MetadataInfo);
          if (fileSystem.Save(new LoadedFile(newName, Model.RawData))) {
             FileName = newName; // don't bother notifying, because tagging the history will cause a notify;
             fileSystem.SaveMetadata(FileName, metadata?.Serialize());
@@ -371,7 +371,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
       private void CloseExecuted(IFileSystem fileSystem) {
          if (!history.IsSaved) {
-            var metadata = Model.ExportMetadata();
+            var metadata = Model.ExportMetadata(Singletons.MetadataInfo);
             var result = fileSystem.TrySavePrompt(new LoadedFile(FileName, Model.RawData));
             if (result == null) return;
             if (result == true) {

--- a/src/HexManiac.Tests/AutoSearchTests.cs
+++ b/src/HexManiac.Tests/AutoSearchTests.cs
@@ -634,7 +634,7 @@ namespace HavenSoft.HexManiac.Tests {
       public IDataModel LoadModelNoCache(string name) {
          Skip.IfNot(File.Exists(name));
          var template = modelCache[name];
-         var metadata = template.ExportMetadata();
+         var metadata = template.ExportMetadata(Singletons.MetadataInfo);
          var model = new PokemonModel(template.RawData.ToArray(), metadata);
          return model;
       }

--- a/src/HexManiac.Tests/GeneralAppTests.cs
+++ b/src/HexManiac.Tests/GeneralAppTests.cs
@@ -460,6 +460,31 @@ namespace HavenSoft.HexManiac.Tests {
          Assert.Equal(1, count);
       }
 
+      [Fact]
+      public void CanLoadVersionFromToml() {
+         var file = @"
+[General]
+ApplicationVersion = '''0.1.0'''
+";
+         var metadata = new StoredMetadata(file.Split(Environment.NewLine));
+         Assert.Equal("0.1.0", metadata.Version);
+      }
+
+      [Fact]
+      public void CanSaveVersionToToml() {
+         var metadata = new StoredMetadata(null, null, null, null, new StubMetadataInfo { VersionNumber = "0.1.0" });
+         var lines = metadata.Serialize();
+         Assert.Contains("[General]", lines);
+         Assert.Contains("ApplicationVersion = '''0.1.0'''", lines);
+      }
+
+      [Fact]
+      public void NullVersionIsNotSavedToToml() {
+         var metadata = new StoredMetadata(null, null, null, null, new StubMetadataInfo());
+         var lines = metadata.Serialize();
+         Assert.All(lines, line => Assert.DoesNotContain("ApplicationVersion = '''", line));
+      }
+
       private StubTabContent CreateClosableTab() {
          var tab = new StubTabContent();
          var close = new StubCommand { CanExecute = arg => true };

--- a/src/HexManiac.Tests/HexManiac.Tests.csproj
+++ b/src/HexManiac.Tests/HexManiac.Tests.csproj
@@ -66,6 +66,9 @@
     <Compile Include="..\..\artifacts\$(AssemblyName)\codegen\StubDataModel.cs">
       <Link>StubDataModel.cs</Link>
     </Compile>
+    <Compile Include="..\..\artifacts\HexManiac.Tests\codegen\StubMetadataInfo.cs">
+      <Link>StubMetadataInfo.cs</Link>
+    </Compile>
     <Compile Include="ArrayColumnHeaderTests.cs" />
     <Compile Include="ArrayRunTests.cs" />
     <Compile Include="AutoSearchTests.cs" />
@@ -123,11 +126,12 @@
     <PreBuildEvent>
 if not exist $(SolutionDir)artifacts\$(AssemblyName)\codegen mkdir $(SolutionDir)artifacts\$(AssemblyName)\codegen
 
-$(SolutionDir)packages\HavenSoft.AutoImplement.1.1.1\AutoImplement $(SolutionDir)artifacts\HexManiac.Core\bin\$(ConfigurationName)\HexManiac.Core.dll ITabContent IFileSystem IViewPort IDataModel
+$(SolutionDir)packages\HavenSoft.AutoImplement.1.1.1\AutoImplement $(SolutionDir)artifacts\HexManiac.Core\bin\$(ConfigurationName)\HexManiac.Core.dll ITabContent IFileSystem IViewPort IDataModel IMetadataInfo
 move /Y StubTabContent.cs $(SolutionDir)artifacts\$(AssemblyName)\codegen
 move /Y StubFileSystem.cs $(SolutionDir)artifacts\$(AssemblyName)\codegen
 move /Y StubViewPort.cs $(SolutionDir)artifacts\$(AssemblyName)\codegen
 move /Y StubDataModel.cs $(SolutionDir)artifacts\$(AssemblyName)\codegen
+move /Y StubMetadataInfo.cs $(SolutionDir)artifacts\$(AssemblyName)\codegen
 
 del *.cs</PreBuildEvent>
     <PostBuildEvent>

--- a/src/HexManiac.Tests/ViewPortSaveTests.cs
+++ b/src/HexManiac.Tests/ViewPortSaveTests.cs
@@ -360,7 +360,7 @@ namespace HavenSoft.HexManiac.Tests {
          change.AddMatchedWord(model, 0, "table");
          model.ObserveRunWritten(change, new WordRun(0, "table"));
 
-         fileSystem.MetadataFor = name => model.ExportMetadata().Serialize();
+         fileSystem.MetadataFor = name => model.ExportMetadata(BaseViewModelTestClass.Singletons.MetadataInfo).Serialize();
          fileSystem.OpenFile = (name, extensions) => new LoadedFile(name, data);
          var editor = new EditorViewModel(fileSystem);
 

--- a/src/HexManiac.WPF/Windows/AboutWindow.xaml.cs
+++ b/src/HexManiac.WPF/Windows/AboutWindow.xaml.cs
@@ -1,15 +1,12 @@
-﻿using System.Diagnostics;
-using System.Reflection;
+﻿using HavenSoft.HexManiac.Core.Models;
+using System.Diagnostics;
 using System.Windows.Navigation;
 
 namespace HavenSoft.HexManiac.WPF.Windows {
    partial class AboutWindow {
-      public AboutWindow() {
+      public AboutWindow(IMetadataInfo metadata) {
          InitializeComponent();
-
-         var assembly = Assembly.GetExecutingAssembly();
-         var fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
-         Version.Text = $"Version {fvi.FileMajorPart}.{fvi.FileMinorPart}.{fvi.FileBuildPart}";
+         Version.Text = $"Version {metadata.VersionNumber}";
       }
 
       private void Navigate(object sender, RequestNavigateEventArgs e) {

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using HavenSoft.HexManiac.Core;
 using HavenSoft.HexManiac.Core.Models;
 using HavenSoft.HexManiac.Core.ViewModels;
-using HavenSoft.HexManiac.Core.ViewModels.Tools;
 using HavenSoft.HexManiac.WPF.Controls;
 using HavenSoft.HexManiac.WPF.Implementations;
 using System;
@@ -12,7 +11,6 @@ using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
 using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -226,7 +224,7 @@ namespace HavenSoft.HexManiac.WPF.Windows {
 
       private void WikiClick(object sender, EventArgs e) => System.Diagnostics.Process.Start("https://github.com/haven1433/HexManiacAdvance/wiki");
       private void ReportIssueClick(object sender, EventArgs e) => System.Diagnostics.Process.Start("https://github.com/haven1433/HexManiacAdvance/issues");
-      private void AboutClick(object sender, EventArgs e) => new AboutWindow().ShowDialog();
+      private void AboutClick(object sender, EventArgs e) => new AboutWindow(ViewModel.Singletons.MetadataInfo).ShowDialog();
 
       private void EditBoxVisibilityChanged(object sender, DependencyPropertyChangedEventArgs e) {
          var box = (TextBox)sender;


### PR DESCRIPTION
This allows us to detect what version of the app was used to last save changes to this file, which lets us detect when the user has upgraded HMA and is now using it on a file last touched with an older version.

For example, we could notice that there were new auto-tables added since the last version, and the user might want us to add them.