### PR TITLE
Fixing some parameter formats in the script reference file.

### DIFF
--- a/src/HexManiac.Core/Models/Code/constantReference.txt
+++ b/src/HexManiac.Core/Models/Code/constantReference.txt
@@ -388,3 +388,10 @@ BPRE0.data.abilities.pickup.length-2 02CEEC
 BPGE0.data.abilities.pickup.length-2 02CEEC
 BPRE1.data.abilities.pickup.length-2 02CF00
 BPGE1.data.abilities.pickup.length-2 02CF00
+
+# maximum flash level
+BPEE0.scripts.moves.flash.maxlevel-1 0854E8
+BPRE0.scripts.moves.flash.maxlevel-1 055D04
+BPGE0.scripts.moves.flash.maxlevel-1 055D04
+AXVE0.scripts.moves.flash.maxlevel-1 053CE0
+AXPE0.scripts.moves.flash.maxlevel-1 053CE0

--- a/src/HexManiac.Core/Models/Code/constantReference.txt
+++ b/src/HexManiac.Core/Models/Code/constantReference.txt
@@ -390,8 +390,12 @@ BPRE1.data.abilities.pickup.length-2 02CF00
 BPGE1.data.abilities.pickup.length-2 02CF00
 
 # maximum flash level
-BPEE0.scripts.moves.flash.maxlevel-1 0854E8
-BPRE0.scripts.moves.flash.maxlevel-1 055D04
-BPGE0.scripts.moves.flash.maxlevel-1 055D04
-AXVE0.scripts.moves.flash.maxlevel-1 053CE0
-AXPE0.scripts.moves.flash.maxlevel-1 053CE0
+BPEE0.scripts.moves.flash.maxlevel-1 54FE78
+AXVE0.scripts.moves.flash.maxlevel-1 39ACE8
+AXPE0.scripts.moves.flash.maxlevel-1 39AB30
+AXVE1.scripts.moves.flash.maxlevel-1 39AD00
+AXPE1.scripts.moves.flash.maxlevel-1 39AB48
+BPRE0.scripts.moves.flash.maxlevel-1 3C68E0
+BPGE0.scripts.moves.flash.maxlevel-1 3C671C
+BPRE1.scripts.moves.flash.maxlevel-1 3C6950
+BPGE1.scripts.moves.flash.maxlevel-1 3C678C

--- a/src/HexManiac.Core/Models/Code/scriptReference.txt
+++ b/src/HexManiac.Core/Models/Code/scriptReference.txt
@@ -53,13 +53,13 @@ if.flagset       2B flag:|h 06 01 pointer<`xse`>
 0C jumpram                                      # executes a script from the default RAM location (???)
 0D killscript                                   # kill the script, reset script RAM
 0E setbyte byte.                                # sets a predefined address to the specified byte value
-0F loadpointer bank.4 pointer<"">               # loads a pointer into script RAM so other commands can use it
+0F loadpointer bank.4 pointer<>                 # loads a pointer into script RAM so other commands can use it
 10 setbyte2 bank.4 value.                       # sets a memory bank to the specified byte value.
-11 writebytetooffset value. offset<>            # store the byte 'value' at the RAM address 'offset'
-12 loadbytefrompointer bank.4 pointer<>         # load a byte value from a RAM address into the specified memory bank
-13 setfarbyte bank.4 pointer<>                  # stores the least-significant byte in the bank to a RAM address
+11 writebytetooffset value. offset::|h          # store the byte 'value' at the RAM address 'offset'
+12 loadbytefrompointer bank.4 pointer::|h       # load a byte value from a RAM address into the specified memory bank
+13 setfarbyte bank.4 pointer::|h                # stores the least-significant byte in the bank to a RAM address
 14 copyscriptbanks destination.4 source.4       # copies the value in source to destination
-15 copybyte destination<> source<>              # copies the value from the source RAM address to the destination RAM address
+15 copybyte destination::|h source::|h          # copies the value from the source RAM address to the destination RAM address
 16 setvar variable: value:                      # sets the given variable to the given value
 17 addvar variable: value:                      # variable += value
 18 subvar variable: value:                      # variable -= value
@@ -68,14 +68,14 @@ if.flagset       2B flag:|h 06 01 pointer<`xse`>
                                                 # (if source isn't a valid variable, it's read as a value)
 1B comparebanks bankA.4 bankB.4                 # sets the condition variable based on the values in the two banks
 1C comparebanktobyte bank.4 value.              # sets the condition variable
