### PR TITLE
Added the "scripts.battle.badge.obey" category.

### DIFF
--- a/src/HexManiac.Core/Models/Code/default.axve.axpe.toml
+++ b/src/HexManiac.Core/Models/Code/default.axve.axpe.toml
@@ -1,3 +1,28 @@
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.flags'''
+Address = 0x01B9EC
+Format = '''[word::|h]4'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.0badges'''
+Address = 0x01B97E
+Format = '''[level.]1'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.2badges'''
+Address = 0x01B98C
+Format = '''[level.]scripts.battle.badge.obey.0badges'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.4badges'''
+Address = 0x01B99A
+Format = '''[level.]scripts.battle.badge.obey.0badges'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.6badges'''
+Address = 0x01B9A8
+Format = '''[level.]scripts.battle.badge.obey.0badges'''
+
 
 [[OffsetPointer]]
 Address = 0x00FB18

--- a/src/HexManiac.Core/Models/Code/default.bpee.toml
+++ b/src/HexManiac.Core/Models/Code/default.bpee.toml
@@ -29,6 +29,31 @@ Name = '''graphics.text.font.japan5.width'''
 Address = 0x66C6E4
 Format = '''[width.]512'''
 
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.flags'''
+Address = 0x045DC4
+Format = '''[word::|h]4'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.0badges'''
+Address = 0x045D4A
+Format = '''[level.]1'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.2badges'''
+Address = 0x045D58
+Format = '''[level.]scripts.battle.badge.obey.0badges'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.4badges'''
+Address = 0x045D66
+Format = '''[level.]scripts.battle.badge.obey.0badges'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.6badges'''
+Address = 0x045D74
+Format = '''[level.]scripts.battle.badge.obey.0badges'''
+
 [[OffsetPointer]]
 Address = 0x038850
 Offset = 0x000004

--- a/src/HexManiac.Core/Models/Code/default.bpre0.bpge0.toml
+++ b/src/HexManiac.Core/Models/Code/default.bpre0.bpge0.toml
@@ -1,3 +1,27 @@
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.flags'''
+Address = 0x01D508
+Format = '''[word::|h]4'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.0badges'''
+Address = 0x01D492
+Format = '''[level.]1'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.2badges'''
+Address = 0x01D4A0
+Format = '''[level.]scripts.battle.badge.obey.0badges'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.4badges'''
+Address = 0x01D4AE
+Format = '''[level.]scripts.battle.badge.obey.0badges'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.6badges'''
+Address = 0x01D4BC
+Format = '''[level.]scripts.battle.badge.obey.0badges'''
 
 [[OffsetPointer]]
 Address = 0x011510

--- a/src/HexManiac.Core/Models/Code/default.bpre1.bpge1.toml
+++ b/src/HexManiac.Core/Models/Code/default.bpre1.bpge1.toml
@@ -1,3 +1,27 @@
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.flags'''
+Address = 0x01D51C
+Format = '''[word::|h]4'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.0badges'''
+Address = 0x01D4A6
+Format = '''[level.]1'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.2badges'''
+Address = 0x01D4B4
+Format = '''[level.]scripts.battle.badge.obey.0badges'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.4badges'''
+Address = 0x01D4C2
+Format = '''[level.]scripts.battle.badge.obey.0badges'''
+
+[[NamedAnchors]]
+Name = '''scripts.battle.badge.obey.6badges'''
+Address = 0x01D4D0
+Format = '''[level.]scripts.battle.badge.obey.0badges'''
 
 [[OffsetPointer]]
 Address = 0x011524

--- a/src/HexManiac.Core/Models/Code/scriptReference.txt
+++ b/src/HexManiac.Core/Models/Code/scriptReference.txt
@@ -259,12 +259,12 @@ double.battle.continue.silent       5C 08 trainer:data.trainers.stats 00 00 star
 7C checkattack move:data.pokemon.moves.names # 800D=n, where n is the index of the pokemon that knows the move.
                                              # 800D=6, if no pokemon in your party knows the move
                                              # if successful, 8004 is set to the pokemon species
-7D bufferPokemon buffer.bufferNames species:data.pokemon.names      # species can be a literal or variable. Store the name in the given buffer
+7D bufferPokemon buffer.bufferNames species:data.pokemon.names      # Species can be a literal or variable. Store the name in the given buffer
 7E bufferfirstPokemon buffer.bufferNames                            # Species of your first pokemon gets stored in the given buffer
-7F bufferpartyPokemon buffer.bufferNames party:                     # Speciel of pokemon 'party' from your party gets stored in the buffer
+7F bufferpartyPokemon buffer.bufferNames party:                     # Species of pokemon 'party' from your party gets stored in the buffer
 80 bufferitem buffer.bufferNames item:data.items.stats              # stores an item name in a buffer
 81 bufferdecoration buffer.bufferNames decoration:
-82 bufferattack buffer.bufferNames move:data.pokemon.moves.names    # species, party, item, decoration, and move can all be literals or variables
+82 bufferattack buffer.bufferNames move:data.pokemon.moves.names    # Species, party, item, decoration, and move can all be literals or variables
 83 buffernumber buffer.bufferNames number:             # literal or variable gets converted to a string and put in the buffer.
 84 bufferstd buffer.bufferNames index:                 # gets one of the standard strings and pushes it into a buffer
 85 bufferstring buffer.bufferNames pointer<>           # copies the string into the buffer.


### PR DESCRIPTION
Credit to Axcellerator for finding these offsets for Emerald.

This category contains unreferenced anchors that allow developers to edit the level thresholds of whether or not traded Pokémon will obey the player in battle and the flags that need to be set in order for the thresholds to change.

Since all of these are part of a THUMB routine, nothing points to these individual anchors, so I had to put them in `default.[GAME CODE].toml` files.
