### PR TITLE
Added some Battle Tent data.

### DIFF
--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -865,8 +865,9 @@ graphics.menus.trade.windowtemplates.yesno,        ,       ,       ,       ,    
 data.statstages.default,                     013104, 013104, 013104, 013104, 014ED4, 014ED4, 014EE8, 014EE8, 03D024, [numerator. denominator. ratio|=numerator÷denominator]13
 scripts.seagallop.destinations,                    ,       ,       ,       , 1471B0, 14718C, 147228, 147204,       , [bank. map. x. y.]scripts.seagallop.count
 data.battlefrontier.battletent.slateport.pokemon,  ,       ,       ,       ,       ,       ,       ,       , 165DA4, [pokemon:data.pokemon.names [move:data.pokemon.moves.names]4item.data.battlefrontier.items EVspread. nature.data.pokemon.natures.names padding:.]70
-data.battlefrontier.battletent.slateport.trainers, ,       ,       ,       ,       ,       ,       ,       , 165D9C, [facilityclass.data.battlefrontier.trainerclass padding:. name""8 [[word:|h]6]3pokemon<>]30 
-
+data.battlefrontier.battletent.slateport.trainers, ,       ,       ,       ,       ,       ,       ,       , 165D9C, [facilityclass.data.battlefrontier.trainerclass padding:. name""8 [[word:|h]6]3pokemon<>]30
+data.battlefrontier.battletent.verdanturf.pokemon, ,       ,       ,       ,       ,       ,       ,       , 165DC4, [pokemon:data.pokemon.names [move:data.pokemon.moves.names]4item.data.battlefrontier.items EVspread. nature.data.pokemon.natures.names padding:.]45
+data.battlefrontier.battletent.verdanturf.trainers,        ,       ,       ,       ,       ,       ,       ,       , 165DBC, [facilityclass.data.battlefrontier.trainerclass padding:. name""8 [[word:|h]6]3pokemon<>]30
 
 // From Soup
 data.statstages.accuracy,            01C578, 01C578, 01C578, 01C578, 01E108, 01E108, 01E11C, 01E11C, 046918, [numerator. divisor. unused:]13

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -868,6 +868,8 @@ data.battlefrontier.battletent.slateport.pokemon,  ,       ,       ,       ,    
 data.battlefrontier.battletent.slateport.trainers, ,       ,       ,       ,       ,       ,       ,       , 165D9C, [facilityclass.data.battlefrontier.trainerclass padding:. name""8 [[word:|h]6]3pokemon<>]30
 data.battlefrontier.battletent.verdanturf.pokemon, ,       ,       ,       ,       ,       ,       ,       , 165DC4, [pokemon:data.pokemon.names [move:data.pokemon.moves.names]4item.data.battlefrontier.items EVspread. nature.data.pokemon.natures.names padding:.]45
 data.battlefrontier.battletent.verdanturf.trainers,        ,       ,       ,       ,       ,       ,       ,       , 165DBC, [facilityclass.data.battlefrontier.trainerclass padding:. name""8 [[word:|h]6]3pokemon<>]30
+data.battlefrontier.battletent.fallarbor.pokemon,  ,       ,       ,       ,       ,       ,       ,       , 165DE4, [pokemon:data.pokemon.names [move:data.pokemon.moves.names]4item.data.battlefrontier.items EVspread. nature.data.pokemon.natures.names padding:.]45
+data.battlefrontier.battletent.fallarbor.trainers, ,       ,       ,       ,       ,       ,       ,       , 165DDC, [facilityclass.data.battlefrontier.trainerclass padding:. name""8 [[word:|h]6]3pokemon<>]30 
 
 // From Soup
 data.statstages.accuracy,            01C578, 01C578, 01C578, 01C578, 01E108, 01E108, 01E11C, 01E11C, 046918, [numerator. divisor. unused:]13

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -863,7 +863,10 @@ data.text.trade.messages,                          ,       ,       ,       , 124
 graphics.menus.trade.windowtemplates.others,       ,       ,       ,       ,       ,       ,       ,       , 0773A8, [background. tilemapleft. tilemaptop. width. height. paletteID. baseblock:]!FF00000000000000
 graphics.menus.trade.windowtemplates.yesno,        ,       ,       ,       ,       ,       ,       ,       , 078EEC, [background. tilemapleft. tilemaptop. width. height. paletteID. baseblock:]1
 data.statstages.default,                     013104, 013104, 013104, 013104, 014ED4, 014ED4, 014EE8, 014EE8, 03D024, [numerator. denominator. ratio|=numerator÷denominator]13
-scripts.seagallop.destinations, , , , , 1471B0, 14718C, 147228, 147204, , [bank. map. x. y.]scripts.seagallop.count
+scripts.seagallop.destinations,                    ,       ,       ,       , 1471B0, 14718C, 147228, 147204,       , [bank. map. x. y.]scripts.seagallop.count
+data.battlefrontier.battletent.slateport.pokemon,  ,       ,       ,       ,       ,       ,       ,       , 165DA4, [pokemon:data.pokemon.names [move:data.pokemon.moves.names]4item.data.battlefrontier.items EVspread. nature.data.pokemon.natures.names padding:.]70
+
+
 
 // From Soup
 data.statstages.accuracy,            01C578, 01C578, 01C578, 01C578, 01E108, 01E108, 01E11C, 01E11C, 046918, [numerator. divisor. unused:]13

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -865,7 +865,7 @@ graphics.menus.trade.windowtemplates.yesno,        ,       ,       ,       ,    
 data.statstages.default,                     013104, 013104, 013104, 013104, 014ED4, 014ED4, 014EE8, 014EE8, 03D024, [numerator. denominator. ratio|=numerator÷denominator]13
 scripts.seagallop.destinations,                    ,       ,       ,       , 1471B0, 14718C, 147228, 147204,       , [bank. map. x. y.]scripts.seagallop.count
 data.battlefrontier.battletent.slateport.pokemon,  ,       ,       ,       ,       ,       ,       ,       , 165DA4, [pokemon:data.pokemon.names [move:data.pokemon.moves.names]4item.data.battlefrontier.items EVspread. nature.data.pokemon.natures.names padding:.]70
-
+data.battlefrontier.battletent.slateport.trainers, ,       ,       ,       ,       ,       ,       ,       , 165D9C, [facilityclass.data.battlefrontier.trainerclass padding:. name""8 [[word:|h]6]3pokemon<>]30 
 
 
 // From Soup


### PR DESCRIPTION
Some table formats may not be finalized due to a possible bug that falsely thinks that this formatting is invalid: `[[word:|h]6]3 pokemon<>`.

I added 2 tables for each Battle Tent in the game: one for the available Pokémon and another for the trainers that Brendan/May could be fighting.

Special thanks to Axcellerator for the feature request.