### PR TITLE
More minor changes to `scriptReference.txt`

### DIFF
--- a/src/HexManiac.Core/Models/Code/default.bpee.toml
+++ b/src/HexManiac.Core/Models/Code/default.bpee.toml
@@ -107,6 +107,16 @@ Address = 0x122CD0
 Offset = -8
 
 [[List]]
+Name = '''newsKinds'''
+0 = [
+   '''None''',
+   '''Slateport''',
+   '''GameCorner''',
+   '''Lilycove''',
+   '''BlendMaster''',
+]
+
+[[List]]
 Name = '''pokenavTowns'''
 0 = [
    '''LITTLEROOT TOWN''',

--- a/src/HexManiac.Core/Models/Code/scriptReference.txt
+++ b/src/HexManiac.Core/Models/Code/scriptReference.txt
@@ -351,7 +351,7 @@ double.battle.continue.silent       5C 08 trainer:data.trainers.stats 00 00 star
 [BPRE_BPGE_BPEE] 95 updatemoney x. y. check. # updates the amount of money shown after a money change (only works if check is 0)
 [AXPE_AXVE] 96 getpricereduction index:data.items.stats
 [BPRE_BPGE] 96 nop96
-[BPEE]      96 getpokenewsactive newsKind:
+[BPEE]      96 getpokenewsactive newsKind:newsKinds
 97 fadescreen effect.screenfades
 98 fadescreendelay effect.screenfades delay.
 99 darken flashSize:                         # makes the screen go dark. Related to flash? Call from a level script.


### PR DESCRIPTION
- Some commands said that they were a `nop` in FireRed, but it would also be the case for LeafGreen.
- Added the `newsKinds` [[List]] that's referenced in the Emerald-exclusive `getpokenewsactive` command.