### PR TITLE
Partially overhauling Debug Asserts

### DIFF
--- a/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
@@ -755,10 +755,7 @@ namespace HavenSoft.HexManiac.WPF.Windows {
                      );
                });
                if (result == 2) {
-                  // fileSystem.ShowCustomMessageBox("test", false, new ProcessModel("Test", "https://discord.gg/x9eQuBg"));
-                  Process.Start(new ProcessStartInfo("https://discord.gg/x9eQuBg") {
-                     UseShellExecute = true
-                  });
+                  NativeProcess.Start("https://discord.gg/x9eQuBg");
                   result = 1;
                }
             }

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
@@ -708,7 +708,7 @@ namespace HavenSoft.HexManiac.WPF.Windows {
                   new VisualOption {
                      Index = 1,
                      Option = "Debug",
-                     ShortDescription = "Show Full Message",
+                     ShortDescription = "View Details",
                      Description = "Bring up the full dialog with debugging options."
                   },
                   new VisualOption {
@@ -733,6 +733,7 @@ namespace HavenSoft.HexManiac.WPF.Windows {
                      "Attach a debugger and click 'Debug' to get more information about the following assertion:" + Environment.NewLine +
                      message + Environment.NewLine +
                      detailMessage + Environment.NewLine +
+                     "To report the assert, copy & paste the stack trace to the #hma-bug-reports channel here: https://discord.gg/x9eQuBg." + Environment.NewLine + Environment.NewLine +
                      "Stack Trace:" + Environment.NewLine +
                      Environment.StackTrace,
                      null,

--- a/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
+++ b/src/HexManiac.WPF/Windows/MainWindow.xaml.cs
@@ -733,7 +733,8 @@ namespace HavenSoft.HexManiac.WPF.Windows {
                      "Attach a debugger and click 'Debug' to get more information about the following assertion:" + Environment.NewLine +
                      message + Environment.NewLine +
                      detailMessage + Environment.NewLine +
-                     "To report the assert, copy & paste the stack trace to the #hma-bug-reports channel here: https://discord.gg/x9eQuBg." + Environment.NewLine + Environment.NewLine +
+                     "To report the assert, copy & paste the stack trace to the Discord's #hma-bug-reports channel." + 
+                     Environment.NewLine + Environment.NewLine +
                      "Stack Trace:" + Environment.NewLine +
                      Environment.StackTrace,
                      null,
@@ -744,9 +745,22 @@ namespace HavenSoft.HexManiac.WPF.Windows {
                               ShortDescription = "Show in Debugger",
                               Description = "Break in a connected debugger"
                            },
+                           new VisualOption {
+                              Index = 2,
+                              Option = "Report",
+                              ShortDescription = "Go to Discord",
+                              Description = "Copy the stack trace, and paste it into #hma-bug-reports."
+                           },
                         }
                      );
                });
+               if (result == 2) {
+                  // fileSystem.ShowCustomMessageBox("test", false, new ProcessModel("Test", "https://discord.gg/x9eQuBg"));
+                  Process.Start(new ProcessStartInfo("https://discord.gg/x9eQuBg") {
+                     UseShellExecute = true
+                  });
+                  result = 1;
+               }
             }
          }
       }


### PR DESCRIPTION
To better communicate to users to report debug asserts to HMA's development team, after clicking [View Details] on a debug assert, users have the option to click [Report] to be redirected to the Discord server after being instructed to copy and paste the stack trace into #bug−reports.