### PR TITLE
Song table formatting updates

### DIFF
--- a/src/HexManiac.Core/Models/Code/default.toml
+++ b/src/HexManiac.Core/Models/Code/default.toml
@@ -1105,10 +1105,10 @@ Name = '''directions'''
 4 = '''East'''
 4 = '''Right'''
 5 = [
-'''Southwest''',
-'''Southeast''',
-'''Northwest''',
-'''Northeast''',
+   '''Southwest''',
+   '''Southeast''',
+   '''Northwest''',
+   '''Northeast''',
 ]
 
 [[List]]
@@ -1128,3 +1128,15 @@ Name = '''AI_type_matchups'''
 40 = '''Neutral'''
 80 = '''SuperEffective'''
 160 = '''DoubleSuperEffective'''
+
+[[List]]
+Name = '''voiceGroupTypes'''
+0 = [
+   '''DirectSound''',
+   '''SquareWave1''',
+   '''SquareWave2''',
+   '''WaveMemory''',
+   '''Noise''',
+]
+64 = '''MultiSample'''
+128 = '''DrumPart'''

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -797,7 +797,7 @@ data.text.menu.itemStorage,            139FAC, 139FAC, 139FCC, 139FCC, 0EBA84, 0
 sound.fanfares,                        074E64, 074E68, 074E84, 074E88,                            ,,,,       , [songID:          duration:]12
 sound.fanfares,                                                   ,,,, 071C08, 071C08, 071C1C, 071C1C,       , [songID:songnames duration:]14
 sound.fanfares,                                                   ,,,,                            ,,,, 0A308C, [songID:songnames duration:]18
-sound.tracks,                          1DDF20, 1DDEB0, 1DDF38, 1DDEC8, 1DD11C, 1DD0F8, 1DD18C, 1DD168, 2E0158, [pointer<> musicplayer: unknown:]songnames
+sound.tracks,                          1DDF20, 1DDEB0, 1DDF38, 1DDEC8, 1DD11C, 1DD0F8, 1DD18C, 1DD168, 2E0158, [header<[numTracks. numBlocks. priority. reverb. voicegroup<>]1> musicplayer: unknown:]songnames
 sound.musicplayer,                                                ,,,,                            ,,,, 2E010C, [info::|h track::|h num: unknown:]4
 sound.pokemon.cry.growl,               0752D8, 0752DC, 0752F8, 0752FC, 072104, 072104, 072118, 072118, 0A35DC, ^[type.|h key. length. pan_sweep. p<> attack. decay. sustain. release.]data.pokemon.names-24
 sound.pokemon.cry.normal,              0752E8, 0752EC, 075308, 07530C, 072114, 072114, 072128, 072128, 0A35EC, ^[type.|h key. length. pan_sweep. p<> attack. decay. sustain. release.]data.pokemon.names-24


### PR DESCRIPTION
I know this is on the red list, but I feel like each entry in the song table can have some more formatting to it. The challenge is making a new type of formatting (like \`tpt`) that adjusts the number of pointers to interpret based on the value of 'numTracks.' I feel like that could be prone to bugs, however.

No need to rush this one; it's a minor feature request that's not easy to implement.