### PR TITLE
Implemented 7 feature requests.

### DIFF
--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -137,7 +137,7 @@ graphics.trainers.animations.back,                ,       ,       ,       , 03F8
 graphics.trainers.animations.frames,        1436B8, 1436B8, 1436D8, 1436D8, 10BDA8, 10BD80, 10BE20, 10BDF8, 18D1E8, [animationPointer<[animation<>]1>]graphics.trainers.sprites.front
 graphics.trainers.coordinates.front,        031AE0, 031AE0, 031AE0, 031AE0, 037E78, 037E78, 037E8C, 037E8C, 05B614, [x. y. unused:]graphics.trainers.sprites.front
 graphics.trainers.palettes.front,           031B98, 031B98, 031B98, 031B98, 03474C, 03474C, 034760, 034760, 05B784, [palette<`lzp4`> index: unused:]graphics.trainers.sprites.front
-graphics.trainers.sprites.back.throw,       031B60, 031B60, 031B60, 031B60,       ,       ,       ,       ,       , [sprite<`lzs4x8x8`> a. b. c:]3
+graphics.trainers.sprites.back.throw,       031B60, 031B60, 031B60, 031B60,       ,       ,       ,       ,       , [sprite<`lzs4x8x8`> size: index:]3
 graphics.trainers.sprites.back.throw,             ,       ,       ,       , 03F8A0, 03F8A0, 03F8B4, 03F8B4,       , [titleTag:|h paletteTag:|h oam<> anims<> sprites<`osl|graphics.trainers.palettes.back:sprite`> affineAnimations<> callback<>]graphics.trainers.sprites.back.enter
 graphics.trainers.sprites.back.throw,             ,       ,       ,       ,       ,       ,       ,       , 06A168, [titleTag:|h paletteTag:|h oam<> anims<> sprites<`osl|graphics.trainers.palettes.back:sprite`> affineAnimations<> callback<>]graphics.trainers.sprites.back.enter
 graphics.trainers.coordinates.back,               ,       ,       ,       , 03240C, 03240C, 032420, 032420,       , [x. y. unused:]graphics.trainers.sprites.back.enter

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -304,7 +304,7 @@ data.pokedex.national,                 03F83C, 03F83C, 03F83C, 03F83C, 04323C, 0
 // -> this table's values can be determined automatically based on the first two
 data.pokedex.hoennToNational,          03F888, 03F888, 03F888, 03F888, 043288, 043288, 04329C, 04329C, 06D494, [index:]data.pokemon.names-1
 data.pokedex.stats,                    08F508, 08F508, 08F528, 08F528, 088E34, 088E30, 088E48, 088E1C,       , [species""12 height: heightInches|=height÷.254 weight: weightLbs|=weight÷4.536 description1<""> description2<""> unused: pokemonScale: pokemonOffset:|z trainerScale: trainerOffset:|z unused:]
-data.pokedex.stats,                          ,       ,       ,       ,       ,       ,       ,       , 0BFA20, [species""12 height: heightInches|=height÷.254 weight: weightLbs|=weight÷4.536 description<""> unused: pokemonScale: pokemonOffset: trainerScale: trainerOffset: unused:]
+data.pokedex.stats,                          ,       ,       ,       ,       ,       ,       ,       , 0BFA20, [species""12 height: heightInches|=height÷.254 weight: weightLbs|=weight÷4.536 description<""> unused: pokemonScale: pokemonOffset:|z trainerScale: trainerOffset:|z unused:]
 data.pokedex.search.alpha,             08D930, 08D930, 08D950, 08D950, 103694, 10366C, 10370C, 1036E4, 0BCB74, [species:data.pokedex.national]data.pokedex.national
 data.pokedex.search.weight,            08D9BC, 08D9BC, 08D9DC, 08D9DC, 1037CC, 1037A4, 103844, 10381C, 0BCC00, [species:data.pokedex.national]data.pokedex.national-25
 data.pokedex.search.size,              08DAE4, 08DAE4, 08DB04, 08DB04, 103868, 103840, 1038E0, 1038B8, 0BCD28, [species:data.pokedex.national]data.pokedex.national-25
@@ -506,7 +506,7 @@ graphics.misc.questionnaire.button.sprite,  ,,,, 43F948, 43F784, 43F9B8, 43F7F4,
 
 graphics.misc.stationary,           ,,,, 1462E4,,,, , [id:: tileset<`lzt4`> tilemap<`lzm4x30x24|table`> palette<`ucp4`>]8
 
