### PR TITLE
Removed the constant references for the XY coords in RSE.

### DIFF
--- a/src/HexManiac.Core/Models/Code/constantReference.txt
+++ b/src/HexManiac.Core/Models/Code/constantReference.txt
@@ -207,22 +207,15 @@ BPGE1.scripts.newgame.start.map  054A1A
 BPGE1.scripts.newgame.start.x    054A1C
 BPGE1.scripts.newgame.start.y    054A14
 
+# Ruby, Sapphire, and Emerald spawn the player in the middle of the truck instead of predefined coordinates.
 AXVE0.scripts.newgame.start.bank 052E0E
 AXVE0.scripts.newgame.start.map  052E10
-AXVE0.scripts.newgame.start.x    052E14
-AXVE0.scripts.newgame.start.y    052E0C
 AXPE0.scripts.newgame.start.bank 052E0E
 AXPE0.scripts.newgame.start.map  052E10
-AXPE0.scripts.newgame.start.x    052E14
-AXPE0.scripts.newgame.start.y    052E0C
 AXVE1.scripts.newgame.start.bank 052E2E
 AXVE1.scripts.newgame.start.map  052E30
-AXVE1.scripts.newgame.start.x    052E34
-AXVE1.scripts.newgame.start.y    052E2C
 AXPE1.scripts.newgame.start.bank 052E2E
 AXPE1.scripts.newgame.start.map  052E30
-AXPE1.scripts.newgame.start.x    052E34
-AXPE1.scripts.newgame.start.y    052E2C
 BPEE0.scripts.newgame.start.bank 084456
 BPEE0.scripts.newgame.start.map  084458
 

--- a/src/HexManiac.Core/Models/Code/constantReference.txt
+++ b/src/HexManiac.Core/Models/Code/constantReference.txt
@@ -225,8 +225,6 @@ AXPE1.scripts.newgame.start.x    052E34
 AXPE1.scripts.newgame.start.y    052E2C
 BPEE0.scripts.newgame.start.bank 084456
 BPEE0.scripts.newgame.start.map  084458
-BPEE0.scripts.newgame.start.x    08445C
-BPEE0.scripts.newgame.start.y    084454
 
 BPRE0.scripts.newgame.professor.pokemon  12FB38,130F40,130F4C # ID of the pokemon shown during the professor's introduction. Also edit pointers to graphics.pokemon.sprites.front/29 and graphics.pokemon.palettes.normal/29
 BPGE0.scripts.newgame.professor.pokemon  12FB10,130F18,130F24 # ID of the pokemon shown during the professor's introduction. Also edit pointers to graphics.pokemon.sprites.front/29 and graphics.pokemon.palettes.normal/29


### PR DESCRIPTION
We may need to do the same for the default BPEF and BPEI `.toml` files.

These addresses are actually part of thumb instructions and don't have anything to do with the spawn coordinates.

Actually, Emerald's code makes the player spawn at (−1, −1), which is a pair of invalid coordinates; therefore, the player actually spawns in the centre of the map. Another tricky thing is that there's no indication in the thumb code about those −1 coordinates — at least one we haven't found yet.. The same can be said for Ruby & Sapphire,