### PR TITLE
Fixed a bug in `setmonmove`'s command description.

### DIFF
--- a/src/HexManiac.Core/Models/Code/scriptReference.txt
+++ b/src/HexManiac.Core/Models/Code/scriptReference.txt
@@ -316,8 +316,8 @@ double.battle.continue.silent       5C 08 trainer:data.trainers.stats 00 00 star
                                              # varResult=2 if there was no room
                                              # 4037=? number of the PC box the pokemon was sent to, if it was boxed?
 7A giveEgg species:data.pokemon.names        # species can be a pokemon or a variable
-7B setmonmove pokemonSlot. attackSlot. newMove:data.pokemon.moves.names  # set a given pokemon in your party to have a specific move.
-                                             # Slots range 0-4 and 0-3.
+7B setmonmove pokemonSlot. attackSlot. newMove:data.pokemon.moves.names  # set a given pokémon in your party to have a specific move.
+                                             # Slots range from 0-5 for the pokémon and 0-3 for the move slot.
 7C checkattack move:data.pokemon.moves.names # varResult=n, where n is the index of the pokemon that knows the move.
                                              # varResult=6, if no pokemon in your party knows the move
                                              # if successful, var4 is set to the pokemon species


### PR DESCRIPTION
I don't know why it's recommiting changes from 61 ancient commits. Surely there won't be merge conflicts, right? Anyway, for the `setmonmove` command, the Pokémon slot ranges from 0-5 because there are 6 party members.