### PR TITLE
Added the constant for what level eggs hatch at.

### DIFF
--- a/src/HexManiac.Core/Models/Code/constantReference.txt
+++ b/src/HexManiac.Core/Models/Code/constantReference.txt
@@ -535,7 +535,12 @@ BPRE1.scripts.seagallop.count-1 1471C0
 BPGE1.scripts.seagallop.count-1 14719C
 
 # What level Pokémon eggs hatch at
-AXVE0.scripts.daycare.hatchlevel       042068,042132,042954,0A080C # You can change the level at which eggs hatch.
-AXPE0.scripts.daycare.hatchlevel       042068,042132,042954,0A080C # You can change the level at which eggs hatch.
-AXVE1.scripts.daycare.hatchlevel       042088,042152,042974,0A082C # You can change the level at which eggs hatch.
-AXPE1.scripts.daycare.hatchlevel       042088,042152,042974,0A082C # You can change the level at which eggs hatch.
+AXVE0.scripts.daycare.hatchlevel       042068,042132,042954,0A080C # You can change the level at which eggs hatch. Choose a level between 1 and 100.
+AXPE0.scripts.daycare.hatchlevel       042068,042132,042954,0A080C # You can change the level at which eggs hatch. Choose a level between 1 and 100.
+AXVE1.scripts.daycare.hatchlevel       042088,042152,042974,0A082C # You can change the level at which eggs hatch. Choose a level between 1 and 100.
+AXPE1.scripts.daycare.hatchlevel       042088,042152,042974,0A082C # You can change the level at which eggs hatch. Choose a level between 1 and 100.
+BPRE0.scripts.daycare.hatchlevel       04623E,046CBE,1375B0        # You can change the level at which eggs hatch. Choose a level between 1 and 100.
+BPGE0.scripts.daycare.hatchlevel       04623E,046CBE,137588        # You can change the level at which eggs hatch. Choose a level between 1 and 100.
+BPRE1.scripts.daycare.hatchlevel       046252,046CD2,137628        # You can change the level at which eggs hatch. Choose a level between 1 and 100.
+BPGE1.scripts.daycare.hatchlevel       046252,046CD2,137600        # You can change the level at which eggs hatch. Choose a level between 1 and 100.
+BPEE0.scripts.daycare.hatchlevel       070A38,071414,1C3200        # You can change the level at which eggs hatch. Choose a level between 1 and 100.

--- a/src/HexManiac.Core/Models/Code/constantReference.txt
+++ b/src/HexManiac.Core/Models/Code/constantReference.txt
@@ -534,3 +534,8 @@ BPGE0.scripts.seagallop.count-1 147124
 BPRE1.scripts.seagallop.count-1 1471C0
 BPGE1.scripts.seagallop.count-1 14719C
 
+# What level Pokémon eggs hatch at
+AXVE0.scripts.daycare.hatchlevel       042068,042132,042954,0A080C # You can change the level at which eggs hatch.
+AXPE0.scripts.daycare.hatchlevel       042068,042132,042954,0A080C # You can change the level at which eggs hatch.
+AXVE1.scripts.daycare.hatchlevel       042088,042152,042974,0A082C # You can change the level at which eggs hatch.
+AXPE1.scripts.daycare.hatchlevel       042088,042152,042974,0A082C # You can change the level at which eggs hatch.


### PR DESCRIPTION
Requested by Timz0r.
Referenced Thread: https://www.pokecommunity.com/threads/quick-research-development-thread.205158/page-16#post-7584159
Credits: Jambo51 (Ruby & FireRed), VersekrDark (Ruby), and Wobbu (Emerald)

Added the anchor, `scripts.daycare.hatchlevel`, which defaults to 5 in the games. It is a constant. The name could change if need be. Testing will be required.