### PR TITLE
Update the check in BlockmapRun.cs to match all FR/LG languages.

### DIFF
--- a/src/HexManiac.Core/Models/Runs/Sprites/BlockmapRun.cs
+++ b/src/HexManiac.Core/Models/Runs/Sprites/BlockmapRun.cs
@@ -54,7 +54,7 @@ namespace HexManiac.Core.Models.Runs.Sprites {
          (BlockWidth, BlockHeight) = (width, height);
          var code = model.GetGameCode();
 
-         if (code.Contains("BPRE") || code.Contains("BPGE")) {
+         if (code.Contains("BPR") || code.Contains("BPG")) {
             PrimaryBlocks = 640;
             PrimaryTiles = 640;
             PrimaryPalettes = 7;


### PR DESCRIPTION
Basically, removes the "E" from the gamecode check so that it doesn't only match English ROMs, but every other FR/LG Roms.