-1D compareBankTofarbyte bank.4 pointer<>        # compares the bank value to the value stored in the RAM address
-1E compareFarByteToBank pointer<> bank.4        # opposite of 1D
-1F compareFarByteToByte pointer<> value.        # compares the value at the RAM address to the value
+1D compareBankTofarbyte bank.4 pointer::|h      # compares the bank value to the value stored in the RAM address
+1E compareFarByteToBank pointer::|h bank.4      # opposite of 1D
+1F compareFarByteToByte pointer::|h value.      # compares the value at the RAM address to the value
 20 compareFarBytes a<> b<>                      # compares the two values at the two RAM addresses
 21 compare variable: value:
 22 comparevars var1: var2:
 23 callasm code<>
-24 setcode pointer<>                                    # puts a pointer to some assembly code at a specific place in RAM
+24 setcode pointer::|h                                  # puts a pointer to some assembly code at a specific place in RAM
 
 25 special function:specials                            # calls a piece of ASM code from a table
 26 special2 variable: function:specials                 # calls a special and puts the ASM's return value in the variable you listed

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -198,7 +198,7 @@ data.pokemon.moves.tutorcompatibility,       ,       ,       ,       , 120C30, 1
 data.pokemon.moves.tms,                06F038, 06F03C, 06F058, 06F05C, 125A8C, 125A64, 125B04, 125ADC, 1B6D10, [move:data.pokemon.moves.names]58
 data.pokemon.moves.tmcompatibility,    0403B0, 0403B0, 0403D0, 0403D0, 043C68, 043C68, 043C7C, 043C7C, 06E048, [moves|b[]data.pokemon.moves.tms]data.pokemon.names
 data.pokemon.moves.hms,                040A24, 040A24, 040A44, 040A44, 0441DC, 0441DC, 0441F0, 0441F0, 06E828, [move:data.pokemon.moves.names]8
-data.pokemon.moves.details.flash.radius,       0815DC, 0815DC, 0815FC, 0815FC, 07F070, 07F080, 07F084, 07F058, 0B00E4, [max: current:]1
+data.pokemon.moves.details.flash.radius,       0815DC, 0815DC, 0815FC, 0815FC, 07F070, 07F080, 07F084, 07F058, 0B00E4, [current:]scripts.moves.flash.maxlevel
 data.pokemon.moves.details.lowkick.power,      02AA50, 02AA50, 02AA50, 02AA50, 02C930, 02C930, 02C944, 02C944, 0556E8, [weight: basePower:]!FFFFFFFF
 data.pokemon.moves.details.singing,            075890, 075894, 0758B0, 0758B4, 0726E8, 0726E8, 0726FC, 0726FC, 0A3BA4, [move:data.pokemon.moves.names]!FFFF
 data.pokemon.moves.details.fallback.names,     120E1C, 120E1C, 120E3C, 120E3C, 0D7624, 0D75F8, 0D7638, 0D760C,       , [name<"">]data.pokemon.type.names

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -198,7 +198,7 @@ data.pokemon.moves.tutorcompatibility,       ,       ,       ,       , 120C30, 1
 data.pokemon.moves.tms,                06F038, 06F03C, 06F058, 06F05C, 125A8C, 125A64, 125B04, 125ADC, 1B6D10, [move:data.pokemon.moves.names]58
 data.pokemon.moves.tmcompatibility,    0403B0, 0403B0, 0403D0, 0403D0, 043C68, 043C68, 043C7C, 043C7C, 06E048, [moves|b[]data.pokemon.moves.tms]data.pokemon.names
 data.pokemon.moves.hms,                040A24, 040A24, 040A44, 040A44, 0441DC, 0441DC, 0441F0, 0441F0, 06E828, [move:data.pokemon.moves.names]8
-data.pokemon.moves.details.flash.radius,       0815DC, 0815DC, 0815FC, 0815FC, 07F070, 07F080, 07F084, 07F058, 0B00E4, [current:]scripts.moves.flash.maxlevel
+data.pokemon.moves.details.flash.radius,       0815DC, 0815DC, 0815FC, 0815FC, 07F070, 07F080, 07F084, 07F058, 0B00E4, [levelToRadius:]scripts.moves.flash.maxlevel
 data.pokemon.moves.details.lowkick.power,      02AA50, 02AA50, 02AA50, 02AA50, 02C930, 02C930, 02C944, 02C944, 0556E8, [weight: basePower:]!FFFFFFFF
 data.pokemon.moves.details.singing,            075890, 075894, 0758B0, 0758B4, 0726E8, 0726E8, 0726FC, 0726FC, 0A3BA4, [move:data.pokemon.moves.names]!FFFF
 data.pokemon.moves.details.fallback.names,     120E1C, 120E1C, 120E3C, 120E3C, 0D7624, 0D75F8, 0D7638, 0D760C,       , [name<"">]data.pokemon.type.names


### PR DESCRIPTION
There were  a few other commands that needed RAM-address parameters set to their correct format so that typing "2024284" doesn't auto format to 0xA024284, etc.