-graphics.overworld.firstpersonview.sprites,  ,       ,       ,       , 0F80FC, 0F80D4, 0F8174, 0F814C,       , [id.data.maps.names+88 transition.transitiontype worldmapflag: tileset<`lzt4|graphics.firstpersonview.sprites`> tilemap<`lzm4x32x20|graphics.firstpersonview.sprites`> pal<`ucp4:DE`>]graphics.firstpersonview.count
+graphics.overworld.firstpersonview.sprites,  ,       ,       ,       , 0F80FC, 0F80D4, 0F8174, 0F814C,       , [id.data.maps.names+88 transition.transitiontype worldmapflag:|h tileset<`lzt4|graphics.firstpersonview.sprites`> tilemap<`lzm4x32x20|graphics.firstpersonview.sprites`> pal<`ucp4:DE`>]graphics.firstpersonview.count
 graphics.battle.background.sprites,          ,       ,       ,       , 00F2A0, 00F2A0, 00F2B4, 00F2B4,       , [battletiles<`lzt4`> battlemap<`lzm4x32x64|graphics.battle.background.sprites|battletiles`> | introtiles<`lzt4`> intromap<`lzm4x32x14|graphics.battle.background.sprites|introtiles`> pal<`lzp4:234`>]
 graphics.battle.background.sprites,    00D954, 00D954, 00D954, 00D954,       ,       ,       ,       , 035940, [battletiles<`lzt4`> battlemap<`lzm4x32x64|graphics.battle.background.sprites|battletiles`> | introtiles<`lzt4`> intromap<`lzm4x32x32|graphics.battle.background.sprites|introtiles`> pal<`lzp4:234`>]10
 graphics.battle.background.fighttype,                             ,,,, 00F24C, 00F24C, 00F260, 00F260, , [id. entry.graphics.battle.background.sprites unused:]8

--- a/src/HexManiac.Core/Models/Code/tableReference.txt
+++ b/src/HexManiac.Core/Models/Code/tableReference.txt
@@ -906,3 +906,7 @@ graphics.berrycheck.tilemap2, 146338, 146338, 146358, 146358,       ,       ,   
 // From Yogia
 graphics.trainers.elite4.mugshot.palettes,         ,       ,       ,       , 0D2958, 0D292C, 0D296C, 0D2940,        , [palette<`ucp4`>]trainerMugshots
 graphics.trainers.players.mugshot.palettes,        ,       ,       ,       , 0D295C, 0D2930, 0D2970, 0D2944,        , [palette<`ucp4`>]playerMugshots 
+data.famechecker.trainerpics,                      ,       ,       ,       , 12D98C, 12D964, 12DA04, 12D9DC,        , [pic.graphics.trainers.sprites.front]16 
+
+// From RedKraken
+scripts.newgame.pc.script,                   06824C, 06824C, 068268, 068268, 06CEDC, 06CEDC, 06CEF0, 06CEF0, 09C26C, `xse`

--- a/src/HexManiac.Core/Models/Singletons.cs
+++ b/src/HexManiac.Core/Models/Singletons.cs
@@ -265,7 +265,7 @@ For example scripts and tutorials, see the [HexManiacAdvance Wiki](https://githu
             foreach (var arg in line.Args) {
                if (arg is SilentMatchArg || arg.Name == "filler") continue;
                if (!string.IsNullOrEmpty(arg.EnumTableName) && !arg.EnumTableName.StartsWith("|")) {
-                  text.AppendLine($"{nl}*  `{arg.Name}` from {arg.EnumTableName}");
+                  text.AppendLine($"{nl}*  `{arg.Name}` is from {arg.EnumTableName}");
                } else if (arg.Type != ArgType.Pointer) {
                   if (string.IsNullOrEmpty(arg.EnumTableName)) {
                      text.AppendLine($"{nl}*  `{arg.Name}` is a number.");

--- a/src/HexManiac.Core/ViewModels/Map/MapHeaderViewModel.cs
+++ b/src/HexManiac.Core/ViewModels/Map/MapHeaderViewModel.cs
@@ -51,13 +51,13 @@ namespace HavenSoft.HexManiac.Core.ViewModels.Map {
          // battle
          battleOptions.Add("Normal");
          battleOptions.Add("Gym");
-         battleOptions.Add("Evil Team");
-         battleOptions.Add("Unknown");
+         battleOptions.Add("Indoor 1 (Magma)");
+         battleOptions.Add("Indoor 2 (Aqua)");
          battleOptions.Add("Elite 1");
          battleOptions.Add("Elite 2");
          battleOptions.Add("Elite 3");
          battleOptions.Add("Elite 4");
-         battleOptions.Add("Big Red Pokeball");
+         battleOptions.Add("Big Red Poké ball");
       }
 
       public ObservableCollection<string> WeatherOptions => weatherOptions;


### PR DESCRIPTION
− `scriptReference.md`: "Is from" used for `param.table_name` fields in script commands. (Previously "from")
− Added an anchor for the PC Event Script.
− Added a fame checker trainer pictures table.
− `graphics.trainers.sprites.back.throw`: Updated the fields' names.
− `graphics.overworld.firstpersonview.sprites`: Made the `worldmapflag` field show up as a hex number.
− `data.pokedex.stats`: Made the two offset variables unsigned.
− Updated the `battleOptions` observable collection.