### PR TITLE
De-emphasize fields named "unused" or "padding"

### DIFF
--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -400,6 +400,10 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
       }
    }
 
+   public class ArrayRunUnusedSegment : ArrayRunElementSegment {
+      public ArrayRunUnusedSegment(string name, int length) : base(name, ElementContentType.Integer, length) { }
+   }
+
    public class ArrayRunTupleSegment : ArrayRunHexSegment {
       public IReadOnlyList<TupleSegment> Elements { get; }
       public int VisibleElementCount => Elements.Count - Elements.Count(e => string.IsNullOrEmpty(e.Name));

--- a/src/HexManiac.Core/ViewModels/ConvertCellToText.cs
+++ b/src/HexManiac.Core/ViewModels/ConvertCellToText.cs
@@ -51,6 +51,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
 
       public void Visit(IntegerHex integerHex, byte data) => Result = integerHex.ToString();
 
+      public void Visit(IntegerUnused integerUnused, byte data) => Result = integerUnused.Value.ToString();
+
       public void Visit(EggSection section, byte data) => Result = section.SectionName;
 
       public void Visit(EggItem item, byte data) => Result = item.ItemName;

--- a/src/HexManiac.Core/ViewModels/DataFormats.cs
+++ b/src/HexManiac.Core/ViewModels/DataFormats.cs
@@ -40,6 +40,7 @@ namespace HavenSoft.HexManiac.Core.ViewModels.DataFormats {
       void Visit(Integer integer, byte data);
       void Visit(IntegerEnum integer, byte data);
       void Visit(IntegerHex integer, byte data);
+      void Visit(IntegerUnused integer, byte data);
       void Visit(EggSection section, byte data);
       void Visit(EggItem item, byte data);
       void Visit(PlmItem item, byte data);
@@ -353,6 +354,17 @@ namespace HavenSoft.HexManiac.Core.ViewModels.DataFormats {
          var format = "X" + (Length * 2);
          return Value.ToString(format);
       }
+   }
+
+   public class IntegerUnused : Integer {
+      public IntegerUnused(int source, int position, int value, int length) : base(source, position, value, length) { }
+
+      public override bool Equals(IDataFormat other) {
+         if (!(other is IntegerUnused)) return false;
+         return base.Equals(other);
+      }
+
+      public override string ToString() => Value.ToString();
    }
 
    public class Tuple : IDataFormatInstance {

--- a/src/HexManiac.Core/ViewModels/Visitors/AutocompleteCell.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/AutocompleteCell.cs
@@ -53,6 +53,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
 
       public void Visit(IntegerHex integer, byte data) { }
 
+      public void Visit(IntegerUnused integer, byte data) { }
+
       public void Visit(EggSection section, byte data) => VisitEgg(section);
 
       public void Visit(EggItem item, byte data) => VisitEgg(item);

--- a/src/HexManiac.Core/ViewModels/Visitors/CompleteCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/CompleteCellEdit.cs
@@ -165,6 +165,13 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          }
       }
 
+      public void Visit(IntegerUnused integerUnused, byte data) {
+         if (char.IsWhiteSpace(CurrentText.Last()) || CurrentText.Last() == ')') {
+            CompleteIntegerEdit(integerUnused);
+            Result = true;
+         }
+      }
+
       public void Visit(EggSection section, byte data) => CompleteEggEdit();
 
       public void Visit(EggItem item, byte data) => CompleteEggEdit();

--- a/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/ContextItemFactory.cs
@@ -211,6 +211,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
 
       public void Visit(IntegerHex integerHex, byte data) => Results.AddRange(GetTableChildren());
 
