### PR TITLE
Changed which NPC facing option we shouldn't use.

### DIFF
--- a/src/HexManiac.Core/Models/Code/default.toml
+++ b/src/HexManiac.Core/Models/Code/default.toml
@@ -172,7 +172,7 @@ Name = '''FacingOptions'''
    '''FaceDown''',
    '''FaceLeft''',
    '''FaceRight''',
-   '''CausesGlitches''',
+   '''Player''',
    '''BerryTreeGrowth''',
    '''FaceDownAndUp''',
    '''FaceLeftAndRight''',

--- a/src/HexManiac.Core/Models/Code/default.toml
+++ b/src/HexManiac.Core/Models/Code/default.toml
@@ -161,7 +161,7 @@ Name = '''egggroups'''
 [[List]]
 Name = '''FacingOptions'''
 0 = [
-   '''DoNotUse''',
+   '''NoMovement''',
    '''LookAround''',
    '''WanderAround''',
    '''WanderUpAndDown''',
@@ -172,7 +172,7 @@ Name = '''FacingOptions'''
    '''FaceDown''',
    '''FaceLeft''',
    '''FaceRight''',
-   '''Player''',
+   '''CausesGlitches''',
    '''BerryTreeGrowth''',
    '''FaceDownAndUp''',
    '''FaceLeftAndRight''',


### PR DESCRIPTION
The movement behavior right below "FaceRight" is actually the one that confuses people as it used to be called "Look Down" in AdvanceMap. That one causes weird stuff to happen after a battle while the first movement option is now correctly labeled "No Movement."