### PR TITLE
Fixing some parameter formats in the script reference file. (Attempt 2)

### DIFF
--- a/src/HexManiac.Core/Models/Code/scriptReference.txt
+++ b/src/HexManiac.Core/Models/Code/scriptReference.txt
@@ -76,10 +76,10 @@ if.trainer.ready.call    60 trainer:data.trainers.stats 07 00 pointer<`xse`>
                                                 # (if source isn't a valid variable, it's read as a value)
 1B comparebanks bankA.4 bankB.4                 # sets the condition variable based on the values in the two banks
 1C comparebanktobyte bank.4 value.              # sets the condition variable
-1D compareBankTofarbyte bank.4 pointer<>        # compares the bank value to the value stored in the RAM address
-1E compareFarByteToBank pointer<> bank.4        # opposite of 1D
-1F compareFarByteToByte pointer<> value.        # compares the value at the RAM address to the value
-20 compareFarBytes a<> b<>                      # compares the two values at the two RAM addresses
+1D compareBankTofarbyte bank.4 pointer::|h      # compares the bank value to the value stored in the RAM address
+1E compareFarByteToBank pointer::|h bank.4      # opposite of 1D
+1F compareFarByteToByte pointer::|h value.      # compares the value at the RAM address to the value
+20 compareFarBytes a::|h b::|h                  # compares the two values at the two RAM addresses
 21 compare variable: value:
 22 comparevars var1: var2:
 23 callasm code<>
@@ -97,7 +97,7 @@ if.trainer.ready.call    60 trainer:data.trainers.stats 07 00 pointer<`xse`>
 [AXPE_AXVE_BPEE] 2C initclock hour: minute:
 2D checkdailyflags                           # nop in firered. Does some flag checking in R/S/E based on real-time-clock
 2E resetvars                                 # sets x8000, x8001, and x8002 to 0
-2F sound number:                             # 0000 mutes the music
+2F sound number:songnames                    # 0000 mutes the music
 30 waitsound                                 # blocks script execution until any playing sounds finish
 31 fanfare song:songnames                    # plays a song from the song list as a fanfare
 32 waitfanfare                               # blocks script execution until any playing fanfair finishes


### PR DESCRIPTION
Hopefully this works unlike the previous pull request.

There were a few other commands that needed RAM-address parameters set to their correct format so that typing "2024284" doesn't auto format to 0xA024284, etc. I also put "songnames" in the parameter for the "sound" command.