### PR TITLE
Fix naming for Cry table in BPRF & BPEF

### DIFF
--- a/src/HexManiac.Core/Models/Code/default.bpef.toml
+++ b/src/HexManiac.Core/Models/Code/default.bpef.toml
@@ -1515,13 +1515,13 @@ DefaultHash = '''FB0F1C4A'''
 [[NamedAnchors]]
 Name = '''sound.pokemon.cry.growl'''
 Address = 0x6A2E40
-Format = '''^[type.|h key. length. pan_sweep. p<> attack. decay. sustain. release.]data.pokemon.names-24'''
+Format = '''^[type.|h key. length. pan_sweep. p<> attack. decay. sustain. release.]data.pokemon.names-1'''
 DefaultHash = '''39732051'''
 
 [[NamedAnchors]]
 Name = '''sound.pokemon.cry.normal'''
 Address = 0x6A1C10
-Format = '''^[type.|h key. length. pan_sweep. p<> attack. decay. sustain. release.]data.pokemon.names-24'''
+Format = '''^[type.|h key. length. pan_sweep. p<> attack. decay. sustain. release.]data.pokemon.names-1'''
 DefaultHash = '''39732051'''
 
 [[NamedAnchors]]

--- a/src/HexManiac.Core/Models/Code/default.bprf0.toml
+++ b/src/HexManiac.Core/Models/Code/default.bprf0.toml
@@ -2606,12 +2606,12 @@ Format = '''[pointer<> musicplayer: unknown:]songnames'''
 [[NamedAnchors]]
 Name = '''sound.pokemon.cry.growl'''
 Address = 0x483C0C
-Format = '''^[type.|h key. length. pan_sweep. p<> attack. decay. sustain. release.]data.pokemon.names-24'''
+Format = '''^[type.|h key. length. pan_sweep. p<> attack. decay. sustain. release.]data.pokemon.names-1'''
 
 [[NamedAnchors]]
 Name = '''sound.pokemon.cry.normal'''
 Address = 0x4829DC
-Format = '''^[type.|h key. length. pan_sweep. p<> attack. decay. sustain. release.]data.pokemon.names-24'''
+Format = '''^[type.|h key. length. pan_sweep. p<> attack. decay. sustain. release.]data.pokemon.names-1'''
 
 [[NamedAnchors]]
 Name = '''sound.pokemon.cry.hoennconversion'''


### PR DESCRIPTION
Fixes naming for Gen 1/Gen 2 Pokemon cries in BPRF & BPEF. Previous value (-24) displayed ARBOK as the first Pokemon in both cry tables.