### PR TITLE
Added script for removing the restriction on running indoors

### DIFF
--- a/src/HexManiac.WPF/Scripts/Add Mechanics From Later Generations/AnyGame_RunIndoors.hma
+++ b/src/HexManiac.WPF/Scripts/Add Mechanics From Later Generations/AnyGame_RunIndoors.hma
@@ -1,0 +1,7 @@
+# Remove restriction on running indoors.
+
+@!game(BPRE0) @0BD494 00
+@!game(BPGE0) @0BD468 00
+@!game(AXVE0) @0E5E00 00
+@!game(AXPE0) @0E5E00 00
+@!game(BPEE0) @11A1E8 00


### PR DESCRIPTION
Although this is a very common task that's been around for over a decade, I'm not sure if the exact bytes in versions other than 1.0 are different than what's listed in the script. Regardless, I titled the file with the *AnyGame_* prefix, since there isn't any example of an alternative prefix that should be used for cases where only one version was tested.

Perhaps someone with a copy of those versions could test these offsets and add to the script based on the results.