### PR TITLE
A bunch of feature requests. (I thought I uploaded this already.)

### DIFF
--- a/src/HexManiac.Core/Models/Code/default.axve.axpe.toml
+++ b/src/HexManiac.Core/Models/Code/default.axve.axpe.toml
@@ -734,6 +734,24 @@ Name = '''songnames'''
 466 = '''mus_vs_aqua_magma_leader'''
 467 = '''mus_gsc_radio_tower_takeover'''
 
+[[List]]
+Name = '''allFonts'''
+0 = [
+   '''japan0''',
+   '''japan1-01''',
+   '''japan1-02''',
+   '''japan3''',
+   '''japan4-04''',
+   '''japan4-05''',
+   '''braille''',
+   '''latin0''',
+   '''latin1-08''',
+   '''latin1-09''',
+   '''default''',
+   '''short-0B''',
+   '''short-0C''',
+   '''braille''',
+]
 
 [[GotoShortcut]]
 Name = '''Pokemon'''

--- a/src/HexManiac.Core/Models/Code/default.bpee.toml
+++ b/src/HexManiac.Core/Models/Code/default.bpee.toml
@@ -1227,13 +1227,13 @@ Name = '''allFonts'''
    '''short2''',
    '''other''',
    '''black''',
-   '''?''',
-   '''?''',
-   '''?''',
+   '''black-03''',
+   '''black-04''',
+   '''black-05''',
    '''braille''',
    '''bag''',
    '''short''',
-   '''japan6,'''
+   '''japan6''',
 ]
 
 [[GotoShortcut]]

--- a/src/HexManiac.Core/Models/Code/default.bpee.toml
+++ b/src/HexManiac.Core/Models/Code/default.bpee.toml
@@ -1221,6 +1221,21 @@ Name = '''songnames'''
    '''ph_nurse_solo''',
 ]
 
+[[List]]
+Name = '''allFonts'''
+0 = [
+   '''short2''',
+   '''other''',
+   '''black''',
+   '''?''',
+   '''?''',
+   '''?''',
+   '''braille''',
+   '''bag''',
+   '''short''',
+   '''japan6,'''
+]
+
 [[GotoShortcut]]
 Name = '''Pokemon'''
 Image = '''graphics.pokemon.sprites.front/295/sprite/'''

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -798,7 +798,7 @@ graphics.text.font.japan4.characters, 	1E6B64, 1E6AF4, 1E6B7C, 1E6B0C, , , , , ,
 graphics.text.font.braille, 		002BF8, 002BF8, 002BF8, 002BF8, , , , , , `ucs1x8x24`
 graphics.text.font.palette, 		002A30, 002A30, 002A30, 002A30, , , , , , `ucp4`
 
-graphics.text.font.buttons.characters,        ,       ,       ,       , 006414, 006414, 006428, 006428, 006334, `ucs4x16x4`
+graphics.text.font.buttons.characters,        ,       ,       ,       , 006414, 006414, 006428, 006428, 006334, `ucs4x16x4|graphics.menu.downarrow.palette`
 
 data.text.menu.pokemon.battle,                                 , , , , 032C38, 032C38, 032C4C, 032C4C,       , ""
 data.text.menu.pause,                  071160, 071164, 071180, 071184, 06EF9C, 06EF9C, 06EFB0, 06EFB0, 09F818, [text<""> code<>]

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -338,6 +338,7 @@ graphics.text.box.message,                   ,       ,       ,       , 14FD68, 1
 graphics.text.box.signpost,                  ,       ,       ,       , 14FD9C, 14FD78, 14FE14, 14FDF0,       , `uct4x19|graphics.text.box.palette`
 graphics.text.boxes,                         ,       ,       ,       , 06979C, 06979C, 0697B0, 0697B0,       , [sprite<`ucs4x3x3`> pal<`ucp4`>]10
 graphics.text.boxes,                         ,       ,       ,       ,       ,       ,       ,       , 09876C, [sprite<`ucs4x3x3`> pal<`ucp4`>]20
