### PR TITLE
Division in tables

### DIFF
--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -731,7 +731,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          } else if (contract.Contains("÷")) {
             var parts = contract.Split('÷');
             Operands = parts;
-            Operator = "÷"; // This might need to be changed to the fwd. slash.
+            Operator = "÷";
          } else {
             Operands = new[] { contract };
             Operator = string.Empty;
@@ -747,7 +747,17 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          switch (Operator) {
             case "+": return values.Aggregate((a, b) => a + b);
             case "*": return values.Aggregate((a, b) => a * b);
-            case "÷": return values.Aggregate((a, b) => a / b);
+            case "÷":
+               try {
+                  return values.Aggregate((a, b) => a / b);
+               }
+               catch (...) {
+                  throw new ArrayRunParseException("Caught a division by zero.");
+               }
+               finally {
+                  return values = 0;
+               }
+                    
             default:  return values.First();
          }
       }

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -738,7 +738,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          }
       }
 
-      public int CalculatedValue(int index) {
+      public double CalculatedValue(int index) {
          if (string.IsNullOrEmpty(Operands[0])) return 0;
          var table = (ITableRun)Model.GetNextRun(index);
          var offset = table.ConvertByteOffsetToArrayOffset(index);
@@ -749,7 +749,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
             case "*": return values.Aggregate((a, b) => a * b);
             case "÷":
                try {
-                  return values.Aggregate((a, b) => a / b);
+                  return values.Aggregate((a, b) => (double) a / b);
                }
                catch (...) {
                   throw new ArrayRunParseException("Caught a division by zero.");

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -747,6 +747,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          switch (Operator) {
             case "+": return values.Aggregate((a, b) => a + b);
             case "*": return values.Aggregate((a, b) => a * b);
+            case "÷": return values.Aggregate((a, b) => a / b);
             default:  return values.First();
          }
       }

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -728,6 +728,10 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
             var parts = contract.Split('+');
             Operands = parts;
             Operator = "+";
+         } else if (contract.Contains("÷")) {
+            var parts = contract.Split('÷');
+            Operands = parts;
+            Operator = "÷"; // This might need to be changed to the fwd. slash.
          } else {
             Operands = new[] { contract };
             Operator = string.Empty;

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -747,17 +747,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          switch (Operator) {
             case "+": return values.Aggregate((a, b) => a + b);
             case "*": return values.Aggregate((a, b) => a * b);
-            case "÷":
-               try {
-                  return values.Aggregate((a, b) => (double) a / b);
-               }
-               catch (...) {
-                  throw new ArrayRunParseException("Caught a division by zero.");
-               }
-               finally {
-                  return values = 0;
-               }
-                    
+            case "÷": return values.Aggregate((a, b) => b == 0 ? 0 : (double) a / b);
             default:  return values.First();
          }
       }

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -60,7 +60,7 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
                var builder = new StringBuilder("@{ ");
                recursionStopper = true;
                if (run is ArrayRun arrayRun && arrayRun.SupportsInnerPointers && arrayRun.ElementContent.Count == 1 && arrayRun.ElementContent[0].Type == ElementContentType.PCS) {
-                  // special case: if the pointer in this arrya is to a specific element of a text array, only copy that one element rather than the whole array.
+                  // special case: if the pointer in this array is to a specific element of a text array, only copy that one element rather than the whole array.
                   run.AppendTo(rawData, builder, address, arrayRun.ElementLength, deep: false);
                } else {
                   run.AppendTo(rawData, builder, run.Start, run.Length, deep);

--- a/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
+++ b/src/HexManiac.Core/Models/Runs/ArrayRunElementSegment.cs
@@ -743,11 +743,11 @@ namespace HavenSoft.HexManiac.Core.Models.Runs {
          var table = (ITableRun)Model.GetNextRun(index);
          var offset = table.ConvertByteOffsetToArrayOffset(index);
 
-         var values = Operands.Select(operand => ParseValue(Model, table, offset.ElementIndex, operand));
+         var values = Operands.Select(operand => (double)ParseValue(Model, table, offset.ElementIndex, operand));
          switch (Operator) {
             case "+": return values.Aggregate((a, b) => a + b);
             case "*": return values.Aggregate((a, b) => a * b);
-            case "÷": return values.Aggregate((a, b) => b == 0 ? 0 : (double) a / b);
+            case "÷": return values.Aggregate((a, b) => b == 0 ? 0 : a / b);
             default:  return values.First();
          }
       }


### PR DESCRIPTION
I thank Haven and Phoenixbound for helping me add on to existing code for supporting the division operator in a field containing `|=`. It adds "÷" as an allowed operator to divide one value from another within a table format. I made sure to prevent crashes from divisions by 0, too.