### PR TITLE
More scriptReference.txt changes

### DIFF
--- a/src/HexManiac.Core/Models/Code/default.toml
+++ b/src/HexManiac.Core/Models/Code/default.toml
@@ -1130,6 +1130,15 @@ Name = '''AI_type_matchups'''
 160 = '''DoubleSuperEffective'''
 
 [[List]]
+Name = '''screenfades'''
+0 = [
+   '''FromBlack''',
+   '''ToBlack''',
+   '''FromWhite''',
+   '''ToWhite''',
+]
+
+[[List]]
 Name = '''move_particles'''
 0 = '''NotSet'''
 10000 = [

--- a/src/HexManiac.Core/Models/Code/scriptReference.txt
+++ b/src/HexManiac.Core/Models/Code/scriptReference.txt
@@ -130,8 +130,8 @@ if.trainer.ready.call    60 trainer:data.trainers.stats 07 00 pointer<`xse`>
 4B adddecoration decoration:data.decorations.stats                 # adds a decoration to the player's PC in FR/LG, this is a NOP
                                                                    # decoration can be either a literal or a variable
 4C removedecoration decoration:data.decorations.stats              # removes a decoration to the player's PC in FR/LG, this is a NOP
-4D testdecoration decoration:data.decorations.stats                # 800D is set to 1 if the PC could store at least 1 more of that decoration
-4E checkdecoration decoration:data.decorations.stats               # 800D is set to 1 if the PC has at least 1 of that decoration
+4D testdecoration decoration:data.decorations.stats                # 800D is set to 1 if the PC could store at least 1 more of that decoration (not in FR/LG)
+4E checkdecoration decoration:data.decorations.stats               # 800D is set to 1 if the PC has at least 1 of that decoration (not in FR/LG)
 4F applymovement npc: data<`move`>           # has character 'npc' move according to movement data 'data'
                                              # npc can be a character number or a variable.
                                              # FF is the player, 7F is the camera.
@@ -139,7 +139,7 @@ if.trainer.ready.call    60 trainer:data.trainers.stats 07 00 pointer<`xse`>
 51 waitmovement npc:                         # block further script execution until the npc movement is completed
 52 waitmovementpos npc: x. y.                # seems bugged. x/y do nothing, only works for FF (the player). Do not use.
 53 hidesprite npc:                           # hides an NPC, but only if they have a Person ID. Doesn't work on the player.
-54 hidespritepos npc: x. y.                  # do not use
+54 hidespritepos npc: x. y.                  # removes the object at the specified coordinates. Do not use.
 55 showsprite npc:                           # opposite of hidesprite
 56 showspritepos npc: x. y.                  # shows a previously hidden sprite, then moves it to (x,y)
 57 movesprite npc: x: y:

--- a/src/HexManiac.Core/Models/Code/scriptReference.txt
+++ b/src/HexManiac.Core/Models/Code/scriptReference.txt
@@ -102,7 +102,7 @@ if.trainer.ready.call    60 trainer:data.trainers.stats 07 00 pointer<`xse`>
 31 fanfare song:songnames                    # plays a song from the song list as a fanfare
 32 waitfanfare                               # blocks script execution until any playing fanfair finishes
 33 playsong song:songnames mode.songloopoptions       # plays a song once or loop
-34 playsong2 song:songnames                           # seems buggy?
+34 playsong2 song:songnames                           # seems buggy? (saves the background music)
 35 fadedefault                               # fades the music back to the default song
 36 fadesong song:songnames                   # fades the music into the given song
 37 fadeout speed.                            # fades out the current song to silent
@@ -290,43 +290,46 @@ C2 updatecoins x. y.
 C3 incrementhiddenvalue a.                   # example: pokecenter nurse uses variable 0xF after you pick yes
 C4 warp6 mapbank. map. warp. x: y:           # sets a particular map to warp to upon using an escape rope/teleport
 C5 waitcry                                   # used after cry, it pauses the script
-C6 bufferboxname buffer.3 box:               # box can be a variable or a literal
-C7 textcolor color.                          # 00=blue, 01=red, FF=default, XX=black. Only in FR/LG
-C8 helptext pointer<>                        # something with helptext? Does some tile loading, which can glitch textboxes
-C9 helptext2                                 # related to help-text box that appears in the opened Main Menu
-CA signmsg                                   # makes message boxes look like signposts
-CB normalmsg                                 # ends the effect of signmsg. Textboxes look like normal textboxes.
-CC comparehiddenvar a. value::               # compares a hidden value to a given value.
-CD setobedience slot:                        # a pokemon in your party becomes obedient (no longer disobeys)
-CE checkobedience slot:                      # if the pokemon is disobedient, 800D=1. If obedient (or empty), 800D=0
-CF executeram                                # Tries a wonder card script.
-D0 setworldmapflag flag:                     # This lets the player fly to a given map, if the map has a flight spot (nop in Emerald)
-D1 warpteleport2 bank. map. exit. x: y:      # clone of warpteleport, only used in FR/LG and only with specials
-D2 setcatchlocation slot: location.data.maps.names          # changes the catch location of a pokemon in your party (0-5)
-
+[BPRE_BPGE_BPEE] C6 bufferboxname buffer.3 box:               # box can be a variable or a literal
+[BPRE_BPGE] C7 textcolor color.              # 00=blue, 01=red, FF=default, XX=black. Only in FR/LG
+[BPEE] C7 nopC7
+[BPRE_BPGE] C8 helptext pointer<>            # something with helptext? Does some tile loading, which can glitch textboxes
+[BPEE] C8 nopC8
+[BPRE_BPGE] C9 helptext2                     # related to help-text box that appears in the opened Main Menu
+[BPEE] C9 nopC9
+[BPRE_BPGE] CA signmsg                       # makes message boxes look like signposts
+[BPEE] CA nopCA
+[BPRE_BPGE] CB normalmsg                     # ends the effect of signmsg. Textboxes look like normal textboxes.
+[BPEE] CB nopCB
+[BPRE_BPGE] CC comparehiddenvar a. value::   # compares a hidden value to a given value.
+[BPEE] CC nopCC
+[BPRE_BPGE_BPEE] CD setobedience slot:       # a pokemon in your party becomes obedient (no longer disobeys)
+[BPRE_BPGE_BPEE] CE checkobedience slot:     # if the pokemon is disobedient, 800D=1. If obedient (or empty), 800D=0
+[BPRE_BPGE_BPEE] CF executeram               # Tries a wonder card script.
+[BPRE_BPGE] D0 setworldmapflag flag:         # This lets the player fly to a given map, if the map has a flight spot
+[BPEE] D0 nopD0                              # (nop in Emerald)
+[BPRE_BPGE_BPEE] D1 warpteleport2 bank. map. exit. x: y:      # clone of warpteleport, only used in FR/LG and only with specials
+[BPRE_BPGE_BPEE] D2 setcatchlocation slot: location.data.maps.names          # changes the catch location of a pokemon in your party (0-5)
 [BPEE] D3 moverotatingtileobjects puzzleNumber:
-[BPRE_BPGE] D3 braillelength pointer<>       # sets variable 8004 based on th ebraille string's length
+[BPRE_BPGE] D3 braillelength pointer<>       # sets variable 8004 based on the braille string's length
                                              # call this, then special 0x1B2 to make a cursor appear at the end of the text
-[BPRE_BPGE] D4 bufferitems buffer.3 item: quantity:      # buffers the item name, but possibly pluralized if quantity is 2 or more
+[BPRE_BPGE] D4 bufferitems2 buffer.3 item: quantity:     # buffers the item name, but pluralized if quantity is 2 or more
 [BPEE] D4 turnrotatingtileobjects
-# there is no D5 in ruby
-[BPRE_BPGE] D5 nopD5
+# there is no D5 in ruby nor firered
 [BPEE] D5 initrotatingtilepuzzle isTrickHouse:
 [BPEE] D6 freerotatingtilepuzzle
-[AXVE_AXPE] D6 cmdD6                         # unknown
-[BPRE_BPGE] D6 cmdD6
-D7 warp7 mapbank. map. warp. x: y:           # used in Mossdeep City's gym
-D8 cmdD8                                     # unknown
-D9 cmdD9                                     # unknown
-DA hidebox2                                  # hides a displayed Braille textbox. Only for Emerald
-DB preparemsg3 pointer<"">                   # shows a text box with text appearing instantaneously.
-DC fadescreen3 unknown.                      # fades the screen in or out, swapping buffers. Emerald only.
-DD buffertrainerclass buffer.3 class:data.trainers.classes.names        # stores a trainer class into a specific buffer (Emerald only)
-DE buffertrainername buffer.3 trainer:data.trainers.stats               # stores a trainer name into a specific buffer  (Emerald only)
-DF pokenavcall pointer<>                     # displays a pokenav call. (Emerald only)
-E0 warp8 bank. map. exit. x: y:              # warps the player while fading the screen to white
-E1 buffercontesttype buffer.3 contest:       # stores the contest type name in a buffer. (Emerald Only)
-E2 bufferitems2 buffer.3 item:data.items.stats quantity:     # stores pluralized item name in a buffer. (Emerald Only)
+[BPEE] D7 warp7 mapbank. map. warp. x: y:           # used in Mossdeep City's gym
+[BPEE] D8 selectapproachingtrainer                  # unknown
+[BPEE] D9 lockfortrainer                            # unknown
+[BPEE] DA hidebox2                                  # hides a displayed Braille textbox. Only for Emerald
+[BPEE] DB preparemsg3 pointer<"">                   # shows a text box with text appearing instantaneously.
+[BPEE] DC fadescreen3 unknown.                      # fades the screen in or out, swapping buffers. Emerald only.
+[BPEE] DD buffertrainerclass buffer.3 class:data.trainers.classes.names        # stores a trainer class into a specific buffer (Emerald only)
+[BPEE] DE buffertrainername buffer.3 trainer:data.trainers.stats               # stores a trainer name into a specific buffer  (Emerald only)
+[BPEE] DF pokenavcall pointer<>                     # displays a pokenav call. (Emerald only)
+[BPEE] E0 warp8 bank. map. exit. x: y:              # warps the player while fading the screen to white
+[BPEE] E1 buffercontesttype buffer.3 contest:       # stores the contest type name in a buffer. (Emerald Only)
+[BPEE] E2 bufferitems2 buffer.3 item:data.items.stats quantity:     # stores pluralized item name in a buffer. (Emerald Only)
 
 
 # XX msgbox text<> type.                       # multicommand, 8 bytes total

--- a/src/HexManiac.Core/Models/Code/scriptReference.txt
+++ b/src/HexManiac.Core/Models/Code/scriptReference.txt
@@ -56,8 +56,8 @@ if.trainer.ready.call    60 trainer:data.trainers.stats 07 00 pointer<`xse`>
 07 if2 condition.script_compare pointer<`xse`>  # if the last comparison returned a certain value, "call" to another script
 08 gotostd function.                            # goto a built-in function
 09 callstd function.                            # call a built-in function
-0A gotostdif condition. function.               # goto a built in function if the condition is met
-0B callstdif condition. function.               # call a built in function if the condition is met
+0A gotostdif condition.script_compare function. # goto a built in function if the condition is met
+0B callstdif condition.script_compare function. # call a built in function if the condition is met
 0C jumpram                                      # executes a script from the default RAM location (???)
 0D killscript                                   # kill the script, reset script RAM
 0E setbyte byte.                                # sets a predefined address to the specified byte value
@@ -93,7 +93,7 @@ if.trainer.ready.call    60 trainer:data.trainers.stats 07 00 pointer<`xse`>
 29 setflag flag:|h                           # flag = 1
 2A clearflag flag:|h                         # flag = 0
 2B checkflag flag:|h                         # compares the flag to the value of 1. Used with !=(5) or =(1) compare values
-[BPRE_BPGE] 2C nop2C                         # considered dangerous, probably does nothing
+[BPRE_BPGE] 2C nop2C                         # Only returns a false value.
 [AXPE_AXVE_BPEE] 2C initclock hour: minute:
 2D checkdailyflags                           # nop in firered. Does some flag checking in R/S/E based on real-time-clock
 2E resetvars                                 # sets x8000, x8001, and x8002 to 0
@@ -111,12 +111,12 @@ if.trainer.ready.call    60 trainer:data.trainers.stats 07 00 pointer<`xse`>
                                              # does it terminate script execution?
 3A warpmuted mapbank. map. warp. x: y:       # same as warp, but doesn't play sappy song 0009
 3B warpwalk  mapbank. map. warp. x: y:       # same as warp, but with a walking effect
-3C warphole  mapbank. map.                   # hole effect. Sends player to same X/Y as on the map they started on?
-3D warpteleport mapbank. map. warp. x: y:    # teleport effect on a warp. Seems to only work in R/S/E
-3E warp3 mapbank. map. warp. x: y:           # seems to be an unused clone of warp
-3F setwarpplace mapbank. map. warp. x: y:    # sets a variable position. Go to it with warp 7F 7F 7F 0000 0000
-40 warp4 mapbank. map. warp. x: y:           # probably shouldn't use
-41 warp5 mapbank. map. warp. x: y:           # probably shouldn't use
+3C warphole  mapbank. map.                   # hole effect. Sends the player to same X/Y as on the map they started on.
+3D warpteleport mapbank. map. warp. x: y:    # teleport effect on a warp. Warping to a door/cave opening causes the player to land on the exact same block as it.
+3E warp3 mapbank. map. warp. x: y:           # Sets the map & coordinates for the player to go to in conjunction with specific "special" commands.
+3F setwarpplace mapbank. map. warp. x: y:    # sets a variable position (dynamic warp). Go to it with warp 7F 7F 7F 0000 0000
+40 warp4 mapbank. map. warp. x: y:           # Sets the map & coordinates that the player would go to after using Dive.
+41 warp5 mapbank. map. warp. x: y:           # Sets the map & coordinates that the player would go to if they fell in a hole.
 42 getplayerpos varX: varY:                  # stores the current player position into varX and varY
 43 countPokemon                              # stores number of pokemon in your party into LASTRESULT (800D)
 44 additem item:data.items.stats quantity:       # item/quantity can both be either a literal or a variable.

--- a/src/HexManiac.Core/Models/Code/scriptReference.txt
+++ b/src/HexManiac.Core/Models/Code/scriptReference.txt
@@ -323,7 +323,7 @@ C5 waitcry                                   # used after cry, it pauses the scr
 [BPEE] D9 lockfortrainer                            # unknown
 [BPEE] DA hidebox2                                  # hides a displayed Braille textbox. Only for Emerald
 [BPEE] DB preparemsg3 pointer<"">                   # shows a text box with text appearing instantaneously.
-[BPEE] DC fadescreen3 unknown.                      # fades the screen in or out, swapping buffers. Emerald only.
+[BPEE] DC fadescreen3 mode.screenfades              # fades the screen in or out, swapping buffers. Emerald only.
 [BPEE] DD buffertrainerclass buffer.3 class:data.trainers.classes.names        # stores a trainer class into a specific buffer (Emerald only)
 [BPEE] DE buffertrainername buffer.3 trainer:data.trainers.stats               # stores a trainer name into a specific buffer  (Emerald only)
 [BPEE] DF pokenavcall pointer<>                     # displays a pokenav call. (Emerald only)

--- a/src/HexManiac.Core/Models/Code/scriptReference.txt
+++ b/src/HexManiac.Core/Models/Code/scriptReference.txt
@@ -151,13 +151,13 @@ if.trainer.ready.call    60 trainer:data.trainers.stats 07 00 pointer<`xse`>
 5C trainerbattle 00 trainer:data.trainers.stats arg: start<""> playerwin<"">
 5C trainerbattle 01 trainer:data.trainers.stats arg: start<""> playerwin<""> winscript<`xse`>         # doesn't play encounter music, continues with winscript
 5C trainerbattle 02 trainer:data.trainers.stats arg: start<""> playerwin<""> winscript<`xse`>         # does play encounter music, continues with winscript
-5C trainerbattle 03 trainer:data.trainers.stats arg: playerwin<"">                              # no intro text
+5C trainerbattle 03 trainer:data.trainers.stats arg: playerwin<"">                                    # no intro text
 5C trainerbattle 04 trainer:data.trainers.stats arg: start<""> playerwin<""> needmorepokemonText<"">  # double battles
-5C trainerbattle 05 trainer:data.trainers.stats arg: start<""> playerwin<"">                        # clone of 0, but with rematch potential
-5C trainerbattle 06 trainer:data.trainers.stats arg: start<""> playerwin<""> needmorepokemonText<""> unknown<> # double battles
-5C trainerbattle 07 trainer:data.trainers.stats arg: start<""> playerwin<""> needmorepokemonText<"">  # clone of 4, but with rematch potential
-5C trainerbattle 08 trainer:data.trainers.stats arg: start<""> playerwin<""> needmorepokemonText<""> unknown<> # clone of 6
-5C trainerbattle 09 trainer:data.trainers.stats arg: start<""> playerwin<""> # tutorial battle (can't lose) (set arg=3 for oak's naration)
+5C trainerbattle 05 trainer:data.trainers.stats arg: start<""> playerwin<"">                          # clone of 0, but with rematch potential
+5C trainerbattle 06 trainer:data.trainers.stats arg: start<""> playerwin<""> needmorepokemonText<""> continuescript<`xse`> # double battles, continues the script
+5C trainerbattle 07 trainer:data.trainers.stats arg: start<""> playerwin<""> needmorepokemonText<"">           # clone of 4, but with rematch potential
+5C trainerbattle 08 trainer:data.trainers.stats arg: start<""> playerwin<""> needmorepokemonText<""> continuescript<`xse`> # clone of 6, does not play encounter music
+5C trainerbattle 09 trainer:data.trainers.stats arg: start<""> playerwin<""> # tutorial battle (can't lose) (set arg=3 for oak's naration) (Pyramid type for Emerald)
 5C trainerbattle other. trainer:data.trainers.stats arg: start<""> playerwin<""> # same as 0
                                              # trainer battle takes different parameters depending on the
                                              # 'type', or the first parameter.
@@ -167,14 +167,14 @@ if.trainer.ready.call    60 trainer:data.trainers.stats 07 00 pointer<`xse`>
                                              # rematches are weird. Look into them later.
 
 5D repeattrainerbattle                       # do the last trainer battle again
-5E endtrainerbattle                          # returns from the trainerbattle screen without starting message
-5F endtrainerbattle2                         # same as 5E?
+5E endtrainerbattle                          # returns from the trainerbattle screen without starting message (go to after battle script)
+5F endtrainerbattle2                         # same as 5E? (go to beaten battle script)
 60 checktrainerflag trainer:data.trainers.stats    # if flag 0x500+trainer is 1, then the trainer has been defeated, set 800D to 1
 61 defeatedtrainer  trainer:data.trainers.stats    # set flag 0x500+trainer to 1. That trainer now counts as defeated.
 62 readytrainer     trainer:data.trainers.stats    # set flag 0x500+trainer to 0. That trainer now counts as active.
 63 movesprite2 npc: x: y:                    # permanently move the npc to the x/y location
 64 moveoffscreen npc:                        # moves the npc to just above the left-top corner of the screen
-65 spritebehave npc: behavior.               # ???
+65 spritebehave npc: behavior.               # temporarily changes the movement type of a selected NPC.
 66 waitmsg                                   # block script execution until box/text is fully drawn
 67 preparemsg text<"">                       # text can be a pointer to a text pointer, or just a pointer to text
                                              # starts displaying text in a textbox. Does not block. Call waitmsg to block.


### PR DESCRIPTION
Sorry for the mess. I found out that some of the commands are either `nop`s in one game or are flat-out invalid in Ruby/Sapphire and/or FireRed/LeafGreen. Since the domain of commands is smaller in those games, many of the commands now have [BPRE_BPGE_BPEE] or [BPEE] tags to clarify that some of those high-index commands are only valid in certain games instead of valid everywhere.