### PR TITLE
Added an `eor` alias.

### DIFF
--- a/src/HexManiac.Core/Models/Code/armReference.txt
+++ b/src/HexManiac.Core/Models/Code/armReference.txt
@@ -54,6 +54,7 @@ nv=1111  @    never
 0100000000 rm rd    |     and   rd, rd, rm    @ alias
 0100000001 rm rd    |     eor   rd, rm        @ rd ^= rm
 0100000001 rm rd    |     eor   rd, rd, rm    @ rd ^= rm
+0100000001 rm rd    |     eor   rd, rm, rd    @ rd ^= rm
 0100000010 rs rd    |     lsl   rd, rs        @ rd <<= rs
 0100000011 rs rd    |     lsr   rd, rs        @ rd >>= rs
 0100000100 rs rd    |     asr   rd, rs        @ rd >>>= rs


### PR DESCRIPTION
HMA now accepts `eor r1, r0, r1` as a valid alternative of `eor r1, r0`.