### PR TITLE
Changing the Default Moves & Default Items buttons' hover texts.

### DIFF
--- a/src/HexManiac.WPF/Controls/TabView.xaml
+++ b/src/HexManiac.WPF/Controls/TabView.xaml
@@ -589,8 +589,20 @@
                                                 <hsg3hv:AutocompleteOverlay Target="{Binding ElementName=StreamTextBox}"/>
                                              </Grid>
                                              <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,2,0,0">
-                                                <hsg3hv:AngleButton Command="{Binding SetDefaultMoves}" Margin="0,0,4,0" Content="Default Moves" Direction="Out"/>
-                                                <hsg3hv:AngleButton Command="{Binding SetDefaultItems}" Content="Default Items" Direction="Out"/>
+                                                <hsg3hv:AngleButton Command="{Binding SetDefaultMoves}" Margin="0,0,4,0" Content="Default Moves" Direction="Out">
+												<hsg3hv:AngleButton.ToolTip>
+                                                   <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{DynamicResource Accent}" BorderThickness="1">
+                                                      <TextBlock TextAlignment="Left" Text="Sets all Pokémon's movesets to<LineBreak/>the last 4 level-up moves." />
+                                                   </ToolTip>
+                                                </hsg3hv:AngleButton.ToolTip>
+												</hsg3hv:AngleButton>
+                                                <hsg3hv:AngleButton Command="{Binding SetDefaultItems}" Content="Default Items" Direction="Out">
+												<hsg3hv:AngleButton.ToolTip>
+                                                   <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{DynamicResource Accent}" BorderThickness="1">
+                                                      <TextBlock TextAlignment="Left" Text="Removes all Pokémon's held items." />
+                                                   </ToolTip>
+                                                </hsg3hv:AngleButton.ToolTip>
+												</hsg3hv:AngleButton>
                                              </StackPanel>
                                           </StackPanel>
                                        </DataTemplate>

--- a/src/HexManiac.WPF/Controls/TabView.xaml
+++ b/src/HexManiac.WPF/Controls/TabView.xaml
@@ -592,7 +592,9 @@
                                                 <hsg3hv:AngleButton Command="{Binding SetDefaultMoves}" Margin="0,0,4,0" Content="Default Moves" Direction="Out">
 												<hsg3hv:AngleButton.ToolTip>
                                                    <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{DynamicResource Accent}" BorderThickness="1">
-                                                      <TextBlock TextAlignment="Left" Text="Sets all Pokémon's movesets to<LineBreak/>the last 4 level-up moves." />
+                                                         <TextBlock TextAlignment="Left">
+                                                            Sets all Pokémon's movesets to<LineBreak />the last 4 level-up moves.
+                                                         </TextBlock>
                                                    </ToolTip>
                                                 </hsg3hv:AngleButton.ToolTip>
 												</hsg3hv:AngleButton>

--- a/src/HexManiac.WPF/Controls/TabView.xaml
+++ b/src/HexManiac.WPF/Controls/TabView.xaml
@@ -590,21 +590,21 @@
                                              </Grid>
                                              <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,2,0,0">
                                                 <hsg3hv:AngleButton Command="{Binding SetDefaultMoves}" Margin="0,0,4,0" Content="Default Moves" Direction="Out">
-												<hsg3hv:AngleButton.ToolTip>
-                                                   <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{DynamicResource Accent}" BorderThickness="1">
+                                                   <hsg3hv:AngleButton.ToolTip>
+                                                      <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{DynamicResource Accent}" BorderThickness="1">
                                                          <TextBlock TextAlignment="Left">
                                                             Sets all Pokémon's movesets to<LineBreak />the last 4 level-up moves.
                                                          </TextBlock>
-                                                   </ToolTip>
-                                                </hsg3hv:AngleButton.ToolTip>
-												</hsg3hv:AngleButton>
+                                                      </ToolTip>
+                                                   </hsg3hv:AngleButton.ToolTip>
+                                                </hsg3hv:AngleButton>
                                                 <hsg3hv:AngleButton Command="{Binding SetDefaultItems}" Content="Default Items" Direction="Out">
-												<hsg3hv:AngleButton.ToolTip>
-                                                   <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{DynamicResource Accent}" BorderThickness="1">
-                                                      <TextBlock TextAlignment="Left" Text="Removes all Pokémon's held items." />
-                                                   </ToolTip>
-                                                </hsg3hv:AngleButton.ToolTip>
-												</hsg3hv:AngleButton>
+                                                   <hsg3hv:AngleButton.ToolTip>
+                                                      <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{DynamicResource Accent}" BorderThickness="1">
+                                                         <TextBlock TextAlignment="Left" Text="Removes all Pokémon's held items." />
+                                                      </ToolTip>
+                                                   </hsg3hv:AngleButton.ToolTip>
+                                                </hsg3hv:AngleButton>
                                              </StackPanel>
                                           </StackPanel>
                                        </DataTemplate>

--- a/src/HexManiac.WPF/Controls/TabView.xaml
+++ b/src/HexManiac.WPF/Controls/TabView.xaml
@@ -601,7 +601,7 @@
                                                 <hsg3hv:AngleButton Command="{Binding SetDefaultItems}" Content="Default Items" Direction="Out">
                                                    <hsg3hv:AngleButton.ToolTip>
                                                       <ToolTip Background="{DynamicResource Backlight}" BorderBrush="{DynamicResource Accent}" BorderThickness="1">
-                                                         <TextBlock TextAlignment="Left" Text="Removes all Pokémon's held items." />
+                                                         <TextBlock TextAlignment="Left" Text="Removes all Pokémon's custom held items." />
                                                       </ToolTip>
                                                    </hsg3hv:AngleButton.ToolTip>
                                                 </hsg3hv:AngleButton>


### PR DESCRIPTION
Instead of saying "pokemon," each button now has a hover tip that elaborates on the functionality of each button.

_(Feature Request by haven)_