+      public void Visit(IntegerUnused integer, byte data) => Results.AddRange(GetTableChildren());
+
       public void Visit(EggSection section, byte data) => Visit((EggItem)null, data);
 
       public void Visit(EggItem item, byte data) {

--- a/src/HexManiac.Core/ViewModels/Visitors/ContinueCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/ContinueCellEdit.cs
@@ -101,6 +101,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
 
       public void Visit(IntegerHex integerHex, byte data) => Visit((Integer)integerHex, data);
 
+      public void Visit(IntegerUnused integerUnused, byte data) => Visit((Integer)integerUnused, data);
+
       public void Visit(EggSection section, byte data) => VisitEgg();
       public void Visit(EggItem item, byte data) => VisitEgg();
       public void VisitEgg() {

--- a/src/HexManiac.Core/ViewModels/Visitors/DataClear.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/DataClear.cs
@@ -52,6 +52,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
 
       public void Visit(IntegerHex integerHex, byte data) => buffer.WriteMultiByteValue(index, integerHex.Length, currentChange, 0);
 
+      public void Visit(IntegerUnused integerUnused, byte data) => buffer.WriteMultiByteValue(index, integerUnused.Length, currentChange, 0);
+
       public void Visit(EggSection section, byte data) => buffer.WriteMultiByteValue(index, 2, currentChange, EggMoveRun.MagicNumber);
 
       public void Visit(EggItem item, byte data) => buffer.WriteMultiByteValue(index, 2, currentChange, 0x0000);

--- a/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/StartCellEdit.cs
@@ -179,6 +179,13 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
          Result = true;
       }
 
+      public void Visit(IntegerUnused integerUnused, byte data) {
+         if (!integerUnused.CanStartWithCharacter(Input)) return;
+
+         NewFormat = new UnderEdit(integerUnused, Input.ToString(), integerUnused.Length, null);
+         Result = true;
+      }
+
       public void Visit(EggSection section, byte data) => VisitEgg(section);
 
       public void Visit(EggItem item, byte data) => VisitEgg(item);

--- a/src/HexManiac.Core/ViewModels/Visitors/ToolTipContentVisitor.cs
+++ b/src/HexManiac.Core/ViewModels/Visitors/ToolTipContentVisitor.cs
@@ -92,6 +92,8 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Visitors {
 
       public void Visit(IntegerHex integer, byte data) { }
 
+      public void Visit(IntegerUnused integer, byte data) { }
+
       public void Visit(EggSection section, byte data) { }
 
       public void Visit(EggItem item, byte data) { }

--- a/src/HexManiac.Tests/StreamTests.cs
+++ b/src/HexManiac.Tests/StreamTests.cs
@@ -349,7 +349,7 @@ namespace HavenSoft.HexManiac.Tests {
 
       [Fact]
       public void SingleElementStreamRunWithTuple_Serialize_TupleAppearsAsTuple() {
-         var stream = new TableStreamRun(Model, 0, SortedSpan<int>.None, "[index::|t|:.|i::::::. unknown:|h unused:|h]", null, new FixedLengthStreamStrategy(1));
+         var stream = new TableStreamRun(Model, 0, SortedSpan<int>.None, "[index::|t|:.|i::::::. unknown:|h unused:]", null, new FixedLengthStreamStrategy(1));
 
          var lines = stream.SerializeRun().SplitLines();
 
@@ -357,7 +357,7 @@ namespace HavenSoft.HexManiac.Tests {
          lines = tokenLines.Select(tokens => " ".Join(tokens)).ToArray();
          Assert.Equal("index: (0)", lines[0]);
          Assert.Equal("unknown: 0x0000", lines[1]);
-         Assert.Equal("unused: 0x0000", lines[2]);
+         Assert.Equal("unused: 0", lines[2]);
       }
 
       [Fact]

--- a/src/HexManiac.WPF/Implementations/FormatDrawer.cs
+++ b/src/HexManiac.WPF/Implementations/FormatDrawer.cs
@@ -76,6 +76,7 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
          collector.Initialize<EggItem>(typeface, fontSize * .75);
          collector.Initialize<IntegerEnum>(typeface, fontSize * .75);
          collector.Initialize<IntegerHex>(typeface, fontSize);
+         collector.Initialize<IntegerUnused>(typeface, fontSize);
          collector.Initialize<Integer>(typeface, fontSize);
          collector.Initialize<BitArray>(typeface, fontSize);
          collector.Initialize<MatchedWord>(typeface, fontSize * .75);
@@ -110,6 +111,8 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
                collector.Collect<IntegerEnum>(format, x, intEnum.Length, intEnum.DisplayValue);
             } else if (format is IntegerHex integerHex) {
                collector.Collect<IntegerHex>(format, x, integerHex.Length, integerHex.ToString());
+            } else if (format is IntegerUnused integerUnused) {
+               collector.Collect<IntegerUnused>(format, x, integerUnused.Length, integerUnused.ToString());
             } else if (format is Integer integer) {
                collector.Collect<Integer>(format, x, integer.Length, integer.Value.ToString());
             } else if (format is Ascii asc) {
@@ -158,6 +161,7 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
          collector.Render<EggSection>(context, Brush(nameof(Theme.Stream1)));
          collector.Render<IntegerEnum>(context, Brush(nameof(Theme.Data2)));
          collector.Render<IntegerHex>(context, Brush(nameof(Theme.Data2)));
+         collector.Render<IntegerUnused>(context, Brush(nameof(Theme.Secondary)));
          collector.Render<Integer>(context, Brush(nameof(Theme.Data1)));
          collector.Render<Ascii>(context, Brush(nameof(Theme.Text2)));
          collector.Render<None>(context, Brush(nameof(Theme.Primary)));
@@ -262,6 +266,8 @@ namespace HavenSoft.HexManiac.WPF.Implementations {
       public void Visit(IntegerEnum integerEnum, byte data) { }
 
       public void Visit(IntegerHex integerHex, byte data) { }
+
+      public void Visit(IntegerUnused integerUnused, byte data) { }
 
       public void Visit(EggSection section, byte data) { }
 


### PR DESCRIPTION
Fields named "unused" or "padding" will be displayed with a muted gray, similar to `00` and `FF` outside of tables.