### PR TITLE
Font changes in Emerald

### DIFF
--- a/src/HexManiac.Core/Models/Code/default.bpee.toml
+++ b/src/HexManiac.Core/Models/Code/default.bpee.toml
@@ -9,6 +9,26 @@ Name = '''sound.newgame.titlescreen.song'''
 Address = 0x0AAAE8
 Format = '''[track::songnames]1'''
 
+[[NamedAnchors]]
+Name = '''graphics.text.font.japan4.characters'''
+Address = 0x65C4E4
+Format = '''`ucs2x16x128`'''
+
+[[NamedAnchors]]
+Name = '''graphics.text.font.japan4.width'''
+Address = 0x6644E4
+Format = '''[width.]512'''
+
+[[NamedAnchors]]
+Name = '''graphics.text.font.japan5.characters'''
+Address = 0x6646E4
+Format = '''`ucs2x16x128`'''
+
+[[NamedAnchors]]
+Name = '''graphics.text.font.japan5.width'''
+Address = 0x66C6E4
+Format = '''[width.]512'''
+
 [[OffsetPointer]]
 Address = 0x038850
 Offset = 0x000004

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -776,7 +776,7 @@ graphics.text.font.short.width2,              ,,,, ,,,, 0064FC, [width.]512
 graphics.text.font.bag.characters,            ,,,, ,,,, 0065DC, `ucs2x2x1024`
 graphics.text.font.bag.width,                 ,,,, ,,,, 0065E4, [width.]512
 graphics.text.font.japan1.characters,         ,,,, ,,,, 0064BC, `ucs2x16x64`
-graphics.text.font.japan2.characters,         ,,,, ,,,, 0065A4, `ucs2x16x324`
+graphics.text.font.japan2.characters,         ,,,, ,,,, 0065A4, `ucs2x16x64`
 graphics.text.font.japan3.characters,         ,,,, ,,,, 006794, `ucs2x16x128`
 graphics.text.font.japan3.width,              ,,,, ,,,, 00679C, [width.]512
 


### PR DESCRIPTION
This pull req might be controversial because table changes should be done in `tableReference.txt`. However, the way HMA formats `graphics.text.font.japan2.characters` is inconsistent with the font entries shown in the decomp:

```
086584e4 g 00004000 gFontNormalJapaneseGlyphs
0865c4e4 g 00008000 gFontFRLGMaleJapaneseGlyphs
086644e4 g 00000200 gFontFRLGMaleJapaneseGlyphWidths
086646e4 g 00008000 gFontFRLGFemaleJapaneseGlyphs
0866c6e4 g 00000200 gFontFRLGFemaleJapaneseGlyphWidths
```
I couldn't put the bottom 4 tables/images in tableReference.txt because they're unused in the base game and thus have no anchor references. For consistency's sake, I did the next best thing: putting them in `default_bpee.toml` in case anyone wants to use those FRLG leftover fonts.

Currently, the font sheet for japan2 in Emerald loads basically 3 different sets of characters and garbage data since it's trying to interpret width tables as image data.
