### PR TITLE
Make gradients smoother

### DIFF
--- a/src/HexManiac.Core/ViewModels/Theme.cs
+++ b/src/HexManiac.Core/ViewModels/Theme.cs
@@ -193,6 +193,55 @@ namespace HavenSoft.HexManiac.Core.ViewModels {
          }
          return (hue, sat, bright);
       }
+
+      public static (byte red, byte green, byte blue) FromOklab(double lightness, double a, double b) {
+         // From the creator of the color space
+         // https://bottosson.github.io/posts/oklab/#converting-from-linear-srgb-to-oklab
+         double lPrime = lightness + 0.3963377774 * a + 0.2158037573 * b;
+         double mPrime = lightness - 0.1055613458 * a - 0.0638541728 * b;
+         double sPrime = lightness - 0.0894841775 * a - 1.2914855480 * b;
+
+         double l = lPrime * lPrime * lPrime;
+         double m = mPrime * mPrime * mPrime;
+         double s = sPrime * sPrime * sPrime;
+
+         double rLinear =  4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s;
+         double gLinear = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s;
+         double bLinear = -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s;
+
+         // Assume the output is sRGB, meaning gamma = 2.4
+         // Real original-model GBA screens have higher gamma, but most people making and playing romhacks aren't going to be playing with a GBA-like screen
+         var toSRGB = (double c) => (c <= 0.0031308 ? 12.92 * c : (1.055 * Math.Pow(c, 1.0 / 2.4) - 0.055)).LimitToRange(0.0, 1.0);
+
+         byte red = (byte)Math.Round(toSRGB(rLinear) * 255.0);
+         byte green = (byte)Math.Round(toSRGB(gLinear) * 255.0);
+         byte blue = (byte)Math.Round(toSRGB(bLinear) * 255.0);
+         return (red, green, blue);
+      }
+
+      public static (double lightness, double a, double b) ToOklab(byte red, byte green, byte blue) {
+         double r_ = red / 255.0;
+         double g_ = green / 255.0;
+         double b_ = blue / 255.0;
+
+         // Assume the input is sRGB, meaning gamma = 2.4
+         // Real original-model GBA screens have higher gamma, but most people making and playing romhacks aren't going to be playing with a GBA-like screen
+         var toLinear = (double c) => c <= 0.04045 ? c / 12.92 : Math.Pow((c + 0.055) / 1.055, 2.4);
+         double rLinear = toLinear(r_);
+         double gLinear = toLinear(g_);
+         double bLinear = toLinear(b_);
+
+         // From the creator of the color space
+         // https://bottosson.github.io/posts/oklab/#converting-from-linear-srgb-to-oklab
+         double lPrime = Math.Cbrt(0.4122214708 * rLinear + 0.5363325363 * gLinear + 0.0514459929 * bLinear);
+         double mPrime = Math.Cbrt(0.2119034982 * rLinear + 0.6806995451 * gLinear + 0.1073969566 * bLinear);
+         double sPrime = Math.Cbrt(0.0883024619 * rLinear + 0.2817188376 * gLinear + 0.6299787005 * bLinear);
+
+         double lightness = 0.2104542553 * lPrime + 0.7936177850 * mPrime - 0.0040720468 * sPrime;
+         double a =         1.9779984951 * lPrime - 2.4285922050 * mPrime + 0.4505937099 * sPrime;
+         double b =         0.0259040371 * lPrime + 0.7827717662 * mPrime - 0.8086757660 * sPrime;
+         return (lightness, a, b);
+      }
    }
 
    // failed experiment: trying to get themes to be closer aligned to Solarized Dark/Light as a baseline.

--- a/src/HexManiac.Core/ViewModels/Tools/PaletteCollection.cs
+++ b/src/HexManiac.Core/ViewModels/Tools/PaletteCollection.cs
@@ -439,23 +439,23 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Tools {
          var right = Elements.Count.Range().Last(i => Elements[i].Selected);
 
          var (r, g, b) = UncompressedPaletteColor.ToRGB(Elements[left].Color);
-         var leftHSB = Theme.ToHSB((byte)(r << 3), (byte)(g << 3), (byte)(b << 3));
+         var leftLAB = Theme.ToOklab((byte)(r * 33 >> 2), (byte)(g * 33 >> 2), (byte)(b * 33 >> 2));
 
          var rightRGB = UncompressedPaletteColor.ToRGB(Elements[right].Color);
-         var rightHSB = Theme.ToHSB((byte)(rightRGB.r << 3), (byte)(rightRGB.g << 3), (byte)(rightRGB.b << 3));
+         var rightLAB = Theme.ToOklab((byte)(rightRGB.r * 33 >> 2), (byte)(rightRGB.g * 33 >> 2), (byte)(rightRGB.b * 33 >> 2));
 
-         var deltaHue = rightHSB.hue - leftHSB.hue;
-         var deltaSat = rightHSB.sat - leftHSB.sat;
-         var deltaBright = rightHSB.bright - leftHSB.bright;
+         var deltaLight = rightLAB.lightness - leftLAB.lightness;
+         var deltaA = rightLAB.a - leftLAB.a;
+         var deltaB = rightLAB.b - leftLAB.b;
 
          var distance = right - left;
          for (int i = 1; i < distance; i++) {
             if (!Elements[left + i].Selected) continue;
             var part = (double)i / distance;
-            var hue = leftHSB.hue + deltaHue * part;
-            var sat = leftHSB.sat + deltaSat * part;
-            var bright = leftHSB.bright + deltaBright * part;
-            var (red, green, blue) = Theme.FromHSB(hue, sat, bright);
+            var light = leftLAB.lightness + deltaLight * part;
+            var a_ = leftLAB.a + deltaA * part;
+            var b_ = leftLAB.b + deltaB * part;
+            var (red, green, blue) = Theme.FromOklab(light, a_, b_);
             Elements[left + i].Color = UncompressedPaletteColor.Pack(red >> 3, green >> 3, blue >> 3);
          }
 


### PR DESCRIPTION
I saw an issue in the Discord server about gradients and got in the mood to mess around a bit. Not sure whether this is what you're looking for or not, but it was a fun break from script commands.

A "perceptually uniform" color space makes drawing a line between two colors more closely match what it looks like to be "halfway" between two colors. This is basically the goal of calculating a gradient, to sample colors on a line between two colors for colors that are slightly more similar to the target color, with each step being roughly the same amount closer to the target.

Here's a comparison of the gradients created by this PR versus those in `master` (made using HSV):

![Comparison of the two gradient creation algorithms. The gradients on the left were made with OKLab, and the ones on the right are what HMA currently creates.](https://github.com/haven1433/HexManiacAdvance/assets/13182187/617b927b-55dc-4eb0-bb01-1e160436bc50)

There is one issue I ran into: this doesn't seem to play nice with changing values in the color picker when multiple colors of a gradient are selected. I'm not sure what the best way to fix that would be. It's possible to spin this coordinate system into something similar to HSV, but doing that makes the browns in the last gradient even more prominent:

![image](https://github.com/haven1433/HexManiacAdvance/assets/13182187/f08530b1-55cb-4ee4-90fa-d8e20b4a9ca5)
