### PR TITLE
Updated the move field for 2 commands

### DIFF
--- a/src/HexManiac.Core/Models/Code/scriptReference.txt
+++ b/src/HexManiac.Core/Models/Code/scriptReference.txt
@@ -204,7 +204,7 @@ if.trainer.ready.call    60 trainer:data.trainers.stats 07 00 pointer<`xse`>
 7A giveEgg species:
 7B setmonmove pokemonSlot. attackSlot. newMove:data.pokemon.moves.names  # set a given pokemon in your party to have a specific move.
                                              # Slots range 0-4 and 0-3.
-7C checkattack move:                         # 800D=n, where n is the index of the pokemon that knows the move.
+7C checkattack move:data.pokemon.moves.names # 800D=n, where n is the index of the pokemon that knows the move.
                                              # 800D=6, if no pokemon in your party knows the move
                                              # if successful, 8004 is set to the pokemon species
 7D bufferPokemon buffer.3 species:data.pokemon.names  # species can be a literal or variable. Store the name in the given buffer
@@ -212,7 +212,7 @@ if.trainer.ready.call    60 trainer:data.trainers.stats 07 00 pointer<`xse`>
 7F bufferpartyPokemon buffer.3 party:        # name of pokemon 'party' from your party gets stored in the buffer
 80 bufferitem buffer.3 item:data.items.stats # stores an item name in a buffer
 81 bufferdecoration buffer.3 decoration:
-82 bufferattack buffer.3 move:               # species, party, item, decoration, and move can all be literals or variables
+82 bufferattack buffer.3 move:data.pokemon.moves.names    # species, party, item, decoration, and move can all be literals or variables
 83 buffernumber buffer.3 number:             # literal or variable gets converted to a string and put in the buffer.
 84 bufferstd buffer.3 index:                 # gets one of the standard strings and pushes it into a buffer
 85 bufferstring buffer.3 pointer<>           # copies the string into the buffer.


### PR DESCRIPTION
You can use move names for the move field in both 'bufferattack' and 'checkattack' now.