+graphics.text.font.buttons.characters,       ,       ,       ,       , 006414, 006414, 006428, 006428, 006334, `ucs4x16x4`
 
 graphics.bag.male,                     3C1CC8, 3C1D20, 3C1CE4, 3C1D40, 3D41E4, 3D4020, 3D4254, 3D4090, 57FB34, `lzs4x8x8|graphics.bag.palette`
 graphics.bag.female,                   3C1CD0, 3C1D28, 3C1CEC, 3C1D48, 3D41EC, 3D4028, 3D425C, 3D4098, 57FB3C, `lzs4x8x8|graphics.bag.palette`

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -781,7 +781,8 @@ graphics.text.font.japan3.characters,         ,,,, ,,,, 006794, `ucs2x16x128`
 graphics.text.font.japan3.width,              ,,,, ,,,, 00679C, [width.]512
 graphics.text.font.japan6.characters,         ,,,, ,,,, 00696C, `ucs2x16x32`
 
-data.fonts, 				003A54, 003A54, 003A54, 003A54, , , , , , [fontType:: glyphs<> size: lowerTileOffset:]14
+data.fonts,                            	003A54, 003A54, 003A54, 003A54, , , , ,       , [fontType:: glyphs<> size: lowerTileOffset:]allFonts
+data.fonts,                            	      ,       ,       ,       , , , , , 006374, [function<> maxWidth. maxHeight. letterSpacing. lineSpacing. colors:|t|unused::|foreground::|background::|shadow:: padding:]allFonts
 graphics.text.font.latin0.characters, 	1E6B88, 1E6B18, 1E6BA0, 1E6B30, , , , , , `ucs1x1x511`
 graphics.text.font.latin0.width, 	004944, 004944, 004944, 004944, , , , , , [width.]254
 graphics.text.font.latin1.characters, 	002B88, 002B88, 002B88, 002B88, , , , , , `ucs1x1x256`

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -331,7 +331,7 @@ graphics.pokemon.type.map,             3C11C8, 3C1220, 3C11E4, 3C1240,       ,  
 graphics.pokemon.bag.type.icon,              ,       ,       ,       ,       ,       ,       ,       , 19A340, `ucs4x16x16|graphics.pokemon.bag.type.palette`
 graphics.pokemon.bag.type.palette,           ,       ,       ,       ,       ,       ,       ,       , 19A2E0, `ucp4`
 graphics.pokemon.bag.type.map,               ,       ,       ,       ,       ,       ,       ,       , 19A33C, [width. height. xy:|t|:|x:|.|y::]data.pokemon.type.names+1+5
-graphics.text.importer,                      ,       ,       ,       , 1456EC, 1456C8, 145764, 145740,       , [a:: tileset<`lzt4`> tilemap<`lzm4x30x20|graphics.text.importer`> pal<`ucp4`>]8
+graphics.text.importer,                      ,       ,       ,       , 1456EC, 1456C8, 145764, 145740,       , [titleTextPal. bodyTextPal. footerTextPal. stampShadowPal. tileset<`lzt4`> tilemap<`lzm4x30x20|graphics.text.importer`> pal<`ucp4`>]8
 graphics.text.box.about,                     ,       ,       ,       , 112FC8, 112FA0, 113040, 113018,       , `ucs4x5x4|graphics.text.box.palette`
 graphics.text.box.palette,                   ,       ,       ,       , 150450, 15042C, 1504C8, 1504A4,       , `ucp4:01234`
 graphics.text.box.message,                   ,       ,       ,       , 14FD68, 14FD44, 14FDE0, 14FDBC,       , `uct4x18|graphics.text.box.palette`

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -338,7 +338,6 @@ graphics.text.box.message,                   ,       ,       ,       , 14FD68, 1
 graphics.text.box.signpost,                  ,       ,       ,       , 14FD9C, 14FD78, 14FE14, 14FDF0,       , `uct4x19|graphics.text.box.palette`
 graphics.text.boxes,                         ,       ,       ,       , 06979C, 06979C, 0697B0, 0697B0,       , [sprite<`ucs4x3x3`> pal<`ucp4`>]10
 graphics.text.boxes,                         ,       ,       ,       ,       ,       ,       ,       , 09876C, [sprite<`ucs4x3x3`> pal<`ucp4`>]20
-graphics.text.font.buttons.characters,       ,       ,       ,       , 006414, 006414, 006428, 006428, 006334, `ucs4x16x4`
 
 graphics.bag.male,                     3C1CC8, 3C1D20, 3C1CE4, 3C1D40, 3D41E4, 3D4020, 3D4254, 3D4090, 57FB34, `lzs4x8x8|graphics.bag.palette`
 graphics.bag.female,                   3C1CD0, 3C1D28, 3C1CEC, 3C1D48, 3D41EC, 3D4028, 3D425C, 3D4098, 57FB3C, `lzs4x8x8|graphics.bag.palette`
@@ -797,6 +796,8 @@ graphics.text.font.japan3.characters, 	1E6B58, 1E6AE8, 1E6B70, 1E6B00, , , , , ,
 graphics.text.font.japan4.characters, 	1E6B64, 1E6AF4, 1E6B7C, 1E6B0C, , , , , , `ucs4x16x14`
 graphics.text.font.braille, 		002BF8, 002BF8, 002BF8, 002BF8, , , , , , `ucs1x8x24`
 graphics.text.font.palette, 		002A30, 002A30, 002A30, 002A30, , , , , , `ucp4`
+
+graphics.text.font.buttons.characters,        ,       ,       ,       , 006414, 006414, 006428, 006428, 006334, `ucs4x16x4`
 
 data.text.menu.pokemon.battle,                                 , , , , 032C38, 032C38, 032C4C, 032C4C,       , ""
 data.text.menu.pause,                  071160, 071164, 071180, 071184, 06EF9C, 06EF9C, 06EFB0, 06EFB0, 09F818, [text<""> code<>]

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -256,6 +256,7 @@ scripts.battle.ai.hpaware.discourage.when.target.medium, 1DBFD5, 1DBF65, 1DBFED,
 scripts.battle.ai.hpaware.discourage.when.target.low,    1DBFB7, 1DBF47, 1DBFCF, 1DBF5F, 1DBB8F, 1DBB6B, 1DBBFF, 1DBBDB, 2DE1EB, [effect.moveeffectoptions]!FF
 scripts.battle.ai.trainer,                               1DA01C, 1DA02C, 1DA034, 1D9FC4, 0C70B8, 0C708C, 0C70CC, 0C70A0, 130FC8, [ai<`tse`>]traineraibits
 scripts.battle.animation.thumb,        37F4B8, 37F448, 37F4D0, 37F460, 3ADF5C, 3ADF3C, 3ADFCC, 3ADFAC, 525E98, [code<>]48
+scripts.battle.statStageRatios,        013104, 013104, 013104, 013104, 014ED4, 014ED4, 014EE8, 014EE8, 03D024, [numerator. denominator.]13
 scripts.newgame.setflags,              052F58, 052F58, 052F78, 052F78, 054B6C, 054B6C, 054B80, 054B80, 0845C8, `xse`
 scripts.newgame.pc.item,               139C70, 139C70, 139C90, 139C90, 0EB6A8, 0EB680, 0EB6BC, 0EB694, 16AE54, [item:data.items.stats count:]!00000000
 scripts.credits.panmap,                                           ,,,, 0F3BC0, 0F3B98, 0F3C38, 0F3C10,       , [data<[loadmapCommand: bank: map:: x: y: delay:: xspeed: yspeed: length:: end1Command: end2Command: end3Command::]1>]13

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -256,7 +256,6 @@ scripts.battle.ai.hpaware.discourage.when.target.medium, 1DBFD5, 1DBF65, 1DBFED,
 scripts.battle.ai.hpaware.discourage.when.target.low,    1DBFB7, 1DBF47, 1DBFCF, 1DBF5F, 1DBB8F, 1DBB6B, 1DBBFF, 1DBBDB, 2DE1EB, [effect.moveeffectoptions]!FF
 scripts.battle.ai.trainer,                               1DA01C, 1DA02C, 1DA034, 1D9FC4, 0C70B8, 0C708C, 0C70CC, 0C70A0, 130FC8, [ai<`tse`>]traineraibits
 scripts.battle.animation.thumb,        37F4B8, 37F448, 37F4D0, 37F460, 3ADF5C, 3ADF3C, 3ADFCC, 3ADFAC, 525E98, [code<>]48
-scripts.battle.statStageRatios,        013104, 013104, 013104, 013104, 014ED4, 014ED4, 014EE8, 014EE8, 03D024, [numerator. denominator.]13
 scripts.newgame.setflags,              052F58, 052F58, 052F78, 052F78, 054B6C, 054B6C, 054B80, 054B80, 0845C8, `xse`
 scripts.newgame.pc.item,               139C70, 139C70, 139C90, 139C90, 0EB6A8, 0EB680, 0EB6BC, 0EB694, 16AE54, [item:data.items.stats count:]!00000000
 scripts.credits.panmap,                                           ,,,, 0F3BC0, 0F3B98, 0F3C38, 0F3C10,       , [data<[loadmapCommand: bank: map:: x: y: delay:: xspeed: yspeed: length:: end1Command: end2Command: end3Command::]1>]13
@@ -836,6 +835,7 @@ graphics.pokemon.sprites.egg,                20A3B0, 20A340, 20A3C8, 20A358, 260
 data.text.trade.messages,                          ,       ,       ,       , 124570, 124548, 1245E8, 1245C0, 07A1EC, [text<"">]9
 graphics.menus.trade.windowtemplates.others,       ,       ,       ,       ,       ,       ,       ,       , 0773A8, [background. tilemapleft. tilemaptop. width. height. paletteID. baseblock:]!FF00000000000000
 graphics.menus.trade.windowtemplates.yesno,        ,       ,       ,       ,       ,       ,       ,       , 078EEC, [background. tilemapleft. tilemaptop. width. height. paletteID. baseblock:]1
+data.statstages.default,                     013104, 013104, 013104, 013104, 014ED4, 014ED4, 014EE8, 014EE8, 03D024, [numerator. denominator. ratio|=numerator÷denominator]13
 
 // From Soup
 data.statstages.accuracy,            01C578, 01C578, 01C578, 01C578,       ,       ,       ,       ,       , [numerator. divisor. unused:]13

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -779,6 +779,7 @@ graphics.text.font.japan1.characters,         ,,,, ,,,, 0064BC, `ucs2x16x64`
 graphics.text.font.japan2.characters,         ,,,, ,,,, 0065A4, `ucs2x16x64`
 graphics.text.font.japan3.characters,         ,,,, ,,,, 006794, `ucs2x16x128`
 graphics.text.font.japan3.width,              ,,,, ,,,, 00679C, [width.]512
+graphics.text.font.japan6.characters,         ,,,, ,,,, 00696C, `ucs2x16x32`
 
 data.fonts, 				003A54, 003A54, 003A54, 003A54, , , , , , [fontType:: glyphs<> size: lowerTileOffset:]14
 graphics.text.font.latin0.characters, 	1E6B88, 1E6B18, 1E6BA0, 1E6B30, , , , , , `ucs1x1x511`


### PR DESCRIPTION
- Added "allFonts" [[Lists]] for Ruby and FireRed/
- Added formatting for the stat change ratios table (though I'll have to rename it to fit Moderator Soup's naming convention).
- Documented another font for Emerald.
- Uncovered the table for the keypad (\btn) characters for FireRed/LeafGreen/Emerald,
- Added a "data.fonts" table for Emerald.

[Todo Removed]