### PR TITLE
Added the "scripts.coins.cap" constant.

### DIFF
--- a/src/HexManiac.Core/Models/Code/constantReference.txt
+++ b/src/HexManiac.Core/Models/Code/constantReference.txt
@@ -199,6 +199,10 @@ BPGE1:scripts.coins.cap-9       16C85D
 BPGE1:scripts.coins.cap-19      16C914,16C974
 BPGE1:scripts.coins.cap-49      16C78E
 BPGE1:scripts.coins.cap-499     16C760
+AXVE0:scripts.coins.cap         11A87C,11A894
+AXVE0:scripts.coins.cap-1       11A85A
+AXPE0:scripts.coins.cap         11A87C,11A894
+AXPE0:scripts.coins.cap-1       11A85A
 
 - Other -------------------------------------------------------------------------------------------------------------------------
 # TryProduceOrHatchEgg

--- a/src/HexManiac.Core/Models/Code/constantReference.txt
+++ b/src/HexManiac.Core/Models/Code/constantReference.txt
@@ -203,6 +203,10 @@ AXVE0:scripts.coins.cap         11A87C,11A894
 AXVE0:scripts.coins.cap-1       11A85A
 AXPE0:scripts.coins.cap         11A87C,11A894
 AXPE0:scripts.coins.cap-1       11A85A
+AXVE1:scripts.coins.cap         11A89C,11A8B4
+AXVE1:scripts.coins.cap-1       11A87A
+AXPE1:scripts.coins.cap         11A89C,11A8B4
+AXPE1:scripts.coins.cap-1       11A87A
 
 - Other -------------------------------------------------------------------------------------------------------------------------
 # TryProduceOrHatchEgg

--- a/src/HexManiac.Core/Models/Code/constantReference.txt
+++ b/src/HexManiac.Core/Models/Code/constantReference.txt
@@ -170,6 +170,11 @@ BPEE0.scripts.ev.cap.stat       06DC48,06DC4E
 - Money cap: The maximum amount of money the player can carry at once. -----------------------------------
 BPEE0::scripts.money.cap        0E5188
 
+# Coins
+BPEE0:scripts.coins.cap         12AFF8,12BC1C,12E22C,141C9C,141DC0,145CA8,145CC8
+BPEE0:scripts.coins.cap-1       12ABF4,12BC14,1419CC,145C98
+BPEE0:scripts.coins.cap-49      20FC39
+BPEE0:scripts.coins.cap-499     20FC7B
 
 
 - Other -------------------------------------------------------------------------------------------------------------------------

--- a/src/HexManiac.Core/Models/Code/constantReference.txt
+++ b/src/HexManiac.Core/Models/Code/constantReference.txt
@@ -175,7 +175,12 @@ BPEE0:scripts.coins.cap         12AFF8,12BC1C,12E22C,141C9C,141DC0,145CA8,145CC8
 BPEE0:scripts.coins.cap-1       12ABF4,12BC14,1419CC,145C98
 BPEE0:scripts.coins.cap-49      20FC39
 BPEE0:scripts.coins.cap-499     20FC7B
-
+BPRE0:scripts.coins.cap         0D05E0
+BPRE0:scripts.coins.cap-1       0D05BC
+BPRE0:scripts.coins.cap-9       16C809
+BPRE0:scripts.coins.cap-19      16C8C0,16C920
+BPRE0:scripts.coins.cap-49      16C73A
+BPRE0:scripts.coins.cap-499     16C70C
 
 - Other -------------------------------------------------------------------------------------------------------------------------
 # TryProduceOrHatchEgg

--- a/src/HexManiac.Core/Models/Code/constantReference.txt
+++ b/src/HexManiac.Core/Models/Code/constantReference.txt
@@ -181,6 +181,12 @@ BPRE0:scripts.coins.cap-9       16C809
 BPRE0:scripts.coins.cap-19      16C8C0,16C920
 BPRE0:scripts.coins.cap-49      16C73A
 BPRE0:scripts.coins.cap-499     16C70C
+BPRE1:scripts.coins.cap         0D05F4
+BPRE1:scripts.coins.cap-1       0D05D0
+BPRE1:scripts.coins.cap-9       16C881
+BPRE1:scripts.coins.cap-19      16C938,16C998
+BPRE1:scripts.coins.cap-49      16C7B2
+BPRE1:scripts.coins.cap-499     16C784
 
 - Other -------------------------------------------------------------------------------------------------------------------------
 # TryProduceOrHatchEgg

--- a/src/HexManiac.Core/Models/Code/constantReference.txt
+++ b/src/HexManiac.Core/Models/Code/constantReference.txt
@@ -193,6 +193,12 @@ BPGE0:scripts.coins.cap-9       16C7E5
 BPGE0:scripts.coins.cap-19      16C89C,16C8FC
 BPGE0:scripts.coins.cap-49      16C716
 BPGE0:scripts.coins.cap-499     16C6E8
+BPGE1:scripts.coins.cap         0D05C8
+BPGE1:scripts.coins.cap-1       0D05A4
+BPGE1:scripts.coins.cap-9       16C85D
+BPGE1:scripts.coins.cap-19      16C914,16C974
+BPGE1:scripts.coins.cap-49      16C78E
+BPGE1:scripts.coins.cap-499     16C760
 
 - Other -------------------------------------------------------------------------------------------------------------------------
 # TryProduceOrHatchEgg

--- a/src/HexManiac.Core/Models/Code/constantReference.txt
+++ b/src/HexManiac.Core/Models/Code/constantReference.txt
@@ -187,6 +187,12 @@ BPRE1:scripts.coins.cap-9       16C881
 BPRE1:scripts.coins.cap-19      16C938,16C998
 BPRE1:scripts.coins.cap-49      16C7B2
 BPRE1:scripts.coins.cap-499     16C784
+BPGE0:scripts.coins.cap         0D05B4
+BPGE0:scripts.coins.cap-1       0D0590
+BPGE0:scripts.coins.cap-9       16C7E5
+BPGE0:scripts.coins.cap-19      16C89C,16C8FC
+BPGE0:scripts.coins.cap-49      16C716
+BPGE0:scripts.coins.cap-499     16C6E8
 
 - Other -------------------------------------------------------------------------------------------------------------------------
 # TryProduceOrHatchEgg


### PR DESCRIPTION
The -49 & -499 bit is presumably for XSE scripts that check the player's coin count before purchasing a multiple of 50 more coins. Right now, those don't work presumably due to a bug where constants get overridden when formatting scripts. 

(WARNING: This branch was created before the earlier pull requests, so there could be merge conflicts and/or newer changes being reverted. Resolving them may be challenging.)