### PR TITLE
Fixed numbers misplacement for OW Table Constant

### DIFF
--- a/src/HexManiac.Core/Models/Code/constantReference.txt
+++ b/src/HexManiac.Core/Models/Code/constantReference.txt
@@ -401,7 +401,7 @@ BPRE1.scripts.moves.flash.maxlevel-1 3C6950
 BPGE1.scripts.moves.flash.maxlevel-1 3C678C
 
 # overworld table limiters (credit to phoenixbound)
-BPRE0.graphics.overworld.tablelength-1 052FE0
+BPRE0.graphics.overworld.tablelength-1 05F2E0
 BPRE1.graphics.overworld.tablelength-1 05F2F4
-BPGE0.graphics.overworld.tablelength-1 052FE0
+BPGE0.graphics.overworld.tablelength-1 05F2E0
 BPGE1.graphics.overworld.tablelength-1 05F2F4


### PR DESCRIPTION
It's "5F2E0," not "52FE0!"