### PR TITLE
Added the E4 mugshot palettes.

### DIFF
--- a/src/HexManiac.Core/Models/Code/default.bpre.bpge.toml
+++ b/src/HexManiac.Core/Models/Code/default.bpre.bpge.toml
@@ -1133,3 +1133,20 @@ Name = '''encountersongs'''
    '''boy0C''',
    '''boy0D''',
 ]
+
+[[List]]
+Name = '''trainerMugshots'''
+0 = [
+   '''Lorelei''',
+   '''Bruno''',
+   '''Agatha''',
+   '''Lance''',
+   '''Blue''',
+]
+
+[[List]]
+Name = '''playerMugshots'''
+0 = [
+   '''Red''',
+   '''Leaf''',
+]

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -887,3 +887,7 @@ scripts.text.destinations, ,,,, 09D824, 09D7F8, 09D838, 09D80C, , [text<"">]
 // From Soup
 data.statstages.accuracy,            01C578, 01C578, 01C578, 01C578, 01E108, 01E108, 01E11C, 01E11C, 046918, [numerator. divisor. unused:]13
 data.statstages.critical,            01C9C8, 01C9C8, 01C9C8, 01C9C8, 01E578, 01E578, 01E58C, 01E58C, 046D68, [rate:]!0000
+
+// From Yogia
+graphics.trainers.elite4.mugshot.palettes,         ,       ,       ,       , 0D2958, 0D292C, 0D296C, 0D2940,        , [palette<`ucp4`>]5
+graphics.trainers.players.mugshot.palettes,        ,       ,       ,       , 0D295C, 0D2930, 0D2970, 0D2944,        , [palette<`ucp4`>]2 

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -889,5 +889,5 @@ data.statstages.accuracy,            01C578, 01C578, 01C578, 01C578, 01E108, 01E
 data.statstages.critical,            01C9C8, 01C9C8, 01C9C8, 01C9C8, 01E578, 01E578, 01E58C, 01E58C, 046D68, [rate:]!0000
 
 // From Yogia
-graphics.trainers.elite4.mugshot.palettes,         ,       ,       ,       , 0D2958, 0D292C, 0D296C, 0D2940,        , [palette<`ucp4`>]5
-graphics.trainers.players.mugshot.palettes,        ,       ,       ,       , 0D295C, 0D2930, 0D2970, 0D2944,        , [palette<`ucp4`>]2 
+graphics.trainers.elite4.mugshot.palettes,         ,       ,       ,       , 0D2958, 0D292C, 0D296C, 0D2940,        , [palette<`ucp4`>]trainerMugshots
+graphics.trainers.players.mugshot.palettes,        ,       ,       ,       , 0D295C, 0D2930, 0D2970, 0D2944,        , [palette<`ucp4`>]playerMugshots 


### PR DESCRIPTION
Feature Request credit: Yogia16

Added the palettes for the elite four & player trainer mugshots in `tableReference.txt`. It comes with two [[Lists]] for the names of the trainers.

All of the ROMs in question have been tested.