### PR TITLE
Filled in the remaining anchor references for 2 tables.

### DIFF
--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -838,5 +838,5 @@ graphics.menus.trade.windowtemplates.yesno,        ,       ,       ,       ,    
 data.statstages.default,                     013104, 013104, 013104, 013104, 014ED4, 014ED4, 014EE8, 014EE8, 03D024, [numerator. denominator. ratio|=numerator÷denominator]13
 
 // From Soup
-data.statstages.accuracy,            01C578, 01C578, 01C578, 01C578,       ,       ,       ,       ,       , [numerator. divisor. unused:]13
-data.statstages.critical,            01C9C8, 01C9C8, 01C9C8, 01C9C8,       ,       ,       ,       ,       , [rate:]6
+data.statstages.accuracy,            01C578, 01C578, 01C578, 01C578, 01E108, 01E108, 01E11C, 01E11C, 046918, [numerator. divisor. unused:]13
+data.statstages.critical,            01C9C8, 01C9C8, 01C9C8, 01C9C8, 01E578, 01E578, 01E58C, 01E58C, 046D68, [rate:]!0000


### PR DESCRIPTION
I also changed the formatting of the critical table because it actually has a terminator token, according to the